### PR TITLE
lisa: Add support for new Hwmon node names with 'mainline' driver

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -340,7 +340,7 @@ class TestEnv(ShareState):
             self.__modules = ['bl', 'hwmon', 'cpufreq']
 
         # Initialize JUNO board
-        elif self.conf['board'].upper() == 'JUNO':
+        elif self.conf['board'].upper() in ('JUNO', 'JUNO2'):
             platform = devlib.platform.arm.Juno()
             self.__modules = ['bl', 'hwmon', 'cpufreq']
 

--- a/target.config
+++ b/target.config
@@ -15,8 +15,13 @@
 
     /* Board */
     /* Currently supported boards are:                            */
-    /*  juno : target is a JUNO board                             */
-    /*  tc2  : target is a TC2 board                              */
+    /*  juno  : target is a JUNO board                            */
+    /*  juno2 : target is a JUNO board, with mainline Hwmon       */
+    /*  tc2   : target is a TC2 board                             */
+    /* If your Juno board /sys/class/hwmon/hwmon0/energy?_name is */
+    /* of the form BOARD_*_ENERGY, then you need 'juno2'.         */
+    /* Otherwise 'juno' is sufficient. In either case, lisa uses  */
+    /* devlib's 'juno' target definition to talk to the board.    */
     /* Leave commented if your board is not listed above          */
     "board" : "juno",
 


### PR DESCRIPTION
The names of the nodes for energy have changed - they are no longer
of the form 'a53_energy' for the CPU clusters, but are now called
'BOARD_LITTLE_ENERGY'. Likewise, all the other sensor names are different
but we don't monitor those in lisa.

In order to support those, add a new device named juno2. Once both types
are no longer in circulation, the names can be changed.

Signed-off-by: Chris Redpath <chris.redpath@arm.com>