### PR TITLE
workload: add possibility to set pauses before and after executing a workload

### DIFF
--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import re
+from time import sleep
 
 class Workload(object):
 
@@ -152,7 +153,9 @@ class Workload(object):
             cgroup=None,
             background=False,
             out_dir='./',
-            as_root=False):
+            as_root=False,
+            start_pause_s=None,
+            end_pause_s=None):
         """
         This method starts the execution of the workload. If the user provides
         an ftrace object, the method will also collect a trace.
@@ -176,6 +179,16 @@ class Workload(object):
 
         :param as_root: run the workload as root on the target
         :type as_root: bool
+
+        :param start_pause_s: time to wait before executing the workload in
+                              seconds. If ftrace is provided, trace collection
+                              is started before waiting.
+        :type start_pause_s: float
+
+        :param end_pause_s: time to wait after executing the workload in
+                            seconds. If ftrace is provided, trace collection is
+                            stopped after this wait time.
+        :type end_pause_s: float
         """
 
         self.cgroup = cgroup
@@ -204,6 +217,12 @@ class Workload(object):
         if ftrace:
             ftrace.start()
 
+        # Wait `start_pause` seconds before running the workload
+        if start_pause_s:
+            logging.info('%14s - Waiting %f seconds before starting workload execution',
+                         'WlGen', start_pause_s)
+            sleep(start_pause_s)
+
         # Start task in background if required
         if background:
             logging.debug('%14s - WlGen [background]: %s', 'WlGen', self.command)
@@ -220,6 +239,12 @@ class Workload(object):
                 timeout=None, as_root=as_root)
         # print type(results)
         self.output['executor'] = results
+
+        # Wait `end_pause` seconds before stopping ftrace
+        if end_pause_s:
+            logging.info('%14s - Waiting %f seconds before stopping trace collection',
+                         'WlGen', end_pause_s)
+            sleep(end_pause_s)
 
         # Stop FTrace (if required)
         ftrace_dat = None

--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -153,6 +153,30 @@ class Workload(object):
             background=False,
             out_dir='./',
             as_root=False):
+        """
+        This method starts the execution of the workload. If the user provides
+        an ftrace object, the method will also collect a trace.
+
+        :param ftrace: FTrace object to collect a trace
+        :type ftrace: :mod:`trappy.trace.FTrace`
+
+        :param cgroup: specifies the cgroup name in which the workload has to
+                       run
+        :type cgroup: str
+
+        :param background: run the workload in background. In this case the
+                           method will not return a result. When used with
+                           ftrace it is up to the caller to stop trace
+                           collection
+        :type background: bool
+
+        :param out_dir: output directory where to store the collected trace (if
+                        any)
+        :type out_dir: str
+
+        :param as_root: run the workload as root on the target
+        :type as_root: bool
+        """
 
         self.cgroup = cgroup
 


### PR DESCRIPTION
By means of a start and an end pause parameter it is now possible to set a
period of time to wait after starting collecting traces and before the
execution of workload (for example to allow something to settle down). In
addition, you can also set a period of time to wait after the workload has
executed and before stopping the trace collection.

The two parameters are optional and their default value is zero.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>