### PR TITLE
Fix LISA-shell paths

### DIFF
--- a/init_env
+++ b/init_env
@@ -20,6 +20,9 @@
 grep "bash" /proc/$$/cmdline &>/dev/null
 if [ $? -eq 0 ]; then
 	source ./src/shell/lisa_shell
+	if [ ! $? -eq 0 ]; then
+	echo "ERROR: LISA must be initialized from the LISA home folder."
+	fi
 else
 	echo "WARNING: Current shell is not a BASH"
 	# Check if a bash shell is available

--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -25,7 +25,7 @@ source src/shell/lisa_colors
 DEVMODE=${DEVMODE:-1}
 
 # Get base installation path of LISA
-LISA_HOME="$(pwd)"
+LISA_HOME=$(pwd)
 
 export PYTHONPATH=''
 export PYTHONPATH=$LISA_HOME/libs/utils:$PYTHONPATH


### PR DESCRIPTION
lisa-help only works when called from the LISA root folder. Fix this by
storing LISA_HOME correctly and add a useful error message if someone
tries to initialize the LISA-shell outside the LISA root folder.

Signed-off-by: Morten Rasmussen <morten.rasmussen@arm.com>