### PR TITLE
Fix cgroups background

### DIFF
--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -227,16 +227,19 @@ class Workload(object):
         if background:
             logging.debug('%14s - WlGen [background]: %s', 'WlGen', self.command)
             self.target.background(self.command, as_root=as_root)
-            return
+            self.output['executor'] = ''
 
-        logging.info('%14s - Workload execution START:', 'WlGen')
-        logging.info('%14s -    %s', 'WlGen', self.command)
+        # Start task in foreground
+        else:
 
-        # Run command and wait for it to complete
-        results = self.target.execute(self.command,
-                timeout=None, as_root=as_root)
-        # print type(results)
-        self.output['executor'] = results
+            logging.info('%14s - Workload execution START:', 'WlGen')
+            logging.info('%14s -    %s', 'WlGen', self.command)
+
+            # Run command and wait for it to complete
+            results = self.target.execute(self.command,
+                    timeout=None, as_root=as_root)
+            # print type(results)
+            self.output['executor'] = results
 
         # Wait `end_pause` seconds before stopping ftrace
         if end_pause_s:

--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -226,7 +226,7 @@ class Workload(object):
         # Start task in background if required
         if background:
             logging.debug('%14s - WlGen [background]: %s', 'WlGen', self.command)
-            self.target.background(self.command, as_root=as_root)
+            self.target.kick_off(self.command, as_root=as_root)
             self.output['executor'] = ''
 
         # Start task in foreground


### PR DESCRIPTION
This should fix an issue related to the background execution of tasks which are also moved into a CGroup. We slightly update also the semantics of the run() call which allows to collect an ftrace for a background task by using the recently added end_pause_s parameter to specify for how long a trace must be collected while the task runs in background.