### PR TITLE
eas test rfc.config comments for ftrace

### DIFF
--- a/tests/eas/rfc.config
+++ b/tests/eas/rfc.config
@@ -7,8 +7,8 @@
     "tools"    : ["rt-app"],
 
     /* FTrace events required by the experiments */
-    /* NOTE: Uncoment this section if you do not want to collect FTrace */
-    /* events while workloads are executed */
+    /* NOTE: "ftrace" has to be specified in the "conf" flags to */
+    /* enable tracing of ftrace events while workloads are executed */
     "ftrace"    : {
         "events" : [
             // "cpu_idle",
@@ -37,7 +37,7 @@
             "kernel"            : "/opt/git/kernel.org/arch/arm64/boot/Image",
             "dtb"               : "/opt/git/kernel.org/arch/arm64/boot/dts/arm/juno.dtb",
             "sched_features"    : "NO_ENERGY_AWARE",
-            "flags"             : "",
+            "flags"             : "", /* "ftrace" to enable tracing */
             "cpufreq" : {
                 "governor"    : "ondemand",
                 "params"      : {
@@ -50,7 +50,7 @@
             "kernel"            : "/opt/git/kernel.org/arch/arm64/boot/Image",
             "dtb"               : "/opt/git/kernel.org/arch/arm64/boot/dts/arm/juno.dtb",
             "sched_features"    : "ENERGY_AWARE",
-            "flags"             : "",
+            "flags"             : "",  /* "ftrace" to enable tracing */
             "cpufreq" : {
                 "governor"  : "ondemand",
                 "params"    : {


### PR DESCRIPTION
Add a few helpful comments to eas test rfc.config describing how to enable ftrace.