### PR TITLE
Add systrace support

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -349,6 +349,16 @@ class TestEnv(ShareState):
             platform = Platform(model='MT8173')
             self.__modules = ['bl', 'cpufreq']
 
+        # Initialize N5X device
+        elif self.conf['board'].upper() == 'N5X':
+            platform = Platform(model='bullhead',
+                                core_names = ['A53', 'A53', 'A53', 'A53',
+                                              'A57', 'A57'],
+                                core_clusters = [ 0, 0, 0, 0, 1, 1],
+                                big_core = 'A57',
+                               )
+            self.__modules = ['bl', 'cpufreq']
+
         # Initialize default UNKNOWN board
         else:
             platform = None


### PR DESCRIPTION
This series integrate the support for SysTrace which is now provided by TRAPpy.
It adds also a board definition for a Nexus 5X device, which is not properly identified as a big.LITTLE system by devlib because of the old format used for "/proc/cpuinfo" in its default kernel.
Being a standard device we can however easily defined the devlib::Platform to be used when this target
is in use.

NOTE: this series depends on trappy HEAD being advanced to include:
https://github.com/ARM-software/trappy/pull/162