### PR TITLE
libs/utils/trace: add support for normalize_time

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -33,6 +33,7 @@ class Trace(object):
 
     def __init__(self, platform, datadir, events,
                  tasks=None, window=(0,None),
+                 normalize_time=True,
                  trace_format='FTrace'):
 
         # The platform used to run the experiments
@@ -76,7 +77,7 @@ class Trace(object):
             self.datadir = datadir
 
         self.__registerTraceEvents(events)
-        self.__parseTrace(datadir, tasks, window, trace_format)
+        self.__parseTrace(datadir, tasks, window, normalize_time, trace_format)
         self.__computeTimeSpan()
 
     def __registerTraceEvents(self, events):
@@ -89,7 +90,7 @@ class Trace(object):
             raise ValueError('Events must be a string or a list of strings')
 
 
-    def __parseTrace(self, path, tasks, window, trace_format):
+    def __parseTrace(self, path, tasks, window, normalize_time, trace_format):
         logging.debug('Loading [sched] events from trace in [%s]...', path)
         logging.debug("Parsing events: %s", self.events)
         if trace_format.upper() == 'SYSTRACE' or path.endswith('html'):
@@ -104,7 +105,7 @@ class Trace(object):
             raise ValueError("Unknown trace format {}".format(trace_format))
 
         self.ftrace = trace_class(path, scope="custom", events=self.events,
-                                  window=window)
+                                  window=window, normalize_time=normalize_time)
 
         # Check for events available on the parsed trace
         self.__checkAvailableEvents()

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -94,16 +94,15 @@ class Trace(object):
         logging.debug("Parsing events: %s", self.events)
         if trace_format.upper() == 'SYSTRACE' or path.endswith('html'):
             logging.info('Parsing SysTrace format...')
-            self.ftrace = trappy.SysTrace(path, scope="custom",
-                                          events=self.events,
-                                          window=window)
+            trace_class = trappy.SysTrace
             self.trace_format = 'SysTrace'
         elif trace_format.upper() == 'FTRACE':
             logging.info('Parsing FTrace format...')
-            self.ftrace = trappy.FTrace(path, scope="custom",
-                                        events=self.events,
-                                        window=window)
+            trace_class = trappy.FTrace
             self.trace_format = 'FTrace'
+
+        self.ftrace = trace_class(path, scope="custom", events=self.events,
+                                  window=window)
 
         # Check for events available on the parsed trace
         self.__checkAvailableEvents()

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -100,6 +100,8 @@ class Trace(object):
             logging.info('Parsing FTrace format...')
             trace_class = trappy.FTrace
             self.trace_format = 'FTrace'
+        else:
+            raise ValueError("Unknown trace format {}".format(trace_format))
 
         self.ftrace = trace_class(path, scope="custom", events=self.events,
                                   window=window)


### PR DESCRIPTION
Pass normalize_time down to trappy.  Sometimes it's useful to have the
same time between kernelshark and trappy.  Trappy supports this with
normalize_time but the Trace class doesn't allow you to specify it.  Let
Trace accept this parameter and pass it down to trappy.

close #57