### PR TITLE
lisa_shell: fix lisa-update failure

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -114,7 +114,7 @@ if [ $ret -ne 0 ]; then
 fi
 
 curr_commit=$(git rev-parse HEAD)
-remote_name=$(git remote -v | grep ARM-software/lisa.git | grep -m 1 fetch | awk '{print $1}')
+remote_name=$(git remote -v | grep ARM-software/lisa | grep -m 1 fetch | awk '{print $1}')
 git merge-base --is-ancestor $curr_commit $remote_name/master
 ret=$?
 if [ $ret -ne 0 ]; then


### PR DESCRIPTION
In patch 3f5553ffb2 "lisa_shell: teach lisa-update to update itself" it
search "ARM-software/lisa.git" to generate "remote_name".

But in some case, for example clone LISA's repo with below command:
git clone https://github.com/ARM-software/lisa; so finally it cannot
find out "ARM-software/lisa.git" due without suffix ".git".

To compatible both cloning methods, change to search
"ARM-software/lisa".

Signed-off-by: Leo Yan <leo.yan@linaro.org>