### PR TITLE
submodules: track mainline devlib repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "libs/devlib"]
 	path = libs/devlib
-	url = https://github.com/derkling/devlib.git
-	branch = devlib-next
+	url = https://github.com/ARM-Software/devlib.git
 [submodule "libs/trappy"]
 	path = libs/trappy
 	url = https://github.com/ARM-Software/trappy.git


### PR DESCRIPTION
This patch updates the tracked devlib repository to be the
official one available on github. This should foster the
mainlining of patches and new features for devlib.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>