### PR TITLE
libs/utils/trace_analysis: fix for image file name

### DIFF
--- a/libs/utils/trace_analysis.py
+++ b/libs/utils/trace_analysis.py
@@ -470,8 +470,8 @@ class TraceAnalysis(object):
                 plot_id = plot_id + 1
 
             # Save generated plots into datadir
-            figname = '{}/{}task_util_{}.png'.format(
-                self.plotsdir, self.prefix, task_name.replace('/', '_'))
+            task_name = re.sub('[:/]', '_', task_name)
+            figname = '{}/{}task_util_{}.png'.format(self.plotsdir, self.prefix, task_name)
             pl.savefig(figname, bbox_inches='tight')
 
     def plotEDiffTime(self, tasks=None,


### PR DESCRIPTION
trace_analysis automatically saves image for method
trace_analysis::plotTasks(), which conjunct task name for saving image
file. But sometimes task name has special characters (like ':', '/'), so
Linux cannot support these characters for file name.

So this patch is to fix this failure to convert special characters to
underline '_'.

Signed-off-by: Leo Yan <leo.yan@linaro.org>