### PR TITLE
.gitmodules: point trappy/bart to their upstream repositories

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,11 +2,11 @@
 	path = libs/devlib
 	url = https://github.com/derkling/devlib.git
 	branch = devlib-next
-[submodule "trappy-next"]
+[submodule "trappy-lisa"]
 	path = libs/trappy
-	url = https://github.com/derkling/trappy.git
-	branch = trappy-next
-[submodule "bart-next"]
+	url = https://github.com/ARM-software/trappy.git
+	branch = lisa
+[submodule "bart-lisa"]
 	path = libs/bart
-	url = https://github.com/derkling/bart.git
-	branch = bart-next
+	url = https://github.com/ARM-software/bart.git
+	branch = lisa


### PR DESCRIPTION
Currently bart is broken because the bart submodule points to a branch
that doesn't contain bart:

$ source init_env
Developer mode ENABLED, using libraries provided by submodules
PYTHONPATH:
/home/vagrant/lisa/libs/bart:/home/vagrant/lisa/libs/trappy:/home/vagrant/lisa/libs/devlib:/home/vagrant/lisa/libs/wlgen:/home/vagrant/lisa/libs/utils:

Update submodules if required
DONE
$ nosetests -v tests/eas/rfc.py:STune
Failure: ImportError (No module named bart.common.Analyzer) ... ERROR

======================================================================
ERROR: Failure: ImportError (No module named bart.common.Analyzer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/loader.py", line 411, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/vagrant/tests/eas/rfc.py", line 18, in <module>
    from bart.common.Analyzer import Analyzer
ImportError: No module named bart.common.Analyzer

----------------------------------------------------------------------
Ran 1 test in 0.002s

FAILED (errors=1)
$ ls libs/bart
Gemfile  index.html  params.json  stylesheets
$

We can fix that by point trappy and bart to their
original repositories, with a lisa specific branch.