### PR TITLE
lisa_shell: document the PORT parameter of lisa-ipython

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -113,11 +113,12 @@ echo
 ################################################################################
 
 function _lisa-ipython-usage {
-    echo "Usage: lisa-ipython CMD [NETIF]"
+    echo "Usage: lisa-ipython CMD [NETIF [PORT]]"
 	echo " CMD     - IPython Notebooks command (deafult: start)"
 	echo "  start  start the ipython server"
 	echo "   stop  stop the ipython server"
     echo " NETIF   - the network interface to start the server on (default: lo)"
+    echo " PORT    - the tcp port for the server (default: 8888)"
 }
 
 function _lisa-ipython-start {


### PR DESCRIPTION
0bb8438f0157 ("lisa_shell: add support for multiple instances") introduced a third parameter to lisa-ipython.  After the network interface you can set the port.  Document it in lisa-ipython's usage.