### PR TITLE
rfc_stune: Add the cgroup module back

### DIFF
--- a/tests/eas/rfc_stune.config
+++ b/tests/eas/rfc_stune.config
@@ -1,6 +1,6 @@
 {
     /* Devlib modules to enable/disbale for all the experiments */
-    "modules"         : [ "cpufreq" ],
+    "modules"         : [ "cpufreq", "cgroups" ],
     "exclude_modules" : [ ],
 
     /* Binary tools required by the experiments */


### PR DESCRIPTION
4e2673a38945 ("libs/utils/env: move modules definition into board
specific section") trimmed down the list of modules defined for each
testsuite.  For STune, it trimmed it too much, removing the cgroups
module which is needed by the test.  Add it back.