### PR TITLE
lisa_shell: fix typo for "nosetests"

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -201,7 +201,7 @@ EOF
 
 function _lisa-test {
 CLASS=${1}
-nosetest -v tests/$CLASS
+nosetests -v tests/$CLASS
 }
 
 function lisa-test {


### PR DESCRIPTION
Change "nosetest" to "nosetests" so can correctly launch lisa-test.

Signed-off-by: Leo Yan <leo.yan@linaro.org>