### PR TITLE
lisa_shell: fix lisa-help command run from anywhere in the filesystem

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -49,7 +49,7 @@ echo "                                                                          
 echo "                    .:: LISA Shell - HELP On-Line ::.                          "
 echo "                                                                               "
 echo -ne "$LISASHELL_RESET$LISASHELL_GREEN"
-cat LisaShell.txt
+cat $LISA_HOME/LisaShell.txt
 echo -ne "$LISASHELL_DEFAULT"
 }
 


### PR DESCRIPTION
When running lisa-help from directories other than the LISA home
directory, the help information were not printed because the command was
looking for LisaShell.txt in the current directory. This adds the
absolute path to that file so that the help is printed from anywhere in
the filesystem.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>