### PR TITLE
libs/utils/env: Pass a force_new flag to force the creation of a new TestEnv

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -57,7 +57,8 @@ class TestEnv(ShareState):
 
     _initialized = False
 
-    def __init__(self, target_conf=None, test_conf=None, wipe=True):
+    def __init__(self, target_conf=None, test_conf=None, wipe=True,
+                 force_new=False):
         """
         Initialize the LISA test environment.
 
@@ -79,10 +80,16 @@ class TestEnv(ShareState):
         :param wipe: set true to cleanup all previous content from the output
         folder
         :type wipe: bool
+
+        :param force_new: Create a new TestEnv object even if there is
+        one available for this session.  By default, TestEnv only
+        creates one object per session, use this to override this
+        behaviour.
+        :type force_new: bool
         """
         super(TestEnv, self).__init__()
 
-        if self._initialized:
+        if self._initialized and not force_new:
             return
 
         self.conf = None


### PR DESCRIPTION
TestEnv only creates one object per session.  When you are
experimenting, sometimes you need to change target_conf or test_conf and
create a new TestEnv.  Add a force_new flag to force TestEnv to
reinitialize the platform with the new values.