### PR TITLE
lisa_shell: bind ipython server to eth0 when run from a vagrant environment

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -170,7 +170,15 @@ rm -f $PIDFILE 2>/dev/null
 
 function lisa-ipython {
 CMD=${1:-start}
-NETIF=${2:-lo}
+
+if [ "x$2" == "x" -a $USER == "vagrant" -a -e /vagrant/src/shell/lisa_shell ]; then
+    # NETIF not set and we are in a vagrant environment.  Default to
+    # eth0 as loopback won't let you connect from your host machine.
+    NETIF="eth0"
+else
+    NETIF=${2:-lo}
+fi
+
 PORT=${3:-8888}
 echo
 case "x${CMD^^}" in


### PR DESCRIPTION
When running inside vagrant with the default VirtualBox configuration, the host accesses the vm using a virtual ethernet link.  `lisa-ipython start` uses loopback as the default interface, which makes the ipython server bind only to loopback and refuse connections from the host.

Make `lisa-ipython start` bind to eth0 by default, which is the more sensible default in that environment.

Reported by @raw-bin 