### PR TITLE
test/eas/rfc: fix calculation of the first period of the task

### DIFF
--- a/tests/stune/smoke_test_ramp.py
+++ b/tests/stune/smoke_test_ramp.py
@@ -61,7 +61,7 @@ class STune(LisaTest):
             # high load and it overutilizes the CPU
             rtapp_period = first_task_params[first_task_name]["params"]["period_ms"]
             task_start = boost_task_rtapp.index[0]
-            after_first_period = task_start + rtapp_period
+            after_first_period = task_start + (rtapp_period / 1000.)
             boost_task_rtapp = boost_task_rtapp.ix[after_first_period:]
 
             sched_load_scale = 1024


### PR DESCRIPTION
We avoid the first period of the rtapp task in the boosted utilization
signal test because of the initial high load.  The period we read from
the parameters is expressed in milliseconds but the index of the
dataframes returned by trappy is in seconds.  Convert rtapp_period to
seconds before adding it to task_start to correctly add the two
variables in the same unit (seconds).