### PR TITLE
Usage of device ID in target configuration for Android devices

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -392,7 +392,7 @@ class TestEnv(ShareState):
         if platform_type.lower() == 'android':
             self.__connection_settings = None
             if 'device' in self.conf:
-                self.__connection_settings['device'] = self.conf['device']
+                self.__connection_settings = {'device' : self.conf['device']}
             logging.info(r'%14s - Connecting Android target [%s]',
                     'Target', self.__connection_settings or 'DEFAULT')
         else:

--- a/target.config
+++ b/target.config
@@ -23,6 +23,9 @@
     /* Target IP or MAC address */
     "host" : "192.168.0.20",
 
+    /* Target Android device ID */
+    //"device" : "00b1346f0878ccb1",
+
     /* Login username (has to be sudo enabled) */
     "username" : "root",
 


### PR DESCRIPTION
When multiple Android devices are connected to the host machine, the user must specify the ID of the device he wants to connect to. This series shows an example of usage in the `target.config` file and fixes a bug when passing the device ID to the test environment.