### PR TITLE
libs/utils/trace: compute time ranges for plot window

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -124,6 +124,15 @@ class Trace(object):
 
         self.__loadTasksNames(tasks)
 
+        # Compute plot window
+        if not normalize_time:
+            start = self.window[0]
+            if self.window[1]:
+                duration = min(self.ftrace.get_duration(), self.window[1])
+            else:
+                duration = self.ftrace.get_duration()
+            self.window = (self.ftrace.basetime + start,
+                           self.ftrace.basetime + duration)
 
     def __checkAvailableEvents(self, key=""):
         for val in self.ftrace.get_filters(key):


### PR DESCRIPTION
If the user does not want the time to be normalized we need to compute the plot
window range boundaries.

Also, the user could specify a window tuple with start and end times. These
values are relative to the basetime of the trace and therefore the plot window
boundaries are computed accordingly.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>