### PR TITLE
Vagrantfile: update virtual machine creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 results*
 *.json
 *.log
+tools/android-sdk-linux

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,5 +50,17 @@ Vagrant.configure(2) do |config|
     echo "export ANDROID_HOME=/vagrant/tools/android-sdk-linux" >> /home/vagrant/.bashrc
     echo "export PATH=$ANDROID_HOME/platform-tools:$ANDROID_HOME/tools:$PATH" >> /home/vagrant/.bashrc
     echo source init_env >> /home/vagrant/.bashrc
+
+    echo "Virtual Machine Installation completed successfully!                "
+    echo "                                                                    "
+    echo "You can now access and use the virtual machine by running:          "
+    echo "                                                                    "
+    echo "    $ vagrant ssh                                                   "
+    echo "                                                                    "
+    echo "NOTE: if you exit, the virtual machine is still running. To shut it "
+    echo "      down, please run:                                             "
+    echo "                                                                    "
+    echo "    $ vagrant suspend                                               "
+    echo "                                                                    "
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,10 @@ Vagrant.configure(2) do |config|
     ln -s /vagrant /home/vagrant/lisa
     chown vagrant.vagrant /home/vagrant/lisa
     echo cd /home/vagrant/lisa >> /home/vagrant/.bashrc
+    for LC in $(locale | cut -d= -f1);
+    do
+        echo unset $LC  >> /home/vagrant/.bashrc
+    done
     echo source init_env >> /home/vagrant/.bashrc
   SHELL
 end


### PR DESCRIPTION
This series addresses the following issues:

* Avoiding warnings with locales
* Installing Android SDK under `lisa/tools` if not yet present and setting `ANDROID_HOME` properly

Solves one of the warnings reported in #102.

close #117 

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>