### PR TITLE
tests/eas/rfc: Only use the energy meter if the platform supports it

### DIFF
--- a/tests/eas/rfc.py
+++ b/tests/eas/rfc.py
@@ -509,13 +509,15 @@ class TestBase(unittest.TestCase):
             cls.env.ftrace.start()
 
         # ENERGY: start sampling
-        cls.env.emeter.reset()
+        if cls.env.emeter:
+            cls.env.emeter.reset()
 
         # WORKLOAD: Run the configured workload
         wload.run(out_dir=cls.env.out_dir, cgroup=cls.cgroup)
 
         # ENERGY: collect measurements
-        cls.env.emeter.report(cls.env.out_dir)
+        if cls.env.emeter:
+            cls.env.emeter.report(cls.env.out_dir)
 
         # FTRACE: stop and collect measurements
         if cls.env.ftrace and cls.target_conf_flag(tc, 'ftrace'):


### PR DESCRIPTION
EnergyMeter.getInstance() returns None if there is no energy meter for
the platform.  Therefore, env.emeter is None for platforms that don't
have an energy meter and rfc.py fails with an AttributeError when it
tries to do things like cls.env.emeter.reset()

Check that emeter is not None before calling any of its methods.