### PR TITLE
README.md: fixes to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ and sched-DVFS, see:
 
 In this notebook the toolkit API is more extensively used to define an
 experiment to:
+
 1. select and configure three different CPUFreq governors
 2. run a couple of RTApp based test workloads in each configuration
 3. collect and plot scheduler and CPUFreq events
@@ -316,7 +317,7 @@ experiment to:
 
 The notebook compares three different CPUFreq governors: "performance",
 "sched" and "ondemand". New configurations are easy to add. For each
-configuration the notebook generate plots and tabular reports regarding
+configuration the notebook generates plots and tabular reports regarding
 working frequencies and energy consumption.
 
 This notebook is a good example of using LISA to build a new set of

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Debian system.
 
 ##### Install additional tools required for some tests and functionalities
 
-	$ sudo apt-get install nmap trace-cmd
+	$ sudo apt-get install nmap trace-cmd sshpass kernelshark
 
 ##### Install required python packages
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ An easy way to test your installation is to give a run to the EAS RFC tests.
 These are a set of experiments which allows to compare EAS performance and
 energy consumption with respect to standard kernel.
 
-*NOTE:* The following [tutorial](Quickstart tutorial) is still recommended it
-you want to get a better grasp on how the framework is organized and how to use
-it at your best.
+*NOTE:* The following
+[tutorial](https://github.com/ARM-software/lisa#quickstart-tutorial) is still
+recommended it you want to get a better grasp on how the framework is organized
+and how to use it at your best.
 
 Let's assume your target is running an EAS enabled kernel, to run such tests
 just run these few steps:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Debian system.
 
 	$ sudo pip install --upgrade trappy bart-py devlib
 
+*NOTE:* TRAPpy and BART depend on *ipython* and *ipython-notebook*. Some IPython
+Notebooks examples are written in JSON nbformat version 4 which might not be
+supported by the IPython version installed by *apt-get* (current version is
+1.2.1-2 which does not support such format). In this case, it is needed to
+remove IPython and install it using *pip* instead:
+
+	$ sudo apt-get remove ipython ipython-notebook
+	$ sudo pip install ipython ipython-notebook
+
 ## Clone the repository
 
 The code of the LISA toolkit with all the supported tests and Notebooks can be

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ corresponding configuration file. For example, the configuration file for the
 tests/eas/rfc.py tests is provided by the __tests/eas/rfc.conf__.
 
 This configuration file describes:
+
 1. which devlib modules are required by this experiment
 2. which binary tools need to be deployed in the target to run the
    experiments

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Debian system.
 
 ##### Install additional tools required for some tests and functionalities
 
-	$ sudo apt-get install nmap trace-cmd sshpass kernelshark
+	$ sudo apt-get install nmap trace-cmd sshpass kernelshark net-tools
 
 ##### Install required python packages
 


### PR DESCRIPTION
Fixes about tools dependencies, ipython version needed for JSON nbformat version 4 and link to the quickstart tutorial.