### PR TITLE
Fixups: Misc spelling fixups + port specification mod

### DIFF
--- a/ipynb/devlib/examples/cgroups.ipynb
+++ b/ipynb/devlib/examples/cgroups.ipynb
@@ -88,7 +88,7 @@
      "output_type": "stream",
      "text": [
       "06:18:54  INFO    :         Target - Using base path: /home/derkling/Code/schedtest\n",
-      "06:18:54  INFO    :         Target - Connecing linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
+      "06:18:54  INFO    :         Target - Connecting linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
       "06:19:00  INFO    : Available controllers: ['cpuset', 'cpu', 'memory', 'hugetlb']\n",
       "06:19:01  INFO    : Controller cpuset mounted under: /sys/fs/cgroup/devlib_cpuset\n",
       "06:19:04  INFO    : Controller cpu mounted under: /sys/fs/cgroup/devlib_cpu\n",

--- a/ipynb/sched_dvfs/smoke_test.ipynb
+++ b/ipynb/sched_dvfs/smoke_test.ipynb
@@ -150,7 +150,7 @@
      "text": [
       "04:22:20  INFO    :         Target - Using base path: /home/derkling/Code/schedtest\n",
       "04:22:20  INFO    : %14s - Loading custom (inline) target configuration\n",
-      "04:22:20  INFO    :         Target - Connecing linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
+      "04:22:20  INFO    :         Target - Connecting linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
       "04:22:57  INFO    :         Target - Initializing target workdir [/root/devlib-target]\n",
       "04:23:01  INFO    : Target topology: [[0, 3, 4, 5], [1, 2]]\n",
       "04:23:03  INFO    :         FTrace - Enabled events:\n",

--- a/ipynb/trappy/example_custom_events.ipynb
+++ b/ipynb/trappy/example_custom_events.ipynb
@@ -181,7 +181,7 @@
      "text": [
       "05:26:51  INFO    :         Target - Using base path: /home/derkling/Code/schedtest\n",
       "05:26:51  INFO    : %14s - Loading custom (inline) target configuration\n",
-      "05:26:51  INFO    :         Target - Connecing linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
+      "05:26:51  INFO    :         Target - Connecting linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
       "05:26:55  INFO    :         Target - Initializing target workdir [/root/devlib-target]\n",
       "05:26:58  INFO    : Target topology: [[0, 3, 4, 5], [1, 2]]\n",
       "05:27:00  INFO    :         FTrace - Enabled events:\n",

--- a/ipynb/utils/testenv_example.ipynb
+++ b/ipynb/utils/testenv_example.ipynb
@@ -92,7 +92,7 @@
      "output_type": "stream",
      "text": [
       "07:16:29  INFO    :         Target - Using base path: /home/derkling/Code/schedtest\n",
-      "07:16:29  INFO    :         Target - Connecing linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
+      "07:16:29  INFO    :         Target - Connecting linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
       "07:16:29  DEBUG   : Logging in root@192.168.0.10\n",
       "07:16:31  DEBUG   : echo $PATH\n",
       "07:16:31  DEBUG   : ls -1 /usr/local/bin\n",
@@ -614,7 +614,7 @@
      "text": [
       "07:17:22  DEBUG   : sudo -- sh -c 'sleep 2 && reboot -f &'\n",
       "07:17:23  INFO    :         Reboot - Waiting 60 [s]for target to reboot...\n",
-      "07:18:23  INFO    :         Target - Connecing linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
+      "07:18:23  INFO    :         Target - Connecting linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
       "07:18:23  DEBUG   : Logging in root@192.168.0.10\n",
       "07:18:24  DEBUG   : echo $PATH\n",
       "07:18:24  DEBUG   : ls -1 /usr/local/bin\n",

--- a/ipynb/wlgen/rtapp_examples.ipynb
+++ b/ipynb/wlgen/rtapp_examples.ipynb
@@ -68,7 +68,7 @@
      "text": [
       "03:34:27  INFO    :         Target - Using base path: /home/derkling/Code/schedtest\n",
       "03:34:27  INFO    :         Target - Loading custom (inline) target configuration\n",
-      "03:34:27  INFO    :         Target - Connecing host target with: {'username': 'derkling', 'password': ''}\n"
+      "03:34:27  INFO    :         Target - Connecting host target with: {'username': 'derkling', 'password': ''}\n"
      ]
     },
     {

--- a/ipynb/wlgen/simple_rtapp.ipynb
+++ b/ipynb/wlgen/simple_rtapp.ipynb
@@ -143,7 +143,7 @@
      "text": [
       "04:35:52  INFO    :         Target - Using base path: /home/derkling/Code/schedtest\n",
       "04:35:52  INFO    : %14s - Loading custom (inline) target configuration\n",
-      "04:35:52  INFO    :         Target - Connecing linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
+      "04:35:52  INFO    :         Target - Connecting linux target with: {'username': 'root', 'host': '192.168.0.10', 'password': ''}\n",
       "04:35:52  DEBUG   : Logging in root@192.168.0.10\n",
       "04:35:54  DEBUG   : echo $PATH\n",
       "04:35:54  DEBUG   : ls -1 /usr/local/bin\n",

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -293,10 +293,10 @@ class TestEnv(ShareState):
             self.__connection_settings = None
             if 'device' in self.conf:
                 self.__connection_settings['device'] = self.conf['device']
-            logging.info(r'%14s - Connecing Android target [%s]',
+            logging.info(r'%14s - Connecting Android target [%s]',
                     'Target', self.__connection_settings or 'DEFAULT')
         else:
-            logging.info(r'%14s - Connecing %s target with: %s',
+            logging.info(r'%14s - Connecting %s target with: %s',
                     'Target', platform_type, self.__connection_settings)
 
         if platform_type.lower() == 'linux':

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -258,6 +258,10 @@ class TestEnv(ShareState):
         else:
             self.__connection_settings['password'] = PASSWORD_DEFAULT
 
+        # Configure port
+        if 'port' in self.conf:
+            self.__connection_settings['port'] = self.conf['port']
+
         # Configure the host IP/MAC address
         if 'host' in self.conf:
             try:


### PR DESCRIPTION
Minor: Some notebooks had trivial misspellings.
Mod: Port specifications in target configs were being ignored.