### PR TITLE
workload: fix background run of a workload

### DIFF
--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -183,10 +183,8 @@ class Workload(object):
         # Start task in background if required
         if background:
             logging.debug('%14s - WlGen [background]: %s', 'WlGen', self.command)
-            results = self.target.execute(self.command,
-                    background=True, as_root=as_root)
-            self.output['executor'] = results
-            return results
+            self.target.background(self.command, as_root=as_root)
+            return
 
         logging.info('%14s - Workload execution START:', 'WlGen')
         logging.info('%14s -    %s', 'WlGen', self.command)


### PR DESCRIPTION
Devlib provides a specific method for running a command in background which is
not what it was used in LISA. Before, LISA was calling execute() with a
background parameter set to True; now it just calls the background() function
which does the job.

This change only works after [this PR](ARM-software/devlib#25) is merged.