### PR TITLE
ipynb: energy_model: add example for energy model analysis

### DIFF
--- a/ipynb/utils/energy_model_example.ipynb
+++ b/ipynb/utils/energy_model_example.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from __future__ import division\n",
+    "from scipy.interpolate import spline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# \n",
+    "# Use Juno's energy model as example, platform only need modify\n",
+    "# energy_model structure to verify energy model is reasonable or not\n",
+    "#\n",
+    "energy_model = {\n",
+    "    'cluster_0' : {\n",
+    "        'label'    : np.array(['450MHz(L)', '575MHz(L)', '700MHz(L)', '775MHz(L)', '850Mhz(L)']),\n",
+    "        'capacity' : np.array([235, 302, 368, 406, 447]),\n",
+    "        'energy'   : np.array([33, 46, 61, 76, 93]),\n",
+    "    },\n",
+    "    \n",
+    "    'cluster_1' : {\n",
+    "        'label'    : np.array(['450MHz(B)', '625MHz(B)', '800MHz(B)', '950MHz(B)', '1100Mhz(B)']),\n",
+    "        'capacity' : np.array([417, 579, 744, 883, 1024]),\n",
+    "        'energy'   : np.array([168, 251, 359, 479, 616]),\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "# set plot size\n",
+    "plt.figure(figsize=(12,6), dpi=80)\n",
+    "\n",
+    "plt.subplot(211)\n",
+    "\n",
+    "# plot for power efficiency\n",
+    "xlable_range = np.array([])\n",
+    "xlable = np.array([])\n",
+    "core_range = np.array([])\n",
+    "range_base = 1\n",
+    "for key in energy_model:\n",
+    "    xlable_range = np.append(xlable_range, np.array(range(len(energy_model[key]['label']))) + range_base)\n",
+    "    xlable = np.append(xlable, energy_model[key]['label'])\n",
+    "    core_range = np.array(range(len(energy_model[key]['label']))) + range_base\n",
+    "    \n",
+    "    energy_model[key]['efficiency'] = energy_model[key]['energy'] / energy_model[key]['capacity']\n",
+    "    x_sm = np.array(core_range)\n",
+    "    x_smooth = np.linspace(x_sm.min(), x_sm.max(), 200)\n",
+    "    y_smooth = spline(core_range, energy_model[key]['efficiency'], x_smooth)\n",
+    "    plt.plot(x_smooth, y_smooth, color=\"green\", linewidth=3, linestyle=\"-\", label=key)\n",
+    "    plt.plot(core_range, energy_model[key]['efficiency'], 'go')\n",
+    "    range_base += len(energy_model[key]['label']) + 1\n",
+    "\n",
+    "plt.xticks(xlable_range, xlable)\n",
+    "\n",
+    "plt.legend(loc='upper left', frameon=False)\n",
+    "\n",
+    "plt.xlim(0, 12)\n",
+    "plt.ylim(0.1, 0.7)\n",
+    "plt.xlabel('CPU OPPs')\n",
+    "plt.ylabel('CPU Power Efficiency')\n",
+    "\n",
+    "plt.subplot(212)\n",
+    "\n",
+    "# plot for cpu's capacity\n",
+    "core_range = np.array([])\n",
+    "range_base = 1\n",
+    "for key in energy_model:\n",
+    "    core_range = np.array(range(len(energy_model[key]['label']))) + range_base\n",
+    "    range_base += len(energy_model[key]['label']) + 1\n",
+    "    x_sm = np.array(core_range)\n",
+    "    x_smooth = np.linspace(x_sm.min(), x_sm.max(), 200)\n",
+    "    y_smooth = spline(core_range, energy_model[key]['capacity'], x_smooth)\n",
+    "    plt.plot(x_smooth, y_smooth, color=\"green\", linewidth=3, linestyle=\"-\", label=key)\n",
+    "    plt.plot(core_range, energy_model[key]['capacity'], 'go')\n",
+    "\n",
+    "plt.xticks(xlable_range, xlable)\n",
+    "\n",
+    "plt.legend(loc='upper left', frameon=False)\n",
+    "\n",
+    "plt.xlim(0, 12)\n",
+    "plt.ylim(0, 1100)\n",
+    "plt.xlabel('CPU OPPs')\n",
+    "plt.ylabel('CPU Capacity')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Add ipynb script to analyse energy model and display the power
efficiency and capacity between two clusters.

This will be helpful to check if energy model is reasonable or not,
and it's straightforward to get to know if there have overlap between
two cluster's energy model; If have overlap, which it's likely to
introduce wrong behavior for EAS energy calculation.

Signed-off-by: Leo Yan <leo.yan@linaro.org>