### PR TITLE
Update trace to match the new APIs available in recent TRAPpy versions

### DIFF
--- a/libs/utils/filters.py
+++ b/libs/utils/filters.py
@@ -73,7 +73,7 @@ class Filters(object):
         if min_utilization is None:
             min_utilization = self.little_cap
 
-        df = self.trace.df('tload')
+        df = self.trace.df('sched_load_avg_task')
         big_tasks_events = df[df.util_avg > min_utilization]
         big_tasks = big_tasks_events.pid.unique()
 
@@ -94,7 +94,7 @@ class Filters(object):
         self.big_frequent_tasks_pids = list(big_topmost.index)
 
         # Keep track of big tasks tload events
-        self.big_tasks['tload'] = big_tasks_events
+        self.big_tasks['sched_load_avg_task'] = big_tasks_events
         return self.big_frequent_tasks_pids
 
     def _taskIsBig(self, utilization):
@@ -114,7 +114,7 @@ class Filters(object):
             return
 
         # Get the list of events for all big frequent tasks
-        df = self.trace.df('tload')
+        df = self.trace.df('sched_load_avg_task')
         big_frequent_tasks_events = df[df.pid.isin(self.big_frequent_tasks_pids)]
 
         # Add a column to represent big status
@@ -164,7 +164,7 @@ class Filters(object):
         Tasks which wakeups more frequent than a specified threshold
         """
 
-        df = self.trace.df('swkp')
+        df = self.trace.df('sched_wakeup')
 
         wkp_tasks_stats = df.groupby('pid').describe(include=['object'])
         wkp_tasks_pids = wkp_tasks_stats.unstack()['comm']\
@@ -196,7 +196,7 @@ class Filters(object):
         if per_cluster:
 
             # Get per cluster wakeup events
-            df = self.trace.df('swkpn')
+            df = self.trace.df('sched_wakeup_new')
             big_frequent = (
                     (df.target_cpu.isin(self.big_cpus))
                     )
@@ -220,14 +220,14 @@ class Filters(object):
 
             ax = axes[0]
             ax.set_title('Tasks WakeUps Events');
-            df = self.trace.df('swkp')
+            df = self.trace.df('sched_wakeup')
             df.pid.astype(int).plot(style=['b.'], ax=ax);
             ax.set_xlim(self.x_min, self.x_max);
             ax.xaxis.set_visible(False);
 
             ax = axes[1]
             ax.set_title('Tasks Forks Events');
-            df = self.trace.df('swkpn')
+            df = self.trace.df('sched_wakeup_new')
             df.pid.astype(int).plot(style=['r.'], ax=ax);
             ax.set_xlim(self.x_min, self.x_max);
             ax.xaxis.set_visible(False);
@@ -246,7 +246,7 @@ class Filters(object):
         fig, axes = plt.subplots(2, 1, figsize=(14, 5));
         plt.subplots_adjust(wspace=0.2, hspace=0.3);
 
-        df_wkp  = self.big_tasks['tload']
+        df_wkp  = self.big_tasks['sched_load_avg_task']
         # Add column of expected cluster, depending on utilization value and
         # capacity of the selected cluster
         bu_bc = ( \
@@ -260,7 +260,7 @@ class Filters(object):
         df_wkp.loc[:,'ccap_mutil'] = np.select(
             [(bu_bc | su_lc)], [True], False)
 
-        df_freq = self.trace.df('pfreq')
+        df_freq = self.trace.df('cpu_frequency')
         rd_freq = df_freq[df_freq['cpu'].isin(cpus)]
 
         ax = axes[0]
@@ -279,7 +279,7 @@ class Filters(object):
         ax.set_xlim(self.x_min, self.x_max);
 
     def rtTasks(self, max_prio = 100):
-        df = self.trace.df('sswitch')
+        df = self.trace.df('sched_switch')
         df = df[df.next_prio <= max_prio]
         df = df[['next_pid', 'next_comm']]
         df = df.drop_duplicates()

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -96,61 +96,61 @@ class Trace(object):
         # Setup internal data reference to interesting events/dataframes
 
         if self.hasEvents('sched_switch'):
-            self.trace_data['sswitch'] = \
+            self.trace_data['sched_switch'] = \
                 self.run.sched_switch.data_frame
 
         if self.hasEvents('sched_wakeup'):
-            self.trace_data['swkp'] = \
+            self.trace_data['sched_wakeup'] = \
                 self.run.sched_wakeup.data_frame
 
         if self.hasEvents('sched_wakeup_new'):
-            self.trace_data['swkpn'] = \
+            self.trace_data['sched_wakeup_new'] = \
                 self.run.sched_wakeup_new.data_frame
 
         if self.hasEvents('cpu_frequency'):
-            self.trace_data['pfreq'] = \
+            self.trace_data['cpu_frequency'] = \
                 self.run.cpu_frequency.data_frame
 
         if self.hasEvents('sched_load_avg_cpu'):
-            self.trace_data['cload'] = \
+            self.trace_data['sched_load_avg_cpu'] = \
                 self.run.sched_load_avg_cpu.data_frame
             self._sanitize_SchedLoadAvgCpu()
 
         if self.hasEvents('sched_load_avg_task'):
-            self.trace_data['tload'] = \
+            self.trace_data['sched_load_avg_task'] = \
                 self.run.sched_load_avg_task.data_frame
             self._sanitize_SchedLoadAvgTask()
 
         if self.hasEvents('cpu_capacity'):
-            self.trace_data['ccap'] = \
+            self.trace_data['cpu_capacity'] = \
                 self.run.cpu_capacity.data_frame
             self._sanitize_SchedCpuCapacity()
 
         if self.hasEvents('sched_boost_cpu'):
-            self.trace_data['cboost'] = \
+            self.trace_data['sched_boost_cpu'] = \
                 self.run.sched_boost_cpu.data_frame
             self._sanitize_SchedBoostCpu()
 
         if self.hasEvents('sched_boost_task'):
-            self.trace_data['tboost'] = \
+            self.trace_data['sched_boost_task'] = \
                 self.run.sched_boost_task.data_frame
             self._sanitize_SchedBoostTask()
 
         if self.hasEvents('sched_contrib_scale_f'):
-            self.trace_data['scalef'] = \
+            self.trace_data['sched_contrib_scale_f'] = \
                 self.run.sched_contrib_scale_f.data_frame
 
         if self.hasEvents('sched_energy_diff'):
-            self.trace_data['ediff'] = \
+            self.trace_data['sched_energy_diff'] = \
                     self.run.sched_energy_diff.data_frame
             self._sanitize_SchedEnergyDiff()
 
         if self.hasEvents('sched_tune_config'):
-            self.trace_data['stune'] = \
+            self.trace_data['sched_tune_config'] = \
                     self.run.sched_tune_config.data_frame
 
         if self.hasEvents('sched_tune_tasks_update'):
-            self.trace_data['utask'] = \
+            self.trace_data['sched_tune_tasks_update'] = \
                     self.run.sched_tune_tasks_update.data_frame
 
         self.__loadTasksNames(tasks)
@@ -169,11 +169,11 @@ class Trace(object):
     def __loadTasksNames(self, tasks):
         # Try to load tasks names using one of the supported events
         if 'sched_switch' in self.available_events:
-            self.getTasks(self.trace_data['sswitch'], tasks,
+            self.getTasks(self.trace_data['sched_switch'], tasks,
                 name_key='next_comm', pid_key='next_pid')
             return
         if 'sched_load_avg_task' in self.available_events:
-            self.getTasks(self.trace_data['tload'], tasks)
+            self.getTasks(self.trace_data['sched_load_avg_task'], tasks)
             return
         logging.warning('Failed to load tasks names from trace events')
 
@@ -262,7 +262,7 @@ class Trace(object):
         return self.trace_data[event]
 
     def _sanitize_SchedCpuCapacity(self):
-        df = self.df('ccap')
+        df = self.df('cpu_capacity')
 
         # Add more columns if the energy model is available
         if 'nrg_model' not in self.platform:
@@ -283,14 +283,14 @@ class Trace(object):
                 [tip_lcap], tip_bcap)
 
     def _sanitize_SchedLoadAvgCpu(self):
-        df = self.df('cload')
+        df = self.df('sched_load_avg_cpu')
         if 'utilization' in df:
             # Convert signals name from v5.0 to v5.1 format
             df.rename(columns={'utilization':'util_avg'}, inplace=True)
             df.rename(columns={'load':'load_avg'}, inplace=True)
 
     def _sanitize_SchedLoadAvgTask(self):
-        df = self.df('tload')
+        df = self.df('sched_load_avg_task')
         if 'utilization' in df:
             # Convert signals name from v5.0 to v5.1 format
             df.rename(columns={'utilization':'util_avg'}, inplace=True)
@@ -303,7 +303,7 @@ class Trace(object):
                 ['LITTLE'], 'big')
 
     def _sanitize_SchedBoostCpu(self):
-        df = self.df('cboost')
+        df = self.df('sched_boost_cpu')
         if 'usage' in df:
             # Convert signals name from to v5.1 format
             df.rename(columns={'usage':'util'}, inplace=True)
@@ -311,7 +311,7 @@ class Trace(object):
 
 
     def _sanitize_SchedBoostTask(self):
-        df = self.df('tboost')
+        df = self.df('sched_boost_task')
         if 'utilization' in df:
             # Convert signals name from to v5.1 format
             df.rename(columns={'utilization':'util'}, inplace=True)
@@ -333,7 +333,7 @@ class Trace(object):
                     em_lcluster['nrg_max'] + em_bcluster['nrg_max']
         print "Maximum estimated system energy: {0:d}".format(power_max)
 
-        df = self.df('ediff')
+        df = self.df('sched_energy_diff')
         df['nrg_diff_pct'] = SCHED_LOAD_SCALE * df.nrg_diff / power_max
 
         # Tag columns by usage_delta

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -39,8 +39,8 @@ class Trace(object):
         # Folder containing all perf data
         self.datadir = None
 
-        # TRAPpy run object
-        self.run = None
+        # TRAPpy FTrace object
+        self.ftrace = None
 
         # The time window used to limit trace parsing to
         self.window = window
@@ -83,7 +83,7 @@ class Trace(object):
     def __parseTrace(self, datadir, tasks, window):
         logging.debug('Loading [sched] events from trace in [%s]...', datadir)
         logging.debug("Parsing events: %s", self.events)
-        self.run = trappy.Run(datadir, scope="custom", events=self.events, window=window)
+        self.ftrace = trappy.FTrace(datadir, scope="custom", events=self.events, window=window)
 
         # Check for events available on the parsed trace
         self.__checkAvailableEvents()
@@ -104,8 +104,8 @@ class Trace(object):
 
 
     def __checkAvailableEvents(self):
-        for val in trappy.Run.get_filters(self.run):
-            obj = getattr(self.run, val)
+        for val in trappy.FTrace.get_filters(self.ftrace):
+            obj = getattr(self.ftrace, val)
             if len(obj.data_frame):
                 self.available_events.append(val)
         logging.debug('Events found on trace:')
@@ -202,8 +202,8 @@ class Trace(object):
         """
         if self.datadir is None:
             raise ValueError("trace data not (yet) loaded")
-        if self.run and hasattr(self.run, event):
-            return getattr(self.run, event).data_frame
+        if self.ftrace and hasattr(self.ftrace, event):
+            return getattr(self.ftrace, event).data_frame
         raise ValueError('Event [{}] not supported. '\
                          'Supported events are: {}'\
                          .format(event, self.available_events))

--- a/libs/utils/trace_analysis.py
+++ b/libs/utils/trace_analysis.py
@@ -69,7 +69,7 @@ class TraceAnalysis(object):
             logging.warn('Events [cpu_frequency] not found, '\
                     'plot DISABLED!')
             return
-        df = self.trace.df('pfreq')
+        df = self.trace.df('cpu_frequency')
 
         pd.options.mode.chained_assignment = None
 
@@ -156,7 +156,7 @@ class TraceAnalysis(object):
         return (avg_lfreq/1e3, avg_bfreq/1e3)
 
     def __addCapacityColum(self):
-        df = self.trace.df('ccap')
+        df = self.trace.df('cpu_capacity')
         # Rename CPU and Capacity columns
         df.rename(columns={'cpu_id':'cpu'}, inplace=True)
         # Add column with LITTLE and big CPUs max capacities
@@ -196,12 +196,12 @@ class TraceAnalysis(object):
 
             # Add CPU utilization
             axes.set_title('{0:s}CPU [{1:d}]'.format(label1, cpu));
-            df1 = df['cload'][df['cload'].cpu == cpu]
+            df1 = df['sched_load_avg_cpu'][df['sched_load_avg_cpu'].cpu == cpu]
             if (len(df1)):
                 df1[['util_avg']].plot(ax=axes, drawstyle='steps-post', alpha=0.4);
 
             # if self.trace.hasEvents('sched_boost_cpu'):
-            #     df2 = df['cboost'][df['cboost'].cpu == cpu]
+            #     df2 = df['sched_boost_cpu'][df['sched_boost_cpu'].cpu == cpu]
             #     if (len(df2)):
             #         df2[['usage', 'boosted_usage']].plot(
             #                 ax=axes,
@@ -210,7 +210,7 @@ class TraceAnalysis(object):
 
             # Add Capacities data if avilable
             if self.trace.hasEvents('cpu_capacity'):
-                df2 = df['ccap'][df['ccap'].cpu == cpu]
+                df2 = df['cpu_capacity'][df['cpu_capacity'].cpu == cpu]
                 if (len(df2)):
                     # data = df2[['capacity', 'tip_capacity', 'max_capacity']]
                     # data.plot(ax=axes, style=['m', 'y', 'r'],
@@ -256,7 +256,7 @@ class TraceAnalysis(object):
             logging.warn('Events [sched_load_avg_task] not found, '\
                     'plot DISABLED!')
             return
-        df = self.trace.trace_data['tload']
+        df = self.trace.trace_data['sched_load_avg_task']
         self.trace.getTasks(df, tasks)
         tasks_to_plot = sorted(self.tasks)
         if tasks:
@@ -282,7 +282,7 @@ class TraceAnalysis(object):
             data.plot(ax=axes, drawstyle='steps-post');
             # Plot boost utilization if available
             if self.trace.hasEvents('sched_boost_task'):
-                df2 = self.trace.trace_data['tboost']
+                df2 = self.trace.trace_data['sched_boost_task']
                 data = df2[df2.comm == task_name][['boosted_util']]
                 if len(data):
                     data.plot(ax=axes, style=['y-'], drawstyle='steps-post');
@@ -342,7 +342,7 @@ class TraceAnalysis(object):
         if not self.trace.hasEvents('sched_energy_diff'):
             logging.warn('Events [sched_energy_diff] not found, plot DISABLED!')
             return
-        df = self.trace.df('ediff')
+        df = self.trace.df('sched_energy_diff')
 
         # Filter on 'tasks'
         if tasks is not None:
@@ -467,7 +467,7 @@ class TraceAnalysis(object):
         if not self.trace.hasEvents('sched_energy_diff'):
             logging.warn('Events [sched_energy_diff] not found, plot DISABLED!')
             return
-        df = self.trace.df('ediff')
+        df = self.trace.df('sched_energy_diff')
 
         # Filter on 'tasks'
         if tasks is not None:
@@ -633,7 +633,7 @@ class TraceAnalysis(object):
         # Plot: Margin
         axes = plt.subplot(gs[0,0]);
         axes.set_title('Margin');
-        data = self.trace.df('stune')[['margin']]
+        data = self.trace.df('sched_tune_config')[['margin']]
         data.plot(ax=axes, drawstyle='steps-post', style=['b']);
         axes.set_ylim(0, 110);
         axes.set_xlim(self.x_min, self.x_max);
@@ -642,7 +642,7 @@ class TraceAnalysis(object):
         # Plot: Boost mode
         axes = plt.subplot(gs[1,0]);
         axes.set_title('Boost mode');
-        data = self.trace.df('stune')[['boostmode']]
+        data = self.trace.df('sched_tune_config')[['boostmode']]
         data.plot(ax=axes, drawstyle='steps-post');
         axes.set_ylim(0, 4);
         axes.set_xlim(self.x_min, self.x_max);

--- a/libs/utils/trace_analysis.py
+++ b/libs/utils/trace_analysis.py
@@ -179,7 +179,6 @@ class TraceAnalysis(object):
         if label != '':
             label1 = '{} '.format(label)
             label2 = '_{}s'.format(label.lower())
-        df = self.trace.trace_data
 
         # Plot required CPUs
         fig, pltaxes = plt.subplots(len(cpus), 1, figsize=(16, 3*(len(cpus))));
@@ -196,27 +195,30 @@ class TraceAnalysis(object):
 
             # Add CPU utilization
             axes.set_title('{0:s}CPU [{1:d}]'.format(label1, cpu));
-            df1 = df['sched_load_avg_cpu'][df['sched_load_avg_cpu'].cpu == cpu]
-            if (len(df1)):
-                df1[['util_avg']].plot(ax=axes, drawstyle='steps-post', alpha=0.4);
+            df = self.trace.df('sched_load_avg_cpu')
+            df = df[df.cpu == cpu]
+            if len(df):
+                df[['util_avg']].plot(ax=axes, drawstyle='steps-post', alpha=0.4);
 
             # if self.trace.hasEvents('sched_boost_cpu'):
-            #     df2 = df['sched_boost_cpu'][df['sched_boost_cpu'].cpu == cpu]
-            #     if (len(df2)):
-            #         df2[['usage', 'boosted_usage']].plot(
-            #                 ax=axes,
-            #                 style=['m-', 'r-'],
-            #                 drawstyle='steps-post');
+            #     df = self.trace.df('sched_boost_cpu')
+            #     df = df[df.cpu == cpu]
+            #     if len(df):
+            #         df[['usage', 'boosted_usage']].plot(
+            #             ax=axes,
+            #             style=['m-', 'r-'],
+            #             drawstyle='steps-post');
 
             # Add Capacities data if avilable
             if self.trace.hasEvents('cpu_capacity'):
-                df2 = df['cpu_capacity'][df['cpu_capacity'].cpu == cpu]
-                if (len(df2)):
-                    # data = df2[['capacity', 'tip_capacity', 'max_capacity']]
+                df = self.trace.df('cpu_capacity')
+                df = df[df.cpu == cpu]
+                if len(df):
+                    # data = df[['capacity', 'tip_capacity', 'max_capacity']]
                     # data.plot(ax=axes, style=['m', 'y', 'r'],
-                    data = df2[['capacity', 'tip_capacity' ]]
+                    data = df[['capacity', 'tip_capacity' ]]
                     data.plot(ax=axes, style=['m', '--y' ],
-                        drawstyle='steps-post')
+                              drawstyle='steps-post')
 
             axes.set_ylim(0, 1100);
             axes.set_xlim(self.x_min, self.x_max);
@@ -256,7 +258,7 @@ class TraceAnalysis(object):
             logging.warn('Events [sched_load_avg_task] not found, '\
                     'plot DISABLED!')
             return
-        df = self.trace.trace_data['sched_load_avg_task']
+        df = self.trace.df('sched_load_avg_task')
         self.trace.getTasks(df, tasks)
         tasks_to_plot = sorted(self.tasks)
         if tasks:
@@ -282,7 +284,7 @@ class TraceAnalysis(object):
             data.plot(ax=axes, drawstyle='steps-post');
             # Plot boost utilization if available
             if self.trace.hasEvents('sched_boost_task'):
-                df2 = self.trace.trace_data['sched_boost_task']
+                df2 = self.trace.df('sched_boost_task')
                 data = df2[df2.comm == task_name][['boosted_util']]
                 if len(data):
                     data.plot(ax=axes, style=['y-'], drawstyle='steps-post');


### PR DESCRIPTION
This series is almost just a cleanup of the Trace module to align its code the most recent versions of TRAPpy.

The series removes the internal trace_data dictionary, which was previously used to map DataFrame to a short and handy name. We use now standard tarcepoint names to access DataFrames collected from a trace, which can be obtained via Trace.df() not before having checked that they exists via Trace.hasEvents().

Appreciated if @JaviMerino can give it a look. Maybe a better interface can be used to wrap the TRAPpy FTrace module? Consider that technically all the features in that Trace module can be migrated directly to TRAPpy. What we do here is mainly DataFrame post-processing, sometimes on events which are not pre-registered in TRAPpy.