### PR TITLE
rta: do not accumulate delay

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -343,11 +343,10 @@ class RTA(Workload):
 
             if 'delay' in task.keys():
                 if task['delay'] > 0:
-                    task['delay'] = int(task['delay'] * 1e6)
                     task_conf['phases']['p000000'] = {}
-                    task_conf['phases']['p000000']['delay'] = task['delay']
+                    task_conf['phases']['p000000']['delay'] = int(task['delay'] * 1e6)
                     self.logger.info('%14s -  | start delay: %.6f [s]',
-                            'RTApp', task['delay'] / 1e6)
+                            'RTApp', task['delay'])
 
             self.logger.info('%14s -  | calibration CPU: %d',
                              'RTApp', target_cpu)


### PR DESCRIPTION
Successive conf() calls were making rta accumulate delay parameter
(since the scaled values was saved in the internal dict). This was also
causing the value to eventually overflow.

Fix it by always using the dict parameter directly to initialize phases.