### PR TITLE
Add ping_time parameter to target.config and reboot

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -644,11 +644,14 @@ class TestEnv(ShareState):
                 'HostResolver', host, ipaddr)
         return (host, ipaddr)
 
-    def reboot(self, reboot_time=120):
+    def reboot(self, reboot_time=120, ping_time=15):
         # Send remote target a reboot command
         if self._feature('no-reboot'):
             logging.warning('%14s - Reboot disabled by conf features', 'Reboot')
         else:
+            if 'ping_time' in self.conf:
+                ping_time = int(self.conf['ping_time'])
+
             self.target.execute('sleep 2 && reboot -f &', as_root=True)
 
             # Wait for the target to complete the reboot
@@ -659,7 +662,7 @@ class TestEnv(ShareState):
             elapsed = 0
             start = time.time()
             while elapsed <= reboot_time:
-                time.sleep(5)
+                time.sleep(ping_time)
                 logging.debug('%14s - Trying to connect to [%s] target...',
                         'Reboot', self.ip)
                 if os.system(ping_cmd) == 0:

--- a/target.config
+++ b/target.config
@@ -60,6 +60,9 @@
     /* Wait time before trying to access the target after reboot */
     // "ping_time" : "15",
 
+    /* Total time to wait after rebooting the target */
+    // "reboot_time" : "120",
+
     /* List of test environment features to enable */
     /*  no-kernel : do not deploy kernel/dtb images               */
     /*  no-reboot : do not force reboot the target at each        */

--- a/target.config
+++ b/target.config
@@ -60,7 +60,7 @@
     /* Wait time before trying to access the target after reboot */
     // "ping_time" : "15",
 
-    /* Total time to wait after rebooting the target */
+    /* Maximum time to wait after rebooting the target */
     // "reboot_time" : "120",
 
     /* List of test environment features to enable */

--- a/target.config
+++ b/target.config
@@ -1,3 +1,11 @@
+/* target.config                                                  */
+/*                                                                */
+/* Configuration file to specify target parameters such as: the   */
+/* kind of platform/board, and login credentials.                 */
+/*                                                                */
+/* NOTE: all commented parameters are optional and report their   */
+/*       default value.                                           */
+
 {
     /* Platform */
     /* - linux   : accessed via SSH connection                    */
@@ -19,7 +27,7 @@
     "username" : "root",
 
     /* Login credentials */
-    /* You can specified either a password or keyfile */
+    /* You can specify either a password or keyfile */
     "password" : "",
     // "keyfile"   : "/complete/path/of/your/keyfile",
 
@@ -48,6 +56,9 @@
 
     /* Binary tools to install by default for all experiments */
     "tools"    : [],
+
+    /* Wait time before trying to access the target after reboot */
+    // "ping_time" : "15",
 
     /* List of test environment features to enable */
     /*  no-kernel : do not deploy kernel/dtb images               */


### PR DESCRIPTION
When rebooting, the reboot function repeatedly pings the target.
However, rebooting might require some seconds and in order to avoid
pinging the machine before it actually reboots, we can set the
ping_time option in target.config to tell the function how long to
wait before pinging.

Also, a comment has been added in target.config to specify what the
file represents and to highlight that commented parameters are
optional.