### PR TITLE
lisa: Add support for new Hwmon node names with 'mainline' driver

### DIFF
--- a/libs/utils/energy.py
+++ b/libs/utils/energy.py
@@ -40,6 +40,13 @@ DEFAULT_ENERGY_METER = {
             'kinds' : [ 'energy' ]
         }
     },
+    'juno2' : {
+        'instrument' : 'hwmon',
+        'conf' : {
+            'sites' : [ 'BOARDLITTLE', 'BOARDBIG' ],
+            'kinds' : [ 'energy' ]
+        }
+    },
 
     # Hikey: by default use AEP
     'hikey' : {
@@ -166,6 +173,10 @@ class HWMon(EnergyMeter):
             if self._target.little_core.upper() in ch.upper():
                 clusters_nrg['LITTLE'] = '{:.6f}'.format(nrg_total)
             elif self._target.big_core.upper() in ch.upper():
+                clusters_nrg['big'] = '{:.6f}'.format(nrg_total)
+            elif 'LITTLE' in ch.upper():
+                clusters_nrg['LITTLE'] = '{:.6f}'.format(nrg_total)
+            elif 'BIG' in ch.upper():
                 clusters_nrg['big'] = '{:.6f}'.format(nrg_total)
             else:
                 logging.warning('%14s - Unable to bind hwmon channel [%s]'\

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -343,6 +343,9 @@ class TestEnv(ShareState):
         elif self.conf['board'].upper() == 'JUNO':
             platform = devlib.platform.arm.Juno()
             self.__modules = ['bl', 'hwmon', 'cpufreq']
+        elif self.conf['board'].upper() == 'JUNO2':
+            platform = devlib.platform.arm.Juno()
+            self.__modules = ['bl', 'hwmon', 'cpufreq']
 
         # Initialize OAK board
         elif self.conf['board'].upper() == 'OAK':

--- a/target.config
+++ b/target.config
@@ -15,10 +15,15 @@
 
     /* Board */
     /* Currently supported boards are:                            */
-    /*  juno : target is a JUNO board                             */
-    /*  tc2  : target is a TC2 board                              */
+    /*  juno  : target is a JUNO board                            */
+    /*  juno2 : target is a JUNO board, with mainline Hwmon       */
+    /*  tc2   : target is a TC2 board                             */
     /* Leave commented if your board is not listed above          */
-    "board" : "juno",
+    /* If your Juno board /sys/class/hwmon/hwmon0/energy?_name is */
+    /* of the form BOARD_*_ENERGY, then you need 'juno2'.         */
+    /* Otherwise 'juno' is sufficient. In either case, lisa uses  */
+    /* devlib's 'juno' target definition to talk to the board.    */
+    "board" : "juno2",
 
     /* Target IP or MAC address */
     "host" : "192.168.0.20",


### PR DESCRIPTION
The names of the nodes for energy have changed - they are no longer
of the form 'a53_energy' for the CPU clusters, but are now called
'BOARD_LITTLE_ENERGY'. Likewise, all the other sensor names are different
but we don't monitor those in lisa.

In order to support those, add a new device named juno2. Once both types
are no longer in circulation, the names can be changed.

Signed-off-by: Chris Redpath <chris.redpath@arm.com>