### PR TITLE
libs/wlgen/wlgen/rta: delay phase has to be named delay

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -319,7 +319,7 @@ class RTA(Workload):
                 if task['delay'] > 0:
                     task['delay'] = int(task['delay'] * 1e6)
                     task_conf['phases']['p000000'] = {}
-                    task_conf['phases']['p000000']['sleep'] = task['delay']
+                    task_conf['phases']['p000000']['delay'] = task['delay']
                     self.logger.info(' | start delay: %.6f [s]',
                             task['delay'] / 1e6)
 


### PR DESCRIPTION
Proper implementation of delayed task activation is requires "delay" label
in rt-app json grammar (where we currently have "sleep").

Fix that.

Signed-off-by: Juri Lelli <juri.lelli@arm.com>