### PR TITLE
README.md: add python-nose dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Debian system.
 
 ##### Install required python packages
 
-	$ sudo apt-get install python-matplotlib python-numpy libfreetype6-dev libpng12-dev
+	$ sudo apt-get install python-matplotlib python-numpy libfreetype6-dev libpng12-dev python-nose
 
 ##### Install the Python package manager
 


### PR DESCRIPTION
python-nose is necessary for running nosetests.

close #64

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>