### PR TITLE
Add API and example Notebook for Kernel functions profiling

### DIFF
--- a/ipynb/examples/trace_analysis/TraceAnalysis_FunctionsProfiling.ipynb
+++ b/ipynb/examples/trace_analysis/TraceAnalysis_FunctionsProfiling.ipynb
@@ -1,0 +1,713 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<font size=\"8\">Trace Analysis Examples</font>\n",
+    "<br>\n",
+    "<font size=\"5\">Kernel Functions Profiling</font>\n",
+    "<br>\n",
+    "<hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Import Required Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "reload(logging)\n",
+    "logging.basicConfig(\n",
+    "    format='%(asctime)-9s %(levelname)-8s: %(message)s',\n",
+    "    datefmt='%I:%M:%S')\n",
+    "\n",
+    "# Enable logging at INFO level\n",
+    "logging.getLogger().setLevel(logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate plots inline\n",
+    "%matplotlib inline\n",
+    "\n",
+    "import json\n",
+    "import os\n",
+    "\n",
+    "# Support to access the remote target\n",
+    "import devlib\n",
+    "from env import TestEnv\n",
+    "\n",
+    "# RTApp configurator for generation of PERIODIC tasks\n",
+    "from wlgen import RTA, Ramp\n",
+    "\n",
+    "# Support for trace events analysis\n",
+    "from trace import Trace\n",
+    "from trace_analysis import TraceAnalysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Target Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Setup target configuration\n",
+    "my_conf = {\n",
+    "\n",
+    "    # Target platform and board\n",
+    "    \"platform\"    : 'linux',\n",
+    "    \"board\"       : 'juno',\n",
+    "    \"host\"        : '192.168.0.1',\n",
+    "\n",
+    "    # Folder where all the results will be collected\n",
+    "    \"results_dir\" : \"TraceAnalysis_FunctionsProfiling\",\n",
+    "\n",
+    "    # Define devlib modules to load\n",
+    "    \"exclude_modules\" : [ 'hwmon' ],\n",
+    "\n",
+    "    # FTrace events to collect for all the tests configuration which have\n",
+    "    # the \"ftrace\" flag enabled\n",
+    "    \"ftrace\"  : {\n",
+    "        \"functions\" : [\n",
+    "            \"pick_next_task_fair\",\n",
+    "            \"select_task_rq_fair\",\n",
+    "            \"enqueue_task_fair\",\n",
+    "            \"update_curr_fair\",\n",
+    "            \"dequeue_task_fair\",\n",
+    "        ],\n",
+    "        \n",
+    "         \"buffsize\" : 100 * 1024,\n",
+    "    },\n",
+    "\n",
+    "    # Tools required by the experiments\n",
+    "    \"tools\"   : [ 'trace-cmd', 'rt-app' ],\n",
+    "    \n",
+    "    # Comment this line to calibrate RTApp in your own platform\n",
+    "    \"rtapp-calib\" :  {\"0\": 360, \"1\": 142, \"2\": 138, \"3\": 352, \"4\": 352, \"5\": 353},\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "03:35:25  INFO    :         Target - Using base path: /home/derkling/Code/lisa\n",
+      "03:35:25  INFO    :         Target - Loading custom (inline) target configuration\n",
+      "03:35:25  INFO    :         Target - Devlib modules to load: ['bl', 'cpufreq']\n",
+      "03:35:25  INFO    :         Target - Connecting linux target:\n",
+      "03:35:25  INFO    :         Target -   username : root\n",
+      "03:35:25  INFO    :         Target -       host : 192.168.0.1\n",
+      "03:35:25  INFO    :         Target -   password : \n",
+      "03:35:25  INFO    :         Target - Connection settings:\n",
+      "03:35:25  INFO    :         Target -    {'username': 'root', 'host': '192.168.0.1', 'password': ''}\n",
+      "03:35:29  INFO    :         Target - Initializing target workdir:\n",
+      "03:35:29  INFO    :         Target -    /root/devlib-target\n",
+      "03:35:34  INFO    :         Target - Topology:\n",
+      "03:35:34  INFO    :         Target -    [[0, 3, 4, 5], [1, 2]]\n",
+      "03:35:35  INFO    :       Platform - Loading default EM:\n",
+      "03:35:35  INFO    :       Platform -    /home/derkling/Code/lisa/libs/utils/platforms/juno.json\n",
+      "03:35:38  INFO    :         FTrace - Enabled tracepoints:\n",
+      "03:35:38  INFO    :         FTrace -   sched:*\n",
+      "03:35:38  INFO    :         FTrace - Kernel functions profiled:\n",
+      "03:35:38  INFO    :         FTrace -   pick_next_task_fair\n",
+      "03:35:38  INFO    :         FTrace -   select_task_rq_fair\n",
+      "03:35:38  INFO    :         FTrace -   enqueue_task_fair\n",
+      "03:35:38  INFO    :         FTrace -   update_curr_fair\n",
+      "03:35:38  INFO    :         FTrace -   dequeue_task_fair\n",
+      "03:35:38  WARNING :         Target - Using configuration provided RTApp calibration\n",
+      "03:35:38  INFO    :         Target - Using RT-App calibration values:\n",
+      "03:35:38  INFO    :         Target -    {\"0\": 360, \"1\": 142, \"2\": 138, \"3\": 352, \"4\": 352, \"5\": 353}\n",
+      "03:35:38  INFO    :    EnergyMeter - HWMON module not enabled\n",
+      "03:35:38  WARNING :    EnergyMeter - Energy sampling disabled by configuration\n",
+      "03:35:38  INFO    :        TestEnv - Set results folder to:\n",
+      "03:35:38  INFO    :        TestEnv -    /home/derkling/Code/lisa/results/TraceAnalysis_FunctionsProfiling\n",
+      "03:35:38  INFO    :        TestEnv - Experiment results available also in:\n",
+      "03:35:38  INFO    :        TestEnv -    /home/derkling/Code/lisa/results_latest\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Initialize a test environment using:\n",
+    "te = TestEnv(my_conf, wipe=False, force_new=True)\n",
+    "target = te.target"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Workload Execution and Functions Profiling Data Collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def experiment(te):\n",
+    "\n",
+    "    # Create and RTApp RAMP task\n",
+    "    rtapp = RTA(te.target, 'ramp', calibration=te.calibration())\n",
+    "    rtapp.conf(kind='profile',\n",
+    "               params={\n",
+    "                    'ramp' : Ramp(\n",
+    "                        start_pct =  60,\n",
+    "                        end_pct   =  20,\n",
+    "                        delta_pct =   5,\n",
+    "                        time_s    =   0.5).get()\n",
+    "              })\n",
+    "\n",
+    "    # FTrace the execution of this workload\n",
+    "    te.ftrace.start()\n",
+    "    rtapp.run(out_dir=te.res_dir)\n",
+    "    te.ftrace.stop()\n",
+    "\n",
+    "    # Collect and keep track of the trace\n",
+    "    trace_file = os.path.join(te.res_dir, 'trace.dat')\n",
+    "    te.ftrace.get_trace(trace_file)\n",
+    "    \n",
+    "    # Collect and keep track of the Kernel Functions performance data\n",
+    "    stats_file = os.path.join(te.res_dir, 'trace.stats')\n",
+    "    te.ftrace.get_stats(stats_file)\n",
+    "\n",
+    "    # Dump platform descriptor\n",
+    "    te.platform_dump(te.res_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "03:35:38  INFO    :          WlGen - Setup new workload ramp\n",
+      "03:35:38  INFO    :          RTApp - Workload duration defined by longest task\n",
+      "03:35:38  INFO    :          RTApp - Default policy: SCHED_OTHER\n",
+      "03:35:38  INFO    :          RTApp - ------------------------\n",
+      "03:35:38  INFO    :          RTApp - task [ramp], sched: using default policy\n",
+      "03:35:38  INFO    :          RTApp -  | calibration CPU: 1\n",
+      "03:35:38  INFO    :          RTApp -  | loops count: 1\n",
+      "03:35:38  INFO    :          RTApp - + phase_000001: duration 0.500000 [s] (5 loops)\n",
+      "03:35:38  INFO    :          RTApp - |  period   100000 [us], duty_cycle  60 %\n",
+      "03:35:38  INFO    :          RTApp - |  run_time  60000 [us], sleep_time  40000 [us]\n",
+      "03:35:38  INFO    :          RTApp - + phase_000002: duration 0.500000 [s] (5 loops)\n",
+      "03:35:38  INFO    :          RTApp - |  period   100000 [us], duty_cycle  55 %\n",
+      "03:35:38  INFO    :          RTApp - |  run_time  55000 [us], sleep_time  45000 [us]\n",
+      "03:35:38  INFO    :          RTApp - + phase_000003: duration 0.500000 [s] (5 loops)\n",
+      "03:35:38  INFO    :          RTApp - |  period   100000 [us], duty_cycle  50 %\n",
+      "03:35:38  INFO    :          RTApp - |  run_time  50000 [us], sleep_time  50000 [us]\n",
+      "03:35:38  INFO    :          RTApp - + phase_000004: duration 0.500000 [s] (5 loops)\n",
+      "03:35:38  INFO    :          RTApp - |  period   100000 [us], duty_cycle  45 %\n",
+      "03:35:38  INFO    :          RTApp - |  run_time  45000 [us], sleep_time  55000 [us]\n",
+      "03:35:38  INFO    :          RTApp - + phase_000005: duration 0.500000 [s] (5 loops)\n",
+      "03:35:38  INFO    :          RTApp - |  period   100000 [us], duty_cycle  40 %\n",
+      "03:35:38  INFO    :          RTApp - |  run_time  40000 [us], sleep_time  60000 [us]\n",
+      "03:35:38  INFO    :          RTApp - + phase_000006: duration 0.500000 [s] (5 loops)\n",
+      "03:35:38  INFO    :          RTApp - |  period   100000 [us], duty_cycle  35 %\n",
+      "03:35:38  INFO    :          RTApp - |  run_time  35000 [us], sleep_time  65000 [us]\n",
+      "03:35:38  INFO    :          RTApp - + phase_000007: duration 0.500000 [s] (5 loops)\n",
+      "03:35:38  INFO    :          RTApp - |  period   100000 [us], duty_cycle  30 %\n",
+      "03:35:38  INFO    :          RTApp - |  run_time  30000 [us], sleep_time  70000 [us]\n",
+      "03:35:38  INFO    :          RTApp - + phase_000008: duration 0.500000 [s] (5 loops)\n",
+      "03:35:38  INFO    :          RTApp - |  period   100000 [us], duty_cycle  25 %\n",
+      "03:35:38  INFO    :          RTApp - |  run_time  25000 [us], sleep_time  75000 [us]\n",
+      "03:35:38  INFO    :          RTApp - + phase_000009: duration 0.500000 [s] (5 loops)\n",
+      "03:35:38  INFO    :          RTApp - |  period   100000 [us], duty_cycle  20 %\n",
+      "03:35:38  INFO    :          RTApp - |  run_time  20000 [us], sleep_time  80000 [us]\n",
+      "03:35:44  INFO    :          WlGen - Workload execution START:\n",
+      "03:35:44  INFO    :          WlGen -    /root/devlib-target/bin/rt-app /root/devlib-target/ramp_00.json 2>&1\n"
+     ]
+    }
+   ],
+   "source": [
+    "experiment(te)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parse Trace and Profiling Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "03:35:53  INFO    : Content of the output folder /home/derkling/Code/lisa/results/TraceAnalysis_FunctionsProfiling\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[01;34m/home/derkling/Code/lisa/results/TraceAnalysis_FunctionsProfiling\u001b[00m\r\n",
+      "├── output.log\r\n",
+      "├── platform.json\r\n",
+      "├── ramp_00.json\r\n",
+      "├── rt-app-ramp-0.log\r\n",
+      "├── trace.dat\r\n",
+      "├── trace.raw.txt\r\n",
+      "├── trace.stats\r\n",
+      "└── trace.txt\r\n",
+      "\r\n",
+      "0 directories, 8 files\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Base folder where tests folder are located\n",
+    "res_dir = te.res_dir\n",
+    "logging.info('Content of the output folder %s', res_dir)\n",
+    "!tree {res_dir}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "03:35:53  INFO    : LITTLE cluster max capacity: 447\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(os.path.join(res_dir, 'platform.json'), 'r') as fh:\n",
+    "    platform = json.load(fh)\n",
+    "#print json.dumps(platform, indent=4)\n",
+    "logging.info('LITTLE cluster max capacity: %d',\n",
+    "             platform['nrg_model']['little']['cpu']['cap_max'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "03:35:53  INFO    : Parsing FTrace format...\n",
+      "03:35:54  INFO    : Trace contains onlt functions stats\n",
+      "03:35:54  INFO    : Collected events spans a 0.000 [s] time interval\n",
+      "03:35:54  INFO    : Set plots time range to (0.000000, 0.000000)[s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "trace = Trace(platform, res_dir, events=[])\n",
+    "ta = TraceAnalysis(trace)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Report Functions Profiling Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>hits</th>\n",
+       "      <th>avg</th>\n",
+       "      <th>time</th>\n",
+       "      <th>s_2</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">0</th>\n",
+       "      <th>dequeue_task_fair</th>\n",
+       "      <td>534</td>\n",
+       "      <td>3.139</td>\n",
+       "      <td>1676.40</td>\n",
+       "      <td>4.969</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>enqueue_task_fair</th>\n",
+       "      <td>791</td>\n",
+       "      <td>3.289</td>\n",
+       "      <td>2601.82</td>\n",
+       "      <td>2.528</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">1</th>\n",
+       "      <th>dequeue_task_fair</th>\n",
+       "      <td>96</td>\n",
+       "      <td>3.960</td>\n",
+       "      <td>380.24</td>\n",
+       "      <td>3.462</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>enqueue_task_fair</th>\n",
+       "      <td>88</td>\n",
+       "      <td>2.929</td>\n",
+       "      <td>257.80</td>\n",
+       "      <td>1.382</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2</th>\n",
+       "      <th>dequeue_task_fair</th>\n",
+       "      <td>191</td>\n",
+       "      <td>2.775</td>\n",
+       "      <td>530.20</td>\n",
+       "      <td>2.693</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>enqueue_task_fair</th>\n",
+       "      <td>194</td>\n",
+       "      <td>2.400</td>\n",
+       "      <td>465.62</td>\n",
+       "      <td>1.237</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">3</th>\n",
+       "      <th>dequeue_task_fair</th>\n",
+       "      <td>282</td>\n",
+       "      <td>5.181</td>\n",
+       "      <td>1461.24</td>\n",
+       "      <td>9.018</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>enqueue_task_fair</th>\n",
+       "      <td>78</td>\n",
+       "      <td>3.766</td>\n",
+       "      <td>293.82</td>\n",
+       "      <td>4.445</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">4</th>\n",
+       "      <th>dequeue_task_fair</th>\n",
+       "      <td>55</td>\n",
+       "      <td>3.101</td>\n",
+       "      <td>170.60</td>\n",
+       "      <td>2.611</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>enqueue_task_fair</th>\n",
+       "      <td>32</td>\n",
+       "      <td>3.203</td>\n",
+       "      <td>102.52</td>\n",
+       "      <td>2.020</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">5</th>\n",
+       "      <th>dequeue_task_fair</th>\n",
+       "      <td>1145</td>\n",
+       "      <td>5.705</td>\n",
+       "      <td>6532.86</td>\n",
+       "      <td>12.424</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>enqueue_task_fair</th>\n",
+       "      <td>1127</td>\n",
+       "      <td>5.332</td>\n",
+       "      <td>6009.62</td>\n",
+       "      <td>7.407</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     hits    avg     time     s_2\n",
+       "0 dequeue_task_fair   534  3.139  1676.40   4.969\n",
+       "  enqueue_task_fair   791  3.289  2601.82   2.528\n",
+       "1 dequeue_task_fair    96  3.960   380.24   3.462\n",
+       "  enqueue_task_fair    88  2.929   257.80   1.382\n",
+       "2 dequeue_task_fair   191  2.775   530.20   2.693\n",
+       "  enqueue_task_fair   194  2.400   465.62   1.237\n",
+       "3 dequeue_task_fair   282  5.181  1461.24   9.018\n",
+       "  enqueue_task_fair    78  3.766   293.82   4.445\n",
+       "4 dequeue_task_fair    55  3.101   170.60   2.611\n",
+       "  enqueue_task_fair    32  3.203   102.52   2.020\n",
+       "5 dequeue_task_fair  1145  5.705  6532.86  12.424\n",
+       "  enqueue_task_fair  1127  5.332  6009.62   7.407"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get the DataFrame for the specified list of kernel functions\n",
+    "df = trace.functions_stats_df(['enqueue_task_fair', 'dequeue_task_fair'])\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>hits</th>\n",
+       "      <th>avg</th>\n",
+       "      <th>time</th>\n",
+       "      <th>s_2</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <th>select_task_rq_fair</th>\n",
+       "      <td>810</td>\n",
+       "      <td>9.760</td>\n",
+       "      <td>7906.32</td>\n",
+       "      <td>52.352</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <th>select_task_rq_fair</th>\n",
+       "      <td>64</td>\n",
+       "      <td>4.512</td>\n",
+       "      <td>288.80</td>\n",
+       "      <td>16.507</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <th>select_task_rq_fair</th>\n",
+       "      <td>164</td>\n",
+       "      <td>3.560</td>\n",
+       "      <td>583.90</td>\n",
+       "      <td>13.352</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <th>select_task_rq_fair</th>\n",
+       "      <td>71</td>\n",
+       "      <td>10.311</td>\n",
+       "      <td>732.12</td>\n",
+       "      <td>65.864</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <th>select_task_rq_fair</th>\n",
+       "      <td>40</td>\n",
+       "      <td>4.777</td>\n",
+       "      <td>191.10</td>\n",
+       "      <td>29.821</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <th>select_task_rq_fair</th>\n",
+       "      <td>1015</td>\n",
+       "      <td>5.306</td>\n",
+       "      <td>5386.04</td>\n",
+       "      <td>17.775</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       hits     avg     time     s_2\n",
+       "0 select_task_rq_fair   810   9.760  7906.32  52.352\n",
+       "1 select_task_rq_fair    64   4.512   288.80  16.507\n",
+       "2 select_task_rq_fair   164   3.560   583.90  13.352\n",
+       "3 select_task_rq_fair    71  10.311   732.12  65.864\n",
+       "4 select_task_rq_fair    40   4.777   191.10  29.821\n",
+       "5 select_task_rq_fair  1015   5.306  5386.04  17.775"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get the DataFrame for the single specified kernel function\n",
+    "df = trace.functions_stats_df('select_task_rq_fair')\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plot Functions Profiling Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/kAAAILCAYAAACzaFyqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3XucXVV9N/7PykVuTgIhlIuRRK4+iFJBrGBTIyh4aXgo\nFwkICo8S608oYPFRQCVItbUi4r0VWxEqKiBawKpYaQSeKhBANIDFgARMCGCAJNxCIOv3xzkZJiGT\nTCBnTmbn/X695sU5++y91/ecPeTMZ6+11y611gAAAABD37BuFwAAAACsHUI+AAAANISQDwAAAA0h\n5AMAAEBDCPkAAADQEEI+AAAANISQDwB0VSllWinlghew/aJSyoS1V9GA2pxZSvmLwWwTAAZCyAeA\nASqlTC+lPFRKeVG3a1kbSik7lVIuLqU8WEp5pJRySynlpFLKYP99UAe6YvsYvGe5jWvtqbXevTYL\nKqU82j55sKiUsrSU8nif54fXWnettV69NtvsllLKa0sp/1FKebiUMr+Ucl0p5ej2a5Pa739RKWVh\nKeW3K7x270r295xjBMDgEfIBYADaPcWvTfJAkgM6sP8Ra3ufq2lv+yTXJZmdZNda66ZJDk2yR5Ke\nwawlSVmDdQd8QuCFqLW+uH3yoCetz+gvlz2vtX57MGpY20opw1eybK8kP0vyX0m2r7VunuT9Sd7S\nZ7U57fc9KsmHk5xbSvlfq2iqZpCOEwDPJeQDwMC8K8l/JrkgybuTpJSyQbsH/BXLViqlbNHu9R3b\nfv6XpZRftXtJ/18p5ZV91r27lPJ/Sym/TrKolDK8lPKRUsqsdq/praWUA/usP6yU8tl2z/tdpZTj\n2r2sw9qvjy6l/EspZW4p5Q+llDNX0St/RpJra60n11rvT5Ja6x211iNrrQva+zugXcPDpZT/KqW8\nfIXaTy6l/Lrdy/svpZQtSyk/KqUsKKX8tJSyaXvdCe06jy2lzGnX97f9fdCllNeVUv673e6vSilv\naC//ZJKJSb7UbvML7eVLSynb9fkMzi+lPNCu8bRSSmm/dnQp5dpSymfaIzLuKqW8pb86VqW9733a\nj6e1R0Rc0D5uvy6l7FhKOaWUcn8pZXYp5c19th3wcWrv+5JSynfa+76xlPKqPq9vU0r5Xvv93lVK\nOX4l215QSlmQ9u/tCj6T5Lxa62dqrQ8lSa31plrrlJXVU2v99yQPJ1lVyO9b/2tLKTPavxPzSimf\nHch2ADx/Qj4ADMy7knw3yUVJ9i+lbFFrXZzke0kO77PeO5JMr7X+sZTy6iT/kuTYJGOS/HOSy0op\nI/usPyXJW5NsWmt9JsmsJH/e7jU9I8m/lVK2bK87Na0e1t2S7J7kwCzfY3pekqeSbJ/k1Un2S/Le\nft7Pvkku6e/NllJ2SnJhkr9JMjbJfyS5vM+Ig5rkoPZ+dk7yl0l+lOQjSf4krb8x/maF3U5KskO7\nrg+XUvZdSbsvSXJFkk/UWjdLcnKS75VSNq+1npbkmiQfaPcsr7j/JPliWiMRXpbkDWkdt2P6vP7a\nJL9NsnmSf0zr+DwfK/ZU/2WS85NsluTmJD9tL98myZlpHftlzsvAj1PSGjlyUXvfFyb5QfuE0LAk\nl7fb2yatY3FiKWW/Fba9uNY6ur1tr1LKxklel1X8Hqyw/rBSyl8l2TTJbwayTZLPJ/lcu/3t2u8D\ngA4S8gFgNUopf57kJUkuq7X+LsltSd7ZfvnCtIL6Mkfk2TA1Nck/11pvqC3nJ1mcVrBKWkHxC7XW\nOe0TBqm1XlJrndd+fFGS36UVTJPWCYRzaq1za62PJPn7tIe6t08EvDXJSbXWJ2qtDyY5Z4Xa+to8\nyX2reNuHJbmi1vqz9smHs5JslGTvPut8sdb6YK11blrh+xe11lva7+X7aQXYvs5o1zYzyTey/MmR\nZY5M8h+11h+3P4P/TDIjydv7rLPS4f2lNRz9sCSn1Fofq7XOTvLZJEf1WW12rfVfaq01rVC+dSnl\nT1bxOQzU1bXWn7Y/q0vS+nz/of38u0kmlFJGPY/jlCQzaq2Xtvd1dpINk+yVZM8kY2utf1drfbrW\n+vskX19hX/9da70sSWqtT66w383S+ltwVb8HSbJNKeXhJA8m+ViSI9v/HwzEU0l2LKWMrbU+Xmu9\nboDbAfA8Der1fwAwRL07yZW11kXt5xe3l52TZHqSjUspy67X3y2tgJsk45O8q+8Q6iQj0+p1XWa5\nictKKe9KclKSCe1FL06rJz1Jtl5h/T/0eTy+ve/72qPTk1aAu6ef9zR/hTpWtHXfbWuttbQmWXtJ\nn3Xu7/P4iRWeP9muva++td+T5JV5rvFJDi2lTO6zbESSq/o87+9677FpfQazV2inb83zendS6+Pt\nz+rFaR27F6Lv9k8k+WP7RMKy58vaGZc1O05Jn+PcPg5/SOvY1TwbwJcZnuTqlW27Eg8nWZrWsb5j\nFevNrbW+dCXLn07rvaxoZJIl7cfvSfKJJLeXUn6f1omeH66iLQBeICEfAFahlLJRWj3ow0opy3o8\nN0iyaSnlVbXWX5dSLkqrV/qBJJfXWh9rr3dPkk/WWj+1iiZ6A2spZXySryXZJ61e8VpKuTnP9lzf\nl6Rv2Or7+N60RglsXmtdOoC39p9JDk5r6PjKzE2fEN6+rv2lSeasYp+rm0Bv2yT/0+fxyvZ1T5IL\naq1T+9nHqiZ0+2Na4XJCktv7tLOqoDvY1vQ4JX2Oc3uI/ri0Prtnkvy+1rpTP9utcgK89kmOXyQ5\nJMnPB1hLX/ckGVtK2WTZ73z792R82idaaq2z0hrdklLKwUkuKaWMqbU+0c8+AXiBDNcHgFU7MK0e\ny/+VVi/9bu3H16R1vXfy7JD9vkP1k+TcJH/dnnyslFI2KaW8vZSyYg/3MpukFcr+mNZJhWOS7Nrn\n9YuSnNCebG3TtGY6r0lSa70vyZVJzi6l9LSvn96+9H8v99OT7F1K+cdl1/yXUnZoT9I2qt3W20sp\n+7TnEPjbtHrn/3sAn1l/PlpK2ai0Jio8Oq1h7Cv6tySTSyn7ta8737C0btW2rDf+/rSuZX+O9nD2\ni5J8spTy4vZJk5Pa+1wnPI/jlCR7lFL+qj0fwolpHYdfJrkhrQkb/2/7cx1eStm1lPKa9nYDuWvB\n/01ydGlNorh5kpRSdiulrPYOArXWe9K6Q8On27/bGyT5UFpD9H/Z3teRpZQt2pssSOv3daAnNwB4\nHoR8AFi1dyX511rrH2qtD7R/7k/ypSRHlFKG1VqvT/JoWsOef7Rsw1rrjWlNuvelJA+ldX39u9JP\n72qt9ba0riH/RVrDyndNcm2fVc5NKyD+OsmNSX6Y5Jk+PcLvSvKitOYMeCitywq26qetu9K6rntC\nkltLKY+kdS35DUkerbXekdb18V9M61rstyeZXGt9ehWfVV3h8Yrv8+dpTSz4n0k+077efrl1a61/\nSPK/k5ya1siIe9I6wbAssH4+ySGlNTv+OSup4fgkjyW5K60TMd9K6/r//mpaG7d6G8h++z4f8HFq\nb/fvac018FBac0EcVGt9pn1S4y+T/Gla7/fBtEaCjFpFXcvvvNZfpDVyZJ8kd5ZS5qc1SWDfIfWr\n2sdhaU20OCutERNvTPL2WutT7df3TzKzlLIoyeeSTFk2/wQAnVGevVyMdU0p5V/T+qPqgVrrK9vL\nPpPWF/pTSe5McsyyWx0BsH4ppbw1yVdrrRO6XcuqlFImpBVCR6zBEHWSlFJOT7JDrfWo1a4MANGT\nv677Rlq3SurryiSvqLXultYkOacMelUAdEV76PrbSikj2sPXT09yabfroqMGMuQeAHoJ+euwWus1\nac1823fZT/v0glyX1uQ7AKwfSpJpaQ3bvinJrUk+3s2C1oChg8/PaofcA0BfZtcf2v5PktVOjANA\nM7RnJH9tt+tYU7XWu9O6tRtrqNZ6RrdrAGBoEfKHqFLKaUmeqrVe2M/rzvoDAAA0WK31OZd1CflD\nUCnl6CRvS7LvqtYzqSIAAEAzlbLyaVuE/CGmlPKWtO5B+4Za65PdrgcAAIB1h1vorcNKKd9O8oYk\nY5Pcn9YsyqekdW/dh9qr/aLW+v+tZNvq2AIAADRTKWWlw/WF/IYS8gEAAJqrv5DvFnoAAADQEK7J\nBwAAWEP9TXoGnbAmo7SFfAAAgOfB5bEMhjU9oWS4PgAAADSEkA8AAAANIeQDAABAQwj5AAAA0BBC\nPgAAQMMdffTR+djHPtbtMtZZz+fzeeKJJzJ58uRsuummOeyww1a7/q677pqrr776+ZY4YGbXBwAA\nWAsG47Z6z3dG/1JK4277N3369Bx11FG59957X/C+ns/nc8kll+SBBx7IQw89lGHDVt9/PnPmzOdb\n3hoR8gEAANaaTt5W74WFdLf8W7U1/Xxmz56dnXbaaUABf3WeeeaZDB8+/AXvJzFcHwAAoHFuvvnm\n7L777hk1alSmTJmSJ598sve1K664In/6p3+azTbbLK9//evzm9/8pt/tpkyZ0juM/bzzzsvEiROX\na2fYsGG56667kiSLFy/OySefnPHjx2errbbK+9///t52X8i2K/PYY4/lrW99a+bOnZuenp6MGjUq\n8+bNy/XXX5+99torm222WbbZZpscf/zxWbJkSe92J510UrbccsuMHj06r3rVq3Lbbbc9Z9+LFi3K\nG9/4xpx44on9tn/66afnzDPPzHe/+9309PTkG9/4Ru66667ss88+GTt2bLbYYosceeSRWbBgQe82\nEyZMyFVXXZUkmTZtWg455JAcddRRGT16dL75zW/229aaEvIBAAAa5KmnnsqBBx6Yd7/73Xn44Ydz\n6KGH5nvf+15KKbn55pvznve8J+eee24eeuihvO9978sBBxyQJUuWrHS7Sy+9dMDD2D/ykY9k1qxZ\nueWWWzJr1qzMmTMnn/jEJzqy7SabbJIf//jH2WabbbJo0aIsXLgwW221VUaMGJHPf/7zmT9/fn7x\ni1/kZz/7Wb7yla8kSX7yk5/kmmuuye9+97ssWLAgF198ccaMGdO7z1JK5s+fn3333TcTJ07MOeec\n02/7Z5xxRk499dRMmTIlixYtyjHHHJNaa0477bTcd999uf3223Pvvfdm2rRpy+2/r8suuyyHHnpo\nFixYkCOOOGJAn9NACPkAAAAN8stf/jJPP/10TjjhhAwfPjwHH3xw9txzz9Rac+655+Z973tf9txz\nz5RS8q53vSsbbLBBfvGLX/S73UAs2/fZZ5+dTTfdNC9+8Ytzyimn5Dvf+U7Htl3Z8Prdd989r33t\nazNs2LCMHz8+U6dOzc9//vMkyciRI7No0aLcfvvtWbp0aXbeeedstdVWvdvOmTMnkyZNymGHHTag\nkxO11uVq2H777bPvvvtm5MiRGTt2bE466aTetldm7733zgEHHJAk2XDDDVfb3kC5Jh8AAKBB5s6d\nm5e85CXLLRs/fnyS1nXk3/zmN/PFL36x97UlS5bkvvvuS6213+1W58EHH8zjjz+ePfbYo3dZrTVL\nly7t6LYruuOOO/LBD34wN954Yx5//PE8/fTTec1rXpMk2WeffXLcccflAx/4QGbPnp2DDjooZ511\nVnp6elJrzQ9/+MP09PTkfe973xq3myT3339/TjjhhFx77bVZtGhRli5dutxIgRWNGzfuebWzOnry\nAQAAGmTrrbfOnDlzlls2e/bsJMlLX/rSnHbaaXn44Yd7fx599NEcdthhq9wuaQ2Rf/zxx3ufz5s3\nr/fx2LFjs9FGG+W2227r3e8jjzyShQsXvuBt+7Oyywje//73Z5dddsmsWbOyYMGCfPKTn1zuZMHx\nxx+fGTNm5Lbbbssdd9yRz3zmM737OvbYY7P//vvnbW9723K1DrT9U089NcOHD8/MmTOzYMGCXHDB\nBas8UdGpux0I+QAAAA2y9957Z8SIEfnCF76QJUuW5NJLL80NN9zQG2T/6Z/+Kddff31qrXnsscfy\nwx/+MI8++mi/2y2z22675dZbb80tt9ySJ598crnrzYcNG5Zjjz02J554Yh588MEkreHvV1555Qve\ntj9bbrll5s+fv9zJgEcffTQ9PT3ZeOON89vf/jZf/epXe8P0jBkzct1112XJkiXZeOONs+GGG/bO\naL9s2P2XvvSl7Lzzzpk8efIqJ/7ru03ftjfZZJOMGjUqc+bM6T2BMNiEfAAAgLWmdPBnYEaOHJlL\nL7005513XjbffPNcdNFFOfjgg5Mke+yxR84999wcd9xxGTNmTHbcccecf/75/W530EEH9YbZnXba\nKR//+Mfzpje9KTvvvHMmTpy4XG/0pz/96eywww553etel9GjR+fNb35z7rjjjhe8bX9e/vKX5/DD\nD892222XMWPGZN68eTnrrLNy4YUXZtSoUZk6dWqmTJnSu/7ChQszderUjBkzJhMmTMjYsWPzoQ99\nqHXUSumt52tf+1rGjRuXAw88MIsXL+63/b7bJK0Z92+66aaMHj06kydPzsEHH9xvb/2K265Nxb0S\nm6mUUh1bAADojFLKenHf+WOOOSbjxo3LmWee2e1S1lv9/a61lz/nTIGefAAAAFZqfTiR0TRCPgAA\nACvVyWHlA/GpT30qPT09z/l5+9vfPijtv+IVr1hp+9/+9rcHpf3nw3D9hjJcHwAAOmd9Ga5P9xmu\nDwAAAOspIR8AAAAaQsgHAACAhhDyAQAAoCGEfAAAAGgIIR8AAID12tFHH52Pfexja7TNE088kcmT\nJ2fTTTfNYYcdttr1d91111x99dXPt8QBG9HxFgAAANYDg3E/ebfte9b06dNz1FFH5d57733B+yql\nrPHxu+SSS/LAAw/koYceyrBhq+8/nzlz5vMtb40I+QAAAGvLtCG6b9b4BMrs2bOz0047DSjgr84z\nzzyT4cOHv+D9JIbrAwAANM7cuXNz8MEH50/+5E+y3Xbb5Ytf/GKSZNq0aXnHO96Rd7/73Rk1alR2\n3XXX3Hjjjb3b3Xzzzdl9990zatSoTJkyJVOmTOkdxn7eeedl4sSJy7UzbNiw3HXXXUmSxYsX5+ST\nT8748eOz1VZb5f3vf3+efPLJF7ztyjz22GN561vfmrlz56anpyejRo3KvHnzcv3112evvfbKZptt\nlm222SbHH398lixZ0rvdSSedlC233DKjR4/Oq171qtx2223P2feiRYvyxje+MSeeeGK/7Z9++uk5\n88wz893vfjc9PT35xje+kbvuuiv77LNPxo4dmy222CJHHnlkFixY0LvNhAkTctVVV/Ueh0MOOSRH\nHXVURo8enW9+85v9trWmhHwAAIAGWbp0aSZPnpxXv/rVmTt3bn72s5/lnHPOyZVXXpkkufzyy3P4\n4YdnwYIFOeCAA3LcccclSZ566qkceOCBefe7352HH344hx56aC699NIBD2P/yEc+klmzZuWWW27J\nrFmzMmfOnHziE5/oyLabbLJJfvzjH2ebbbbJokWLsnDhwmy11VYZMWJEPv/5z2f+/Pn5xS9+kZ/9\n7Gf5yle+kiT5yU9+kmuuuSa/+93vsmDBglx88cUZM2ZM7z5LKZk/f3723XffTJw4Meecc06/7Z9x\nxhk59dRTM2XKlCxatCjHHHNMaq057bTTct999+X222/Pvffem2nTpi23/74uu+yyHHrooVmwYEGO\nOOKIAX1OAyHkAwAANMgNN9yQP/7xj/noRz+aESNG5GUve1ne+9735jvf+U5KKZk4cWLe8pa3pJSS\nI488MrfcckuS5Je//GWefvrpnHDCCRk+fHgOPvjg7LnnngNqs9aac889N2effXY23XTTvPjFL84p\np5yS73znOx3bdmXD63ffffe89rWvzbBhwzJ+/PhMnTo1P//5z5MkI0eOzKJFi3L77bdn6dKl2Xnn\nnbPVVlv1bjtnzpxMmjQphx122IBOTtRal6th++23z7777puRI0dm7NixOemkk3rbXpm99947Bxxw\nQJJkww03XG17A+WafAAAgAaZPXt25s6dm80226x32TPPPJO/+Iu/yPjx47Plllv2Lt94443z5JNP\nZunSpZk7d25e8pKXLLev8ePHD6jNBx98MI8//nj22GOP3mW11ixdurSj267ojjvuyAc/+MHceOON\nefzxx/P000/nNa95TZJkn332yXHHHZcPfOADmT17dg466KCcddZZ6enpSa01P/zhD9PT05P3ve99\na9xuktx///054YQTcu2112bRokVZunTpciMFVjRu3Ljn1c7q6MkHAABokG233TYve9nL8vDDD/f+\nLFy4MFdcccUqt9t6660zZ86c5ZbNnj279/Emm2ySxx9/vPf5vHnzeh+PHTs2G220UW677bbeNh95\n5JEsXLjwBW/bn5VdRvD+978/u+yyS2bNmpUFCxbkk5/85HInC44//vjMmDEjt912W+6444585jOf\n6d3Xsccem/333z9ve9vblqt1oO2feuqpGT58eGbOnJkFCxbkggsuWOWJik7djUHIBwAAaJDXvva1\n6enpyT/+4z/miSeeyDPPPJOZM2dmxowZq9xur732yogRI/KFL3whS5YsyaWXXpobbrih9/Xddtst\nt956a2655ZY8+eSTy11vPmzYsBx77LE58cQT8+CDDyZpDX9fNg/AC9m2P1tuuWXmz5+/3MmARx99\nND09Pdl4443z29/+Nl/96ld7w/SMGTNy3XXXZcmSJdl4442z4YYb9s5ov2zY/Ze+9KXsvPPOmTx5\n8ion/uu7Td+2N9lkk4waNSpz5szpPYEw2IR8AACAtWVaB38GaNiwYbniiivyq1/9Ktttt1222GKL\nTJ06tXem9xV7kJc9f9GLXpRLL7005513XjbffPNcdNFFOeigg3rD7E477ZSPf/zjedOb3pSdd945\nEydOXG5fn/70p7PDDjvkda97XUaPHp03v/nNueOOO17wtv15+ctfnsMPPzzbbbddxowZk3nz5uWs\ns87KhRdemFGjRmXq1KmZMmVK7/oLFy7M1KlTM2bMmEyYMCFjx47Nhz70od7PYFk9X/va1zJu3Lgc\neOCBWbx4cb/t990mac24f9NNN2X06NGZPHlyDj744H5761fcdm0qa3ovQIaGUkp1bAEAoDNKKWt8\nX/Wh6Jhjjsm4ceNy5plndruU9VZ/v2vt5c85U6AnHwAAgJVaH05kNI2QDwAAwEp1clj5QHzqU59K\nT0/Pc37e/va3D0r7r3jFK1ba/re//e1Baf/5MFy/oQzXBwCAzllfhuvTfYbrAwAAwHpKyAcAAICG\nEPIBAACgIYR8AAAAaAghHwAAABpCyAcAAFjP3X333Rk2bFiWLl3a7VLW2LRp03LUUUd1rf3vf//7\neelLX5qenp7ccsstq1z3W9/6Vvbff/+O1iPkAwAArAXL7infyZ913YQJE3LVVVetdr21eVKh25/L\nySefnK985StZtGhRdtttt1Wu+853vjM/+clPOlqPkA8AALCW1A7+DAX93dO9P2uybif38cwzzzzv\ntu+5557ssssuL7iGp59++gXvIxHyAQAAGufTn/50xo0bl1GjRuXlL395rrrqqtRa8w//8A/ZYYcd\nMnbs2Bx22GF5+OGHV7r9ggUL8p73vCfbbLNNxo0bl4997GPL9bqfe+652WWXXTJq1Ki84hWvyM03\n35yjjjoq99xzTyZPnpyenp6cddZZ/db3F3/xF0mSTTfdND09Pbnuuuty5513Zp999snYsWOzxRZb\n5Mgjj8yCBQtW+Z5WtGTJkhx++OE55JBDsmTJkn7bnzZtWg455JAcddRRGT16dL75zW/m97//fd7w\nhjdk1KhR2W+//XLcccet8jKAxYsXp6enJ88880x222237LjjjknS+xkv+2x+8IMf9G5z3nnnZeLE\nib3Phw0blq985SvZcccds/POO/fb1poQ8gEAABrkf/7nf/LlL385M2bMyMKFC3PllVdmwoQJ+cIX\nvpDLLrssV199de67775sttlm+cAHPrDSfRx99NF50YtelDvvvDM333xzrrzyynz9619Pklx88cU5\n44wzcsEFF2ThwoW57LLLsvnmm+eCCy7ItttumyuuuCKLFi3KySef3G+N11xzTZLWyYRFixblz/7s\nz5Ikp512Wu67777cfvvtuffeezNt2rRVvqe+nnzyyRx44IHZaKONcvHFF2fkyJGr/Jwuu+yyHHro\noVmwYEGOOOKIHHHEEdlzzz0zf/78fOxjH8v555+/yksBNthggzz66KNJkl//+tf53e9+lyTZYYcd\ncu2112bhwoU5/fTTc+SRR+b+++/vdz///u//nhtuuCG33XbbKusdKCEfAACgQYYPH57Fixfn1ltv\nzZIlS7Lttttmu+22yz//8z/n7/7u77LNNttk5MiROf3003PJJZc857r4+++/Pz/60Y/yuc99Lhtt\ntFG22GKLnHjiifnOd76TJPn617+eD3/4w9ljjz2SJNtvv3223XbbNapxZUPst99+++y7774ZOXJk\nxo4dm5NOOik///nPV/mektYlAgsXLsz++++fHXfcMf/6r/86oOv099577xxwwAFJkgceeCAzZszI\nmWeemZEjR2bixImZPHny87oU4JBDDslWW22VJHnHO96RHXfcMdddd12/659yyinZdNNNs8EGG6xx\nWyszYq3sBQAAgHXCDjvskHPOOSfTpk3Lrbfemv333z+f/exnc/fdd+ev/uqvMmzYs329I0aMeE4v\n8+zZs7NkyZJsvfXWvcuWLl3aG+T/8Ic/ZPvtt1/rdd9///054YQTcu2112bRokVZunRpxowZ0+97\nOvvss7P11lun1ppf/vKXefrpp3tPRAzEuHHjeh/PnTs3m222WTbaaKPeZePHj8+99967xu/j/PPP\nz+c+97ncfffdSZJHH3008+fP73f9l770pWvcxqroyQcAAGiYww8/PNdcc01mz56dUko+/OEPZ9tt\nt82Pf/zjPPzww70/jz/++HJhPmmFzg022CDz58/vXW/BggX5zW9+0/v6rFmzVtruQGe6X9l6p556\naoYPH56ZM2dmwYIFueCCC5YbZbCy97TMfvvtl4985CPZd99988ADDwyo/b41bL311r2fxzKzZ88e\n0Hvpa/bt5bJCAAAgAElEQVTs2Zk6dWq+/OUv56GHHsrDDz+cXXfddZUjAtb23QGEfAAAgAa54447\nctVVV2Xx4sXZYIMNsuGGG2bEiBH567/+65x66qm55557kiQPPvhgLrvssudsv/XWW2e//fbLBz/4\nwd4e9TvvvDNXX311kuS9731vzjrrrNx0002ptWbWrFm9+9xyyy1z5513rrbGLbbYIsOGDVtu3Ucf\nfTSbbLJJRo0alTlz5uQzn/nMKt/T8OHDl9vnhz70oRxxxBHZd999V9lznjz3coHx48fnNa95TU4/\n/fQsWbIk1157ba644oo1DuCPPfZYSikZO3Zsli5dmm984xuZOXPmGu3jhRLyAQAA1pLSwZ+BWrx4\ncU455ZRsscUW2XrrrfPHP/4xf//3f58TTjghBxxwQPbbb7+MGjUqe+21V66//vpna+8TaM8///w8\n9dRT2WWXXTJmzJgceuihmTdvXpLWNeennXZajjjiiIwaNSoHHXRQ7yz9p5xySv7u7/4um222Wc4+\n++x+a9x4441z2mmn5fWvf33GjBmT66+/PqeffnpuuummjB49OpMnT87BBx/cW1N/72lZ3cvW++hH\nP5oDDzwwb3rTm/LII4/02/6KPflJcuGFF+a6667LmDFj8olPfCLvete7BnRNft/97LLLLvnbv/3b\n7LXXXtlqq60yc+bM/Pmf/3m/7a7tXvwkKWvjnoKse0op1bEFAIDOWNP7wTP0nHHGGZk1a1YuuOCC\nrtbR3+9ae/lzzhLoyQcAAIAVDNWTOEI+AAAAa923vvWt9PT0POfnla985aC0/9a3vnWl7f/DP/zD\ngLZfNrT+wgsv7Or7WFOG6zeU4foAwNrQietFV8bfLQw1huszWNZ0uP6IQakKAIAhq9MxZnBOIwCs\nHwzXBwAAgIYQ8gEAAKAhDNcHAAB4HgZrzgpYE0I+AADAGjLpHusqw/UBAACgIYR8AAAAaAghfx1W\nSvnXUsr9pZTf9Fk2ppTy01LKHaWUK0spm3azRgAAANYdQv667RtJ3rLCso8k+WmtdackP2s/BwAA\nACF/XVZrvSbJwyssPiDJN9uPv5nkwEEtCgAAgHWWkD/0bFlrvb/9+P4kW3azGAAAANYdbqE3hNVa\nayml33t3TJs2rffxpEmTMmnSpEGoCgAAgLVt+vTpmT59+mrXK+7vuG4rpUxIcnmt9ZXt579NMqnW\nOq+UsnWS/6q1vnwl21XHFgB4oUop6fRfFCXuOQ6wpkopqbWWFZcbrj/0XJbk3e3H707ygy7WAgAA\nwDpET/46rJTy7SRvSDI2revvP57k35NclGTbJHcneUet9ZGVbKsnHwB4wfTkA6yb+uvJF/IbSsgH\nANYGIR9g3WS4PgAAADSckA8AAAANIeQDAABAQwj5AAAA0BAjul0ADDWlPGdui44wAREAALCmhHx4\nHgZjlmEAAIA1Zbg+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBD\nCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkA\nAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQ\nEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+\nAAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAA\nNISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQ\nDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQDwAA\nAA0h5AMAAEBDCPlDVCnllFLKraWU35RSLiylbNDtmgAAAOguIX8IKqVMSHJskt1rra9MMjzJlG7W\nBAAAQPeN6HYBPC8LkyxJsnEp5ZkkGyeZ092SAAAA6DY9+UNQrfWhJJ9Nck+SuUkeqbX+Z3erAgAA\noNv05A9BpZTtk5yYZEKSBUkuLqW8s9b6rb7rTZs2rffxpEmTMmnSpMErEgAAgLVm+vTpmT59+mrX\nK7XWzlfDWlVKOSzJm2ut720/PyrJ62qtH+izTnVsO6OUkk5/siWJ4wfAusD3HsC6qZSSWmtZcbnh\n+kPTb5O8rpSyUSmlJHlTktu6XBMAAABdJuQPQbXWW5Kcn2RGkl+3F3+texUBAACwLjBcv6EM1+8c\nwxYBWJ/43gNYNxmuDwAAAA0n5AMAAEBDCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQ\nEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+AAAANISQDwAAAA0h5AMAAEBDCPkAAADQEEI+\nAAAANISQDwAAAA0h5AMAAEBDjOh2AU1WStkjSV3Naktqrb8ZjHoAAABotlLr6jIoz1cpZVGSGatZ\n7WW11gkdaLs6tp1RSlntmZsX3EYSxw+AdYHvPYB1Uykltday4nI9+Z01o9b6xlWtUEr5r8EqBgAA\ngGbTk99QevI7R48GAOsT33sA66b+evJNvDcISil/Xkp5cfvxUaWUz5VSxne7LgAAAJpFyB8cX03y\nWClltyQfTDIryfndLQkAAICmEfIHx9PtsfMHJvlyrfXLSXq6XBMAAAANY+K9wbGolHJqkiOTTCyl\nDE8ysss1AQAA0DB68gfHYUkWJ/k/tdZ5SV6S5KzulgQAAEDTmF2/ocyu3zlmGQZgfeJ7D2Dd1N/s\n+obrD4JSyqNJ7/fji9Iaqv9orXVU96oCAACgaYT8QVBrffGyx6WUYUkOSPK67lUEAABAExmu3yWl\nlF/VWv+0g/s3XL9DDFsEYH3iew9g3WS4fheVUg7u83RYkj2SPNGlcgAAAGgoIX9wTM6z1+Q/neTu\nJP+7a9UAAADQSIbrN5Th+p1j2CIA6xPfewDrpv6G6w/rRjHri1LK1LWxDgAAAAyEnvwOKqXcleTk\ntE5Qr6i2l59Za92lA23rye8QPRoArE987wGsm0y81x1Xp3U9/qpcORiFAAAA0Hx68htKT37n6NEA\nYH3iew9g3eSafAAAAGg4IR8AAAAaQsgHAACAhhDyB0EpZatSyr+UUn7cfr5LKeU93a4LAACAZhHy\nB8d5ac2iv037+e+SnNS1agAAAGgkIX9wjK21fjfJM0lSa12S5OnulgQAAEDTCPmD49FSyubLnpRS\nXpdkQRfrAQAAoIFGdLuA9cTfJrk8yXallP9OskWSQ7pbEgAAAE1Taq3drmG9UEoZmWSnJCXJ/7SH\n7HeyverYdkYpJZ3+ZEsSxw+AdYHvPYB1UykltdbynOX+Qe28UsqIJG9PMiHPjp6otdazO9imkN8h\n/tgBYH3iew9g3dRfyDdcf3BcnuSJJL9JsrTLtQAAANBQQv7geEmt9VXdLgIAAIBmM7v+4LiylLJ/\nt4sAAACg2fTkD47/TvL9UsqwJMsm3Ku11lFdrAkAAICGMfHeICil3J3kgCQza62Dck2+ifc6xwRE\nAKxPfO8BrJv6m3jPcP3BcU+SWwcr4AMAALB+Mlx/cPw+yX+VUn6U5Kn2so7eQg8AAID1j5A/OH7f\n/nlR+6ckHR/5BgAAwHrGNfkN5Zr8znFtIgDrE997AOum/q7J15PfQaWUz9daTyilXL6Sl2ut9YBB\nLwoAAIDGEvI769/a//3sSl5zuhoAAIC1ynD9Diql3FxrfXWX2jZcv0MMWwRgfeJ7D2Dd5BZ6AAAA\n0HCG63fWFqWUD6Z1gnpFbqEHAADAWiXkd9bwJD3dLgIAAID1g2vyO8g1+c3k2kQA1ie+9wDWTa7J\nBwAAgIYT8jvrTZ3acSll01LKJaWU20spt5VSXteptgAAABgaXJPfQbXW+R3c/eeT/Eet9ZBSyogk\nm3SwLQAAAIYA1+QPQaWU0UlurrVut4p1XJPfIa5NBGB94nsPYN3kmvxmeVmSB0sp3yil3FRKObeU\nsnG3iwIAAKC7hPxBUEo5uJTyu1LKwlLKovbPwhewyxFJdk/ylVrr7kkeS/KRtVIsAAAAQ5Zr8gfH\nPyb5y1rr7Wtpf39I8oda6w3t55dkJSF/2rRpvY8nTZqUSZMmraXmAQAAGEzTp0/P9OnTV7uea/IH\nQSnl/9VaX7+W93l1kvfWWu8opUxLslGt9cN9XndNfoe4NhGA9YnvPYB1U3/X5Av5g6CU8vkkWyX5\nQZKn2otrrfXSF7DP3ZJ8PcmLktyZ5Jha64I+rwv5HeKPHQDWJ773ANZNQn4XlVLOaz9c7sOutR7T\nwTaF/A7xxw4A6xPfewDrJiF/PSPkd44/dgBYn/jeA1g3uYVeF5VSXlpK+X4p5cH2z/dKKeO6XRcA\nAADNIuQPjm8kuSzJNu2fy9vLAAAAYK0xXH8QlFJuqbXutrpla7lNw/U7xLBFANYnvvcA1k2G63fX\n/FLKUaWU4aWUEaWUI5P8sdtFAQAA0CxC/uD4P0nekWRekvuSHJqkYzPrAwAAsH4yXL+hDNfvHMMW\nAVif+N4DWDf1N1x/RDeKWV+UUj5ca/10KeWLK3m51lr/ZtCLAgAASCskDgYn8QaXkN9Zt7X/e2Oy\n3EnwssJzAACALhiMsToMJiG/g2qtl7cfPl5rvajva6WUd3ShJAAAABrMxHuD45QBLgMAAIDnTU9+\nB5VS3prkbUleUkr5Qp4dq9KTZEnXCgMAAKCRhPzOmpvW9fj/u/3fZdfiL0pyUhfrAgAAoIHcQm8Q\nlFJGJhmZZNta628HqU230OsQtxICYH3iew+aqzW7fuf/D/f/d2f0dws91+QPjrcmuTnJj5OklPLq\nUspl3S0JAACAphHyB8e0JH+W5OEkqbXenGS7bhYEAABA8wj5g2NJrfWRFZYt7UolAAAANJaJ9wbH\nraWUdyYZUUrZMcnfJPnvLtcEAABAw+jJHxzHJ3lFksVJvp1kYZITu1oRAAAAjWN2/YYyu37nmGUY\ngPWJ7z1oLrPrD239za5vuH4HlVIuX8XLtdZ6wKAVAwAA0AWtkwmd5UTCs4T8zvrsKl7zWwgAADTf\ntM7v34mEZwn5HVRrnb7scSllgyQvT2tW/f+ptT7VrboAAACaZDAuKxoqhPxBUEp5e5J/SnJXe9F2\npZT31Vr/o4tlAQAA0DBC/uA4O8kba62zkqSUsn2S/2j/AAAAwFrhFnqDY+GygN92V1q30QMAAIC1\nRk/+4LixlPIfSS5qPz80yYxSykFJUmu9tGuVAQAdYyIoAAabkD84NkzyQJI3tJ8/2F42uf1cyAeA\nxupkCB9KU0EBMBiE/EFQaz262zUAAADQfEL+ICilbJfk+CQT8uxnXmutB3StKAAAABpHyB8cP0jy\n9SSXJ1naXuYCOgAAANYqIX9wPFlr/UK3iwAAAKDZhPzB8cVSyrQkP0myeNnCWutNXasIAACAxhHy\nB8crkhyV5I15drh+2s8BAABgrRDyB8ehSV5Wa32q24UAAADQXMO6XcB64jdJNut2EQAAADSbnvzB\nsVmS35ZSbsiz1+S7hR4AAABrlZA/OE5v/3fZbfNK3EIPAACAtUzIHwS11umllK2S7JlWuL++1vpA\nl8sCAACgYVyTPwhKKe9Icl1aE/C9I8n1pZRDu1sVAAAATaMnf3B8NMmey3rvSylbJPlZkou7WhUA\nAACNIuQPjpLkwT7P57eXAQDAeqWUwfkzuFZTYLF+EvIHx4+T/KSUcmFa4f6wJD/qbkkAANAdnY7f\netNYnwn5g6DW+qFSysFJXt9e9M+11u93syYAAACaR8jvoFLKjkm2rLVeW2v9XpLvtZf/eSll+1rr\nnd2tEAAAgCYxu35nnZNk4UqWL2y/BgAAAGuNkN9ZW9Zaf73iwvayl3WhHgAAABpMyO+sTVfx2oaD\nVgUAAADrBSG/s2aUUqauuLCUcmySG7tQDwAAAA1m4r3OOjHJ90sp78yzoX6PJBsk+auuVQUAAEAj\nCfkdVGudV0rZO8kbk+ya1i1Br6i1XtXdygAAAGgiIb/Daq01yVXtH4DnKKV0vI3WP0UAADSdkA+w\nDuhkBO/8KQQAANYVJt4DAACAhhDyAQAAoCGEfAAAAGgIIR8AAAAaQsgHAACAhhDyAQAAoCGEfAAA\nAGgIIR8AAAAaQsgHAACAhhDyAQAAoCGEfAAAAGgIIR8AAAAaQsgHAACAhhDyh7BSyvBSys2llMu7\nXQsAAADdJ+QPbSckuS1J7XYhAAAAdJ+QP0SVUsYleVuSrycpXS4HAACAdYCQP3R9LsmHkiztdiEA\nAACsG0Z0uwDWXCnlL5M8UGu9uZQyqb/1pk2b1vt40qRJmTSp31UBAABYh02fPj3Tp09f7XqlVpdz\nDzWllE8lOSrJ00k2TDIqyfdqre/qs051bDujlNLxSRBKEsdv9UoZnCtVOn0sOv075fcJuqf171Rn\n/w8f6v9GJf6dWt/4nVp3dP7fqCQpybQONzFtUN7FOvc7VUpJrfU5fxAbrj8E1VpPrbW+tNb6siRT\nklzVN+DD+qV2+AcAAIYOIb8ZJBEAAABckz/U1Vp/nuTn3a4DAACA7tOTDwAAAA0h5AMAAEBDCPkA\nAADQEEI+AAAANISJ9wAAhrDWfa4BoEXIBwAYyqYN8f0DsFYZrg8AAAANIeQDAABAQwj5AAAA0BBC\nPgAAADSEkA8AAAANYXZ9AGiQwbqdWq11UNoBANaMkA8ADdPp+O2u7ACw7jJcHwAAABpCyAcAAICG\nEPIBAACgIYR8AAAAaAghHwAAABpCyAcAAICGEPIBAACgIYR8AAAAaIgR3S4A1qZSSrdLAAAA6Boh\nn+aZNsT3DwAA8DwZrg8AAAANIeQDAABAQxiuDwAAJDG/ETSBkA8AADxr2hDfP6znhHwGjTPDAAAA\nnSXkM8hqh/fvRAIA0Ew6TICBEPIBAGDI0GECrJrZ9QEAAKAhhHwAAABoCCEfAAAAGkLIBwAAgIYQ\n8gEAAKAhzK4PsBpuWQQAwFAh5AOszrQhvn8AANYbhusDAABAQwj5AAAA0BBCPgAAADSEkA8AAAAN\nYeI9AGgbrDsp1FoHpR0AYP0j5APAcjodwN2SEQDoHMP1AQAAoCGEfAAAAGgIIR8AAAAaQsgHAACA\nhhDyAQAAoCGEfAAAAGgIIR8AAAAaQsgHAACAhhDyAQAAoCGEfAAAAGgIIR8AAAAaQsgHAACAhhjR\n7QIAYH1TSul2CQBAQwn5ADDYpg3RfQMA6zzD9QEAAKAhhHwAAABoCCEfAAAAGkLIBwAAgIYQ8gEA\nAKAhhHwAAABoCCEfAAAAGkLIBwAAgIYQ8oegUspLSyn/VUq5tZQys5TyN92uCQAAgO4b0e0CeF6W\nJDmp1vqrUsqLk9xYSvlprfX2bhcGAABA9+jJH4JqrfNqrb9qP340ye1JtuluVQAAAHSbkD/ElVIm\nJHl1kuu6WwkAAADdZrj+ENYeqn9JkhPaPfrLmTZtWu/jSZMmZdKkSYNWGwAAAGvP9OnTM3369NWu\nJ+QPUaWUkUm+l+Tfaq0/WNk6fUM+AAAAQ9eKHbdnnHHGStczXH8IKqWUJP+S5LZa6zndrgcAAIB1\ng5A/NL0+yZFJ3lhKubn985ZuFwUAAEB3Ga4/BNVar40TNAAAAKxAUAQAAICGEPIBAACgIYR8AAAA\naAghHwAAABpCyAcAAICGEPIBAACgIYR8AAAAaAghHwAAABpCyAcAAICGEPIBAACgIYR8AAAAaAgh\nHwAAABpCyAcAAICGEPIBAACgIYR8AAAAaAghHwAAABpCyAcAAICGEPIBAACgIYR8AAAAaAghHwAA\nABpCyAcAAICGEPIBAACgIYR8AAAAaAghHwCA/7+9e4+rqsr/P/46Cn7TQK3GW+IMDJVy5wCKmjgS\neEsjr3grxUtTOaPVtxz1V823m5Vp3xnLbMqHl5hKNK2UJk2ddGQ0HwQexUlTM1C85K1QEZ3DZf3+\nYNxfEQ6SHkWO7+fjweMBZ6+192fDh7322nvttUVExEOoky8iIiIiIiLiIdTJFxEREREREfEQ6uSL\niIiIiIiIeAh18kVEREREREQ8hDr5IiIiIiIiIh5CnXwRERERERERD6FOvoiIiIiIiIiHUCdfRERE\nRERExEOoky8iIiIiIiLiIdTJFxEREREREfEQ6uSLiIiIiIiIeAh18kVEREREREQ8hDr5IiIiIiIi\nIh5CnXwRERERERERD6FOvoiIiIiIiIiHUCdfRERERERExEOoky8iIiIiIiLiIdTJFxEREREREfEQ\n6uSLiIiIiIiIeAh18kVEREREREQ8hDr5IiIiIiIiIh5CnXwRERERERERD6FOvoiIiIiIiIiHUCdf\nRERERERExEOoky8iIiIiIiLiIdTJFxEREREREfEQ6uSLiIiIiIiIeAh18kVEREREREQ8hDr5IiIi\nIiIiIh5CnXwRERERERERD6FOvoiIiIiIiIiHUCdfRERERERExEOoky8iIiIiIiLiIdTJFxERERER\nEfEQ6uSLiIiIiIiIeAh18kVEREREREQ8hDr5IiIiIiIiIh5CnXwRERERERERD6FOvoiIiIiIiIiH\nUCdfRERERERExEOoky8iIiIiIiLiIdTJFxEREREREfEQ6uTXUTabrZfNZvvWZrPtsdlsk2s7HhER\nEREREal96uTXQTabrT4wG+gFBAPDbDZbUO1GJSIiIiIiIrVNnfy6qQPwnTEmzxhTDKQB99dyTCIi\nIiIiIlLL1Mmvm1oD+Rf8fOA/n4mIiIiIiMgNzGaMqe0Y5Gey2WwDgV7GmIf+8/MDQKwxZsIFZfSH\nFRERERER8WDGGNvFn3nVRiByxQ4CbS74uQ3ld/Mr0AUccSebzaacErdSTok7KZ/E3ZRT4m7KKXE3\nm61S/x7QcP26Kgu402az+dtstgbAEGBFLcdU56xatYp27dpx5513Mn369NoOR+q4MWPG0KJFC8LC\nwmo7FPEQ+fn5xMfHExISQmhoKG+88UZthyR12Llz54iNjSUyMpLg4GCmTp1a2yGJhygtLcVut3Pf\nfffVdijiAfz9/QkPD8dut9OhQ4faDqfO0nD9Ospms/UG/gzUB+YZY165aLnR39a10tJS2rZty9q1\na2ndujXt27dn0aJFBAXpJQWu6Opz9TIyMvDx8WHkyJFs3769tsOpE5RT1fvhhx/44YcfiIyMpLCw\nkOjoaD799FMdp1xQPl1aUVERjRo1oqSkhC5dujBz5ky6dOlS22Fdt5RTNfO///u/ZGdnc/r0aVas\n0D2n6iinLi0gIIDs7GxuvfXW2g6lTvhPTlW6na87+XWUMWalMaatMeaOizv4cmmZmZnccccd+Pv7\n4+3tzdChQ1m+fHlthyV1WFxcHLfccktthyEepGXLlkRGRgLg4+NDUFAQhw4dquWopC5r1KgRAE6n\nk9LSUp1EyxU7cOAAn3/+OePGjVPnVdxGuXTl1MmXG9LBgwdp0+b/pjXw8/Pj4MGDtRiRiIhreXl5\nOBwOYmNjazsUqcPKysqIjIykRYsWxMfHExwcXNshSR33xBNPMGPGDOrVU5dC3MNms5GYmEhMTAxz\n586t7XDqLP1Hyg3J1SQVIiLXm8LCQgYNGsSsWbPw8fGp7XCkDqtXrx5bt27lwIEDbNiwgfXr19d2\nSFKHffbZZzRv3hy73a47r+I2GzduxOFwsHLlSt566y0yMjJqO6Q6SZ18uSG1bt2a/Px86+f8/Hz8\n/PxqMSIRkcqKi4sZOHAgDzzwAP369avtcMRDNGnShD59+pCVlVXboUgdtmnTJlasWEFAQADDhg3j\nyy+/ZOTIkbUdltRxrVq1AqBZs2b079+fzMzMWo6oblInX25IMTEx7Nmzh7y8PJxOJ4sXLyYpKam2\nwxIRsRhjGDt2LMHBwTz++OO1HY7UccePH6egoACAs2fPsmbNGux2ey1HJXXZyy+/TH5+Prm5uaSl\npXHPPfeQmppa22FJHVZUVMTp06cBOHPmDKtXr9Zbiy6TOvlyQ/Ly8mL27Nn07NmT4OBghgwZohmr\n5YoMGzaMzp07s3v3btq0acOCBQtqOySp4zZu3Mj777/PunXrsNvt2O12Vq1aVdthSR11+PBh7rnn\nHiIjI4mNjeW+++4jISGhtsMSD6JHIeVKHTlyhLi4OOs41bdvX3r06FHbYdVJeoWeh9Ir9MTd9NoX\ncTfllLiT8kncTTkl7qacEnfTK/REREREREREPFy1d/JtNpsuNYmIiIiIiIhch6q6k+9Vg0pXJxq5\nqjQcSNxNOSXuppwSd1I+ibspp8TdlFPibq7mwrhqw/Wfe+45Xn/99au1erfbt28fixYtuuz6P+fd\nxZMmTSI0NJTJkye7LJOens706dMvOx6pO86dO0dsbCyRkZEEBwczderUSmW+/fZbOnXqxE033VTh\n/6q6utu2baNTp06Eh4eTlJRkzVYqN66a5NpPP/1E//79iYiIIDY2lm+++cZaVlBQwKBBgwgKCiI4\nOJjNmzdfy/ClluTn5xMfH09ISAihoaG88cYblcrMnDnTmhwwLCwMLy8vCgoK2LVrl/W53W6nSZMm\nVv3nnnsOPz8/TSp4g/L39yc8PBy73U6HDh0qLXfV7gG88sorhISEEBYWxvDhw/n3v/8NwEcffURI\nSAj169dny5Yt12Q/5PpwJedSAKtWraJdu3bceeedFc6/lVM3tksdp1y1feA6p65Z22eMcflVvvjy\nPPfcc2bmzJmXXf9aW7dunenbt+9l1/fx8alx2SZNmpiysrLL2k5JSUmNyl3J306uvTNnzhhjjCku\nLjaxsbEmIyOjwvKjR4+ar7/+2jz99NOV/q8urvvPf/7TGGNMTEyM2bBhgzHGmPnz55tnn332imJU\nTkQUgkwAACAASURBVHmGS+XaU089ZV544QVjjDHffvutSUhIsJaNHDnSzJs3z6pfUFBwRbEop+qG\nw4cPG4fDYYwx5vTp0+auu+4yO3bscFk+PT29Qt6cV1paalq2bGn2799vjCk/T3j99dfdFqfyqW7x\n9/c3J06ccLncVbuXm5trAgICzLlz54wxxiQnJ5uFCxcaY4zZuXOn2bVrl+nWrZvJzs6+4hiVU3XL\n5Z5LlZSUmMDAQJObm2ucTqeJiIiwjnHKqRvbpY5TF7qw7asup65S21epH+/WO/nTpk2jbdu2xMXF\nsWvXLgD27t1L7969iYmJoWvXrtbnubm51l3GZ555Bl9fXwDWr1/PfffdZ63z97//Pe+99x4A2dnZ\ndOvWjZiYGHr16sUPP/wAQLdu3cjOzgbK3wMbEBAAQGlpKZMmTaJDhw5ERETw7rvvuox9ypQpZGRk\nYLfbmTVrFvv27aNr165ER0cTHR3NV199BZS/gqZr167WFZuNGzdWWM/x48fp3LkzK1eurHI7SUlJ\nFBYWEhUVxZIlS/jss8/o2LEjUVFRdO/enaNHjwKwcOFCJkyYAEBKSgqPPPIIHTt2rPbuv9RdjRo1\nAsDpdFJaWsqtt95aYXmzZs2IiYnB29v7knVvueUWAPbs2UNcXBwAiYmJLFu27GrugtQRl8q1nTt3\nEh8fD0Dbtm3Jy8vj2LFjnDx5koyMDMaMGQOUv4aySZMm1zZ4qRUtW7YkMjISKB+1FhQUxKFDh1yW\n//DDDxk2bFilz9euXUtgYCBt2rSxPjMatnpDq+7v76rda9y4Md7e3hQVFVFSUkJRURGtW7cGoF27\ndtx1111XNWa5fl3uuVRmZiZ33HEH/v7+eHt7M3ToUJYvXw4op6Tm7dSFbV91OfVz1nkl3NbJz87O\nZvHixWzbto3PP/+cr7/+GoCHH36YN998k6ysLGbMmMH48eMBeOyxx/jd735HTk4Ot99+u8v12mw2\nbDYbxcXFTJgwgWXLlpGVlcXo0aN5+umnK5S52Lx582jatCmZmZlkZmYyd+5c8vLyqtzO9OnTiYuL\nw+Fw8Nhjj9G8eXPWrFlDdnY2aWlpTJw4ESj/A/bq1QuHw8G2bduIiIiw1nH06FH69u3Liy++SO/e\nvavczooVK2jYsCEOh4Pk5GS6dOnC5s2b2bJlC0OGDOG1116z9ulChw4d4quvvmLmzJkuf1dSd5WV\nlREZGUmLFi2Ij48nODj4iuuGhIRYB5SPPvqI/Pz8qxK71C2XyrWIiAg+/vhjoLyR2rdvHwcOHCA3\nN5dmzZoxevRooqKieOihhygqKqqNXZBalJeXh8PhIDY2tsrlRUVFfPHFFwwcOLDSsrS0NIYPH17h\nszfffJOIiAjGjh1rDXGUG4PNZiMxMZGYmBjmzp1b43q33norTz75JL/85S+5/fbbadq0KYmJiVcx\nUqkrLvdc6uDBgxUuPvr5+XHw4MGrFabUITU9Tl3c9l0qp65F2+e2Tn5GRgYDBgzgpptuwtfXl6Sk\nJM6dO8emTZsYPHgwdrudRx55xLr7vmnTJutqxwMPPFDtuo0x7Nq1i2+++YbExETsdjvTpk275D/g\n6tWrSU1NxW6307FjR3788Ue+++47l9u4kNPpZNy4cYSHh5OcnMzOnTsB6NChAwsWLOD5559n+/bt\n1rP4TqeThIQEZsyYQUJCwqV/Yf+Rn59Pjx49CA8PZ+bMmezYsaNSPDabjcGDB7ucWEHqvnr16rF1\n61YOHDjAhg0bWL9+/RXXnT9/PnPmzCEmJobCwkIaNGhwdYKXOuVSuTZlyhQKCgqw2+3Mnj0bu91O\n/fr1KSkpYcuWLYwfP54tW7Zw88038+qrr9bOTkitKCwsZNCgQcyaNcvlPDTp6el06dKFpk2bVvjc\n6XSSnp7O4MGDrc8effRRcnNz2bp1K61ateLJJ5+8qvHL9WXjxo04HA5WrlzJW2+9RUZGRo3q7d27\nlz//+c/k5eVx6NAhCgsL+eCDD65ytFIXXO65lM6vxZWaHqcubvuqy6lr1fa5rZNf1WyRZWVlNG3a\nFIfDYX1dOIlTVby8vCgrK7N+PnfunPV9SEiItZ6cnBxrooIL61xYHmD27NlWnb1799b4au+f/vQn\nWrVqRU5ODllZWdakLnFxcWRkZNC6dWtSUlL461//CoC3tzcxMTE/e/KECRMmMHHiRHJycnjnnXc4\ne/ZsleXOD0ESz9akSRP69OlDVlbWFddt27YtX3zxBVlZWQwdOpTAwEB3hyt1mKtc8/X1Zf78+Tgc\nDlJTUzl27Bi//vWv8fPzw8/Pj/bt2wMwaNAgTUJ0AykuLmbgwIE88MAD9OvXz2W5tLS0Kofqr1y5\nkujoaJo1a2Z91rx5c2sk3rhx48jMzLwqscv1qVWrVkD5EOr+/fvX+O+flZVF586due222/Dy8mLA\ngAFs2rTpaoYqdczPPZdq3bp1hdGO+fn5+Pn5Xa3wpA6p6XHq4ravupy6Vm2f2zr5Xbt25dNPP+Xc\nuXOcPn2a9PR0GjVqREBAAEuXLgXK707n5OQAcPfdd5OWlgZQ4Qrsr371K3bs2IHT6aSgoIC///3v\n2Gw22rZty7Fjx6zZnIuLi6273v7+/tY/8vltAfTs2ZM5c+ZQUlICwO7du10OL23cuHGF2cdPnTpF\ny5YtAUhNTaW0tBSA/fv306xZM8aNG8fYsWNxOBxA+UWO+fPn8+2331pD7mvi1KlT1uMKCxcurHE9\n8RzHjx+3huqcPXuWNWvWYLfbqyx78YW06uoeO3YMKL/Y9tJLL/Hoo49erV2QOqImuXby5EmcTicA\nc+fO5Te/+Q0+Pj60bNmSNm3asHv3bqD8+eqQkJBruwNSK4wxjB07luDgYB5//HGX5U6ePMmGDRu4\n//77Ky1btGhRpc7/4cOHre8/+eQTwsLC3Be0XNeKioqsc64zZ86wevVql3//i9u9du3asXnzZs6e\nPYsxhrVr11Y5LFvzPdxYruRcKiYmhj179pCXl4fT6WTx4sUkJSVdsp54tpoep6pq+6rLqWvV9nm5\na0V2u50hQ4YQERFB8+bN6dChAzabjQ8++IBHH32Ul156ieLiYoYNG0Z4eDizZs1i+PDhTJ8+vcIv\npU2bNiQnJxMaGkpAQABRUVFA+Z3ypUuXMnHiRE6ePElJSQlPPPEEwcHBPPXUUyQnJ/Puu+/Sp08f\na4jEuHHjyMvLIyoqCmMMzZs355NPPqky/vDwcOrXr09kZCSjR49m/PjxDBw4kNTUVHr16mUNTVy3\nbh0zZ87E29sbX19fUlNTgf+bF2DRokUkJSXRuHFjHnnkkSq3deEQjueee47Bgwdzyy23cM8997Bv\n374K66uqjniWw4cPM2rUKMrKyigrK+PBBx8kISGBd955Byif1+KHH36gffv2nDp1inr16jFr1ix2\n7NjBoUOHSElJqVQXyk+q33rrLQAGDhxISkpKbe2iXCdqkms7duwgJSUFm81GaGgo8+bNs+q/+eab\njBgxAqfTSWBgIAsWLKitXZFraOPGjbz//vvWa4QAXn75Zfbv3w+U5w3Ap59+Ss+ePWnYsGGF+mfO\nnGHt2rWVnmecPHkyW7duxWazERAQYOWheL4jR47Qv39/AEpKShgxYgQ9evSoUbsXERHByJEjiYmJ\noV69ekRFRfHb3/4WKD9hnjhxIsePH6dPnz7Y7XaXEyGLZ7mScykfHx9mz55Nz549KS0tZezYsQQF\nBQHKqRtZTY5TUHXb5+Xl5TKnrlXbZ6vuqpTNZjPX6qqVr6+v3uPtRlU9PiFyJZRT4m7KKXEn5ZO4\nm3JK3E05Je72n5yqdDfYra/QuxK6Uy0iIiIiIiJyZS55J/8axiIiIiIiIiIiNVTVnfxLPpOvISV1\nk4YDibspp8TdlFPiTsoncTfllLibckrczdVo+OtmuH5t27dvH4sWLbrs+q7eGVyVSZMmERoayuTJ\nk12WSU9PZ/r06Zcdj9Qd586dIzY2lsjISIKDg5k6dWqlMh988AERERGEh4dz9913W2+pAHjllVcI\nCQkhLCyM4cOHW6973LZtG506dSI8PJykpCTNeXGDyM/PJz4+npCQEEJDQ3njjTcqlfnpp5/o378/\nERERxMbGWq82ra6u8kl+jprk4Xlff/01Xl5efPzxx9cwQqlNNWn3Zs6cid1ux263ExYWhpeXlzV7\nekFBAYMGDSIoKIjg4GDrzUtQPkFoUFDQJc+zxLNc6bnUqlWraNeuHXfeeWeF8+9nn32WiIgIIiMj\nSUhIqPBaNPF8/v7+1qSzHTp0qLR8+fLlREREYLfbiY6O5ssvvwSqz8dJkyYRFBREREQEAwYM4OTJ\nk1cneGOMy6/yxTeGdevWmb59+152fR8fnxqXbdKkiSkrK7us7ZSUlNSo3I30t/MEZ86cMcYYU1xc\nbGJjY01GRkaF5Zs2bTIFBQXGGGNWrlxpYmNjjTHG5ObmmoCAAHPu3DljjDHJyclm4cKFxhhjYmJi\nzIYNG4wxxsyfP988++yzVxSjcqpuOHz4sHE4HMYYY06fPm3uuusus2PHjgplnnrqKfPCCy8YY4z5\n9ttvTUJCgsu6O3fuNMa4P5+MUU55sprkoTHlbVp8fLzp06ePWbp06RVtU/lUt1yq3btQenq6dZwy\nxpiRI0eaefPmWfXPt49ffvmlSUxMNE6n0xhjzNGjR68oRuVU3XK551IlJSUmMDDQ5ObmGqfTaSIi\nIqzj1alTp6z6b7zxhhk7duwVxaicqlv8/f3NiRMnXC4vLCy0vs/JyTGBgYHWz67ycfXq1aa0tNQY\nY8zkyZPN5MmTryjG/+RUpX68W+/kv//++8TGxmK323nkkUcoLS3Fx8eHZ555hsjISDp16sTRo0cB\nyM3Nte4KPfPMM/j6+gKwfv167rvvPmudv//973nvvfcAyM7Oplu3bsTExNCrVy9++OEHALp160Z2\ndjZQ/p7MgIAAAEpLS5k0aRIdOnQgIiKCd99912XsU6ZMISMjA7vdzqxZs9i3bx9du3YlOjqa6Oho\nvvrqK6D8FR1du3a1rixv3LixwnqOHz9O586dXb5eIykpicLCQqKioliyZAmfffYZHTt2JCoqiu7d\nu1u/n4ULFzJhwgQAUlJSeOSRR+jYsaOuSnuoRo0aAeB0OiktLeXWW2+tsLxTp040adIEgNjYWA4c\nOABA48aN8fb2pqioiJKSEoqKimjdujUAe/bsIS4uDoDExESWLVt2rXZHalHLli2JjIwEykcYBQUF\ncejQoQpldu7cSXx8PABt27YlLy+PY8eOVVn34MGDgPJJfp6a5CGU33UdNGgQzZo1u9YhSi27VLt3\noQ8//JBhw4YB5e+kzsjIYMyYMUD5q6rOt49vv/02U6dOxdvbG0B5dYO53HOpzMxM7rjjDvz9/fH2\n9mbo0KEsX74cwOqfABQWFvKLX/ziWuyKXEdMNY9X3Hzzzdb3F+eHq3zs3r079eqVd8EvzEN3c1sn\nf+fOnSxZsoRNmzbhcDioX78+H3zwAUVFRXTq1ImtW7fStWtX6z25jz32GL/73e/Iycnh9ttvd7ne\n8++LLy4uZsKECSxbtoysrCxGjx7N008/XaHMxebNm0fTpk3JzMwkMzOTuXPnkpeXV+V2pk+fTlxc\nHA6Hg8cee4zmzZuzZs0asrOzSUtLY+LEiUB5Q9OrVy8cDgfbtm0jIiLCWsfRo0fp27cvL774Ir17\n965yOytWrKBhw4Y4HA6Sk5Pp0qULmzdvZsuWLQwZMoTXXnvN2qcLHTp0iK+++oqZM2e6/F1J3VVW\nVkZkZCQtWrQgPj6e4OBgl2XnzZvHvffeC8Ctt97Kk08+yS9/+Utuv/12mjZtSmJiIgAhISFWI/XR\nRx9piNkNKC8vD4fDQWxsbIXPIyIirKHRmZmZ7Nu3r1Ijc3Fd5ZNcLld5ePDgQZYvX86jjz4K6C07\nN5qatntFRUV88cUXDBw4ECi/SdSsWTNGjx5NVFQUDz30EEVFRUD5xcgNGzbQsWNHunXrRlZW1jXb\nH6l9l3sudfDgQdq0aWMt8/Pzsy5wAzz99NP88pe/5L333mPKlClXbwfkumOz2UhMTCQmJsbqw17s\n008/JSgoiN69e1d4NK0m+Th//nwrD93NbZ38v//972RnZxMTE4PdbufLL78kNzeXBg0a0KdPHwCi\no6OtTvamTZusq7IPPPBAtes2xrBr1y6++eYbEhMTsdvtTJs2rcI/YFVWr15Namoqdrudjh078uOP\nP/Ldd9+53MaFnE4n48aNIzw8nOTkZHbu3AlAhw4dWLBgAc8//zzbt2+3nsV3Op0kJCQwY8YMEhIS\nqv9lXSA/P58ePXoQHh7OzJkz2bFjR6V4bDYbgwcP1gmQB6tXrx5bt27lwIEDbNiwgfXr11dZbt26\ndcyfP996Xmzv3r38+c9/Ji8vj0OHDlFYWMgHH3wAlB845syZQ0xMDIWFhTRo0OBa7Y5cBwoLCxk0\naBCzZs2qNGfIlClTKCgowG63M3v2bOx2O/Xr16+2rvJJLkd1efj444/z6quvWhNRVXe3RDxPTdu9\n9PR0unTpQtOmTQEoKSlhy5YtjB8/ni1btnDzzTfz6quvWst++uknNm/ezIwZM0hOTr5WuyPXgcs9\nl7rU+fW0adPYv38/KSkpPPHEE+4OW65jGzduxOFwsHLlSt566y0yMjIqlenXrx87d+4kPT2dBx98\n0Pr8Uvk4bdo0GjRowPDhw69K7G4drj9q1CgcDgcOh4OdO3fyP//zP9aQKSjf2ZKSkmrX4eXlRVlZ\nmfXzuXPnrO9DQkKs9efk5LBq1apKdS4sDzB79myrzt69e627nJfypz/9iVatWpGTk0NWVpY1mVlc\nXBwZGRm0bt2alJQU/vrXvwLg7e1NTEyMFVNNTZgwgYkTJ5KTk8M777zD2bNnqyx3fsiHeLYmTZrQ\np0+fKu8+5OTk8NBDD7FixQpuueUWALKysujcuTO33XYbXl5eDBgwgE2bNgHlw7C/+OILsrKyGDp0\nKIGBgdd0X6T2FBcXM3DgQB544AH69etXabmvry/z58/H4XCQmprKsWPH+PWvf11tXeWT/FyXysPs\n7GyGDh1KQEAAy5YtY/z48axYsaIWIpXaVF27B5CWlmbdFILyu6x+fn60b98egIEDB7JlyxZr2YAB\nAwBo37499erV48SJE1d5D+R683PPpVq3bl1hdFp+fj5+fn6V6g4fPpyvv/766gUu151WrVoB5Y/+\n9O/fn8zMTJdl4+LiKCkpqXTMqSofFy5cyOeff27dmLsa3NbJT0hIYOnSpRw7dgyAH3/8kX379rks\nf/fdd5OWlgZQYQd/9atfsWPHDpxOJwUFBfz973/HZrPRtm1bjh07Zs2gWlxcbN319vf3t35xS5cu\ntdbVs2dP5syZY11Y2L17tzWk62KNGzeuMFv0qVOnaNmyJQCpqamUlpYCsH//fpo1a8a4ceMYO3Ys\nDocDKL8KOH/+fL799ltryH1NnDp1ynpcYeHChTWuJ57j+PHj1ozBZ8+eZc2aNdjt9gpl9u/fz4AB\nA3j//fe54447rM/btWvH5s2bOXv2LMYY1q5daw0HOv+/WFZWxksvvWQNiRXPZoxh7NixBAcH8/jj\nj1dZ5uTJkzidTgDmzp3Lb37zG3x8fKqtq3ySn6Mmefj999+Tm5tLbm4ugwYN4u233yYpKekaRyq1\noSbtHpQfqzZs2MD9999vfdayZUvatGnD7t27gfKRpCEhIUD5HbXzs1vv3r0bp9PJbbfddrV3R64D\nV3IuFRMTw549e8jLy8PpdLJ48WLrWLRnzx6r3PLly6vMU/FMRUVFVt/wzJkzrF69mrCwsApl9u7d\na41CO3+x8bbbbqs2H1etWsWMGTNYvnw5N91001WL38tdKwoKCuKll16iR48elJWV0aBBA2bPnl1h\nCMyFz87PmjWL4cOHM3369AoH7zZt2pCcnExoaCgBAQFERUUB5XfKly5dysSJEzl58iQlJSU88cQT\nBAcH89RTT5GcnMy7775Lnz59rG2MGzeOvLw8oqKiMMbQvHlzPvnkkyrjDw8Pp379+kRGRjJ69GjG\njx/PwIEDSU1NpVevXtYww3Xr1jFz5ky8vb3x9fUlNTW1wr4tWrSIpKQkGjduzCOPPFLlti78nTz3\n3HMMHjyYW265hXvuuce6MHLxPAMaqu+5Dh8+zKhRoygrK6OsrIwHH3yQhIQE3nnnHQAefvhhXnjh\nBX766SerY+Xt7U1mZiYRERGMHDmSmJgY6tWrR1RUFL/97W8BWLRoEW+99RZQfqcjJSWlVvZPrq2N\nGzfy/vvvW698AXj55ZfZv38/UJ5PO3bsICUlBZvNRmhoKPPmzXNZ95VXXqFXr17KJ/lZapKHcuOq\nSbsH5c+69uzZk4YNG1ao/+abbzJixAicTieBgYEsWLAAgDFjxjBmzBjCwsJo0KCBdY4mnu9KzqW8\nvLyYPXs2PXv2pLS0lLFjxxIUFATA1KlT2bVrF/Xr1ycwMJC333671vZRrq0jR47Qv39/oPxRoBEj\nRtCjR48KObVs2TJSU1Px9vbGx8fHuoHtKh+hfBS30+mke/fuQPmEkHPmzHF7/LbqnoGz2WzmWj0j\n5+vrq/cuu9H5ZxxF3EU5Je6mnBJ3Uj6JuymnxN2UU+Ju/8mpSneD3fpM/pXQnWoRERERERGRK3PJ\nO/nXMBYRERERERERqaGq7uRf8pl8DSmpmzQcSNxNOSXuppwSd1I+ibspp8TdlFPibq5Gw9fKcP2U\nlBSWLVv2s+vt27ePRYsWVVtm27ZtrFy58rLiysvLqzRr4tXy0UcfERwcbE3CUJVDhw4xePDgaxKP\nXJ9mzZpFWFgYoaGhzJo1q9LymTNnYrfbsdvthIWF4eXlZc3mWVBQwKBBgwgKCiI4ONh6M4XcGEpL\nS7Hb7dx3332Vlq1fv54mTZpYufPSSy9Zy8aMGUOLFi0qHQsnTZpEUFAQERERDBgwgJMnT171fZDr\n27lz54iNjSUyMpLg4GCmTp1aqUx1uaZjlOer6njy448/0r17d+666y569OhhtVkXqi63PvroI0JC\nQqhfv741m/X59cbHx+Pr68uECROu7o7Jdau6ts/VOdOuXbusz+12O02aNOGNN94AYMiQIdbnAQEB\nml3/BuPv729NINuhQ4dKy5cvX05ERAR2u53o6Gjr7R5QPot+u3btuPPOO5k+fXqFem+++SZBQUGE\nhoYyefLkqxO8McblV/li90tJSTHLli372fXWrVtn+vbtW22ZBQsWmN///veXFVdubq4JDQ392fWK\ni4t/dp2ePXuajRs3/ux6Nd3e1frbybWzfft2Exoaas6ePWtKSkpMYmKi+e6771yWT09PNwkJCdbP\nI0eONPPmzTPGlOdMQUHBFcWjnKpbXn/9dTN8+HBz3333VVq2bt26Kj83xpgNGzaYLVu2VDoWrl69\n2pSWlhpjjJk8ebKZPHnyFceonKr7zpw5Y4wpP8bExsaajIyMCsuryzUdozxfVceTSZMmmenTpxtj\njHn11VddHktc5dbOnTvNrl27TLdu3Ux2dnaF8v/85z/NX/7yl8s+D7yYcqruqa7tu9DF50znlZaW\nmpYtW5r9+/dXWvbkk0+aF1988YriU07VLf7+/ubEiRMulxcWFlrf5+TkmMDAQGOMMSUlJSYwMNDk\n5uYap9NpIiIizI4dO4wxxnz55ZcmMTHROJ1OY4wxR48evaIY/5NTlfrxbruTf+bMGfr06UNkZCRh\nYWEsWbKE7OxsunXrRkxMDL169eKHH36ocHEBcFnmu+++IzExkcjISGJiYvj++++ZMmUKGRkZ2O32\nKu9qOp1O/vjHP7J48WLsdjtLlizh66+/pnPnzkRFRXH33Xdb71X95ptviI2NxW63ExERwd69eyus\n6/vvvycqKors7Owq93fhwoUkJSWRkJBA9+7dOXfuHEOHDiU4OJgBAwbQsWNHl3VfeOEFNm7cyJgx\nY/jDH/7Avn376Nq1K9HR0URHR/PVV18BFUcWXLw98XzffvstsbGx3HTTTdSvX5/f/OY3fPzxxy7L\nf/jhhwwbNgwof7dwRkYGY8aMAcDLy4smTZpck7il9h04cIDPP/+ccePGuRwW6OrzuLg4brnllkqf\nd+/enXr1ypuM2NhYDhw44L6Apc5q1KgRUN7+lpaWcuutt1YqU1Wu6Rh1Y6jqeLJixQpGjRoFwKhR\no/j000+rrOsqt9q1a8ddd91VZfm7776b//qv/3LnLkgdUpO277wLz5kutHbtWgIDA2nTpk2Fz40x\nLFmypMo64tmqy6Wbb77Z+r6wsJBf/OIXAGRmZnLHHXfg7++Pt7c3Q4cOZfny5QC8/fbbTJ06FW9v\nbwCaNWt2VeJ2Wyd/1apVtG7dmq1bt7J9+3Z69erFxIkTWbZsGVlZWYwePZqnn37aKm+z2SguLmbC\nhAlVlhkxYgQTJkxg69atbNq0iVatWjF9+nTi4uJwOBw89thjlWJo0KABL774IkOHDsXhcJCcnEy7\ndu3IyMhgy5YtPP/88/y///f/APjLX/7CY489hsPhIDs7m9atW1vr2bVrF4MGDeK9994jOjra5T47\nHA6WLVvGunXrmDNnDj4+PuzYsYPnn3+e7Oxsl89I/PGPfyQmJoYPP/yQ1157jebNm7NmzRqys7NJ\nS0tj4sSJl9yeeL7Q0FAyMjL48ccfKSoq4m9/+5vLjlVRURFffPEFAwcOBCA3N5dmzZoxevRooqKi\neOihhygqKrqW4UsteuKJJ5gxY4bVKb+YzWZj06ZNREREcO+997Jjx46ftf758+dz7733uiNUqePK\nysqIjIykRYsWxMfHExwcXGG5q1zTMerGdeTIEVq0aAFAixYtOHLkSJXlLpVbruhtTTeuS7V95118\nznShtLQ0hg8fXunzjIwMWrRoQWBgoNvileufzWYjMTGRmJgY5s6dW2WZTz/9lKCgIHr37m09oFXD\nuwAAB5dJREFU5nHw4MEKF4r8/Pw4ePAgAHv27GHDhg107NiRbt26kZWVdVVid1snPzw8nDVr1jBl\nyhT++c9/sn//fv71r3+RmJiI3W5n2rRp1s5B+VWRXbt28c0331QqU1hYyKFDh7j//vuB8s57w4YN\nazRRhfm/Rw2A/3vmLywsjP/+7/+2TjA6d+7Myy+/zGuvvUZeXh433XQTAEePHqVfv358+OGH1T6f\nb7PZ6N69O02bNgXK//kfeOABAMLCwggPD69RrFB+lXrcuHGEh4eTnJzs8oS7R48e1vbE87Vr147J\nkyfTo0cPevfujd1ud9lwpaen06VLFys/SkpK2LJlC+PHj2fLli3cfPPNvPrqq9cyfKkln332Gc2b\nN8dut7s8ZkZFRZGfn8+2bduYMGEC/fr1q/H6p02bRoMGDao8CZIbT7169di6dSsHDhxgw4YNrF+/\nvsJyV7mmY5RA+bmUy0mjLpFbIheqSdt33sXnTOc5nU7S09OrnA9r0aJFavduQBs3bsThcLBy5Ure\neustMjIyKpXp168fO3fuJD09nQcffPCS+VdSUsJPP/3E5s2bmTFjBsnJyVcldrd18u+8804cDgdh\nYWE888wzLFu2jJCQEBwOBw6Hg5ycHFatWlWpXlVlatKZd+XixuLZZ58lISGB7du3k56eztmzZwEY\nNmwY6enpNGzYkHvvvZd169Zhs9lo2rQpv/rVr6r8I17swiEa8PPfRHA+1j/96U+0atWKnJwcsrKy\ncDqdVZY/P3RNbhxjxowhKyuLf/zjHzRt2pS2bdtWWS4tLa3CEDI/Pz/8/Pxo3749AIMGDaowQZF4\nrk2bNrFixQoCAgIYNmwYX375JSNHjqxQxtfX1zqe9O7dm+LiYn788cdLrnvhwoV8/vnnfPDBB1cl\ndqm7mjRpQp8+fSrdkXCVazpG3bhatGhhPZp5+PBhmjdvXm15V7klcqGatH3nXXzOdN7KlSuJjo6u\nNHy6pKSETz75hCFDhlyV2OX61apVK6B8SH3//v3JzMx0WTYuLo6SkhKrjcvPz7eW5efn4+fnB5Sf\now8YMACA9u3bU69ePU6cOOH22N3WyT98+DA33XQTI0aM4KmnniIzM5Pjx49bs+UWFxdXuENts9lo\n27Ytx44dq1TG19cXPz8/69mFf//735w9e5bGjRtz+vTpauPw9fWtUObUqVPcfvvtACxYsMD6/Pvv\nvycgIIAJEyZw//33s337dqB81MDHH39MampqtTP5X9yh79q1Kx9++CEA//rXv8jJyan+F3aBU6dO\n0bJlSwBSU1MpLS2tcV3xbEePHgVg//79fPLJJ1VeRT558iQbNmywRr4AtGzZkjZt2lhzUKxdu5aQ\nkJBrE7TUqpdffpn8/Hxyc3NJS0vjnnvuITU1tUKZI0eOWMewzMxMjDFVPkt9oVWrVjFjxgyWL19u\njXySG9vx48etmdHPnj3LmjVrKs087SrXdIy6cSUlJfHee+8B8N5771U5kqgmuQVV31y5khtFUnfV\npO2Dqs+Zzlu0aJHL5/SDgoKs/oTcGIqKiqw+5ZkzZ1i9enWlUd579+61jjnnL1TfdtttxMTEsGfP\nHvLy8nA6nSxevJikpCSg/M7/+Vn4d+/ejdPp5LbbbnN7/F7uWtH27duZNGkS9erVo0GDBrz99tvU\nr1+fiRMncvLkSUpKSnjiiScqPFPl7e3N0qVLqyzz17/+lYcffpg//vGPVrnw8HDq169PZGQko0eP\nrvK5/Pj4eF599VXsdjtTp07lD3/4A6NGjeKll16iT58+1t3zJUuW8P777+Pt7U2rVq14+umnKSgo\nwGaz0ahRIz777DO6d++Or68vffv2rbSdi4eYPfroo4wePZrg4GCCgoKqfZb/YuPHj2fgwIGkpqbS\nq1cvfHx8Kmynqu3JjWHQoEGcOHECb29v5syZQ+PGjXnnnXcAePjhh4HyZ4F69uxJw4YNK9R98803\nGTFiBE6nk8DAwAoXueTGcf64cWHeLF26lLfffhsvLy8aNWpEWlqaVX7YsGH84x//4MSJE7Rp04YX\nXniB0aNHM2HCBJxOpzXxZ6dOnZgzZ8613yG5bhw+fJhRo0ZRVlZGWVkZDz74IAkJCTXONR2jPN/5\n48nx48et48mUKVNITk5m3rx5+Pv7s2TJEqD8tcEPPfQQf/vb3zh06BApKSmVcgvgk08+YeLEiRw/\nfpw+ffpgt9utVyf7+/tz+vRpnE4ny5cvZ/Xq1bRr167W9l9qT1VtH7g+Zzpz5gxr166t8rnrxYsX\na8K9G9CRI0fo378/UD6aY8SIEfTo0aNCTi1btozU1FS8vb3x8fGx2jgvLy9mz55Nz549KS0tZezY\nsQQFBQHlo3THjBlDWFgYDRo0qPJilDvYqrviabPZjK6IXp74+Hhef/11oqKiamX7NptNV7PFrZRT\n4m7KKXEn5ZO4m3JK3E05Je72n5yqdCfYbcP1RURERERERKR2XfJO/jWMRURERERERERqqKo7+dV2\n8kVERERERESk7tBwfREREREREREPoU6+iIiIiIiIiIdQJ19ERERERETEQ6iTLyIiIiIiIuIh1MkX\nERERERER8RD/Hz6i7n53wk8QAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fc752039e90>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/kAAAILCAYAAACzaFyqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3X2cVnWd//HXhxsVaIYbIW5E8Q51qbQ0NS2K1LyphVzv\nAJPUNXE1zZts8yZjzGprM1Mr3c12FVxv0tZc0tZ0NTJ/qyJqFqKLaKKCoKHCIIqD8/n9cR3Gi3EG\nZ0ZmLrzm9Xw8rkfnfK/zPd/vORePnPf5fs85kZlIkiRJkqT3vh6V7oAkSZIkSdowDPmSJEmSJFUJ\nQ74kSZIkSVXCkC9JkiRJUpUw5EuSJEmSVCUM+ZIkSZIkVQlDviRJ73ER0RgR21a6Hx0REWMj4vEu\nbnOriKiPiOjKdiVJ6gqGfEmSOklErCzCZH0RxFeVrU9upc64iHh2A/ZhVkS8VtZufUT814bafwf6\ns84Ficz8Q2butIHbGFt2rCuLNteurwAaM7MmM3NDtlspEXFkRMwpjm9xRPwmIj5efFcXEQ3Fdy9H\nxP+LiI+VfXd1C/t7z140kiQZ8iVJ6jSZ+b4iTNYAC4G/Xbuemdd1VTeAL5e1W5OZn++itlvTqSPo\nxYWDtef9A0Vx/6KsNjOf68z2O0MUWig/A/gR8G3g/cCWwE+B8WWbXVeciyHAPcBNnd9jSVKlGPIl\nSepiEbFpRFwcEYuKz48iYpOI6Af8NzBi7ahzRAyLiD0i4t5iJHZxRPw4InpvgH58PSLui4iexfqJ\nETG36EuPiDgrIhZExF8j4hcRMbCs7ici4n+LPj0TEV8symdFxHFl2x0TEX8olu8uih8pju/w5jMX\nIuJvin28XPRlfNl3V0XETyPiluLc3NeGEeeWgvHWxWh1j7I+X1CMctdHxMyIGBwR10TE8oiYHRGj\nyurvFBF3RMSyiHg8Ig5fzzmeFRH/FBH3F/u6udl5/FjZefxjRHyqWd1vR8T/A14Ftmm27/7A+cBJ\nmXlzZr6WmW9m5q2ZeVbzc5CZa4AZwLCI2PwdztvaNo6JiCeL8/1URBzZlnqSpMox5EuS1PXOBfYA\ndik+ewDfyMxXgQOBxWWjzkuANcCpwObAXsC+wEntaK+1kfN/BlYD34iI0cB3gC9k5hvAKcAE4JPA\ncOBlSiPEFIH3N8AlwGDgw8AjxT6z+LxNZn6yWNy5OL4b1+lk6cLFr4HbKI06nwJcExE7lG02EagD\nBgILij5vCBOBo4AtgO2Ae4F/AwYBjwHTij72A+4A/qPo4yTgsoj4m/XsewpwLKXzuAa4tNjXFsAt\nwLcycyBwJvCfzQL4UcCXgPcBzzTb717AZsCv2nKAEbEpcAzwTGYua8P2/Sj9xgdmZm3R3h/b0pYk\nqXIM+ZIkdb0jKQW7v2bmXymNxk4pvntbIM/MhzJzdmY2ZuZC4GfAp5pv14oALi1Gitd+zi/2m8AX\nga8A/wV8PzPXhvUTKF14WJyZDUUfDytG/Y8E7sjMXxQjxy+V1Xs3Pgb0y8zvZeaazPwdpRBc/vyC\nmzJzTma+CVxD6QLDu5XAlZn5l8xcQWk2xfzMvKto50bgI8W2fwv8JTOnF7/HHylNf29tND+BGZk5\nLzNXAecBRxSzCI4CfpOZtwFk5v8Ac4DPldW9KjMfK9pa02zfmwN/zczGdzi+IyLiZUoXCT4C/F0b\nzslajcCHIqJPZi7NzHntqCtJqoBele6AJEnd0AhK9+iv9UxR1qJiJPsiYDegL6X/fs9pY1sJnJKZ\n/97il5kLI2IWpRkEPy37amvgVxFRHiDXAEOBkcBTbWy/PUYAzR86uJC3zk0CS8u+e43SCPeGUL7f\n14EXmq2vbWcUsGcRmtfqRWkafGvKj+kZoDelGRCjgMPLb0ko9nVXK3WbWwYMjoge7xD0f5GZX2yh\nvKHoS5Oy20AaMvPViJhIaYbBvxW3DXw1M/9vPW1JkirMkXxJkrreYkoheq2tijJoear75cA8YPvM\n7E9puv8G+W94RHyO0gj6ncCFZV89Q2ma9sCyT9/MXEwpeG7Xyi5fBfqVrQ9rR3cWA1s2e8DcKGBR\nO/axIazvqfvPAL9vdl5qMvPL66mzVbPlBuDFYl9Xt7Cvf25jX+6ldLvF+kbmk9Zv13iGdf8dQum+\n/zUU5zwzb8/M/Sn9jo8DV6ynLUnSRsCQL0lS17uO0n3wgyNiMPBNYO2rzJYCm0dEbdn27wPqgVUR\nsRNwYjvbazHkFW1fARxH6V7t8RFxUPH1vwDfjYitim2HRMSE4rtrgP2KB+f1iojNI2KX4rs/AodE\nRJ+I2L7Yd7mltH6B4H5gFfCPEdE7IsZRmh5//fqOYwOJVpabuxXYISKOKvrYOyJ2L36X1vZ7VPFA\nwb7At4Abi1sl/oPSOd8/InpGxGbFgwi3aEtfMnM5pX87P42Iz0dE36I/B0XE99twLLcBO5UdyyDg\nu8AvM7MxIt5f7LcfpQsTrwJvrmd/kqSNgCFfkqSu921K0+3/VHzmFGVk5uOULgI8FREvRcQwStOl\njwRWULof/3rWHeF9p/e9/yTeek98fUQ8UJT/K3BzZt6WmS9RCuQ/L57+fgkwE7g9Su+Wv5fSAwLJ\nzGeBzwJfpTRl/GFg52KfPwLeoBTmr6QUZMv7VwdML54NcBhlD+orHvg3HjiI0kj3T4ApmTm/7Dib\nH2tb3nXf0jbr20+r7WRmPbA/pQfuLQKeB/4J2GQ9bV8NXFVsuwmlZyBQvMrv88A5lG4PeIbSOY1m\n9VuVmRcBZwDfKNvHSbz1ML71PQjxRUrn+gRKv9efgZd46yJSD+D04jiXAWNp/wUmSVIXi9KFZHWF\niDib0kN2Gin9h/RYSlMaf0FpOuLTwBGZ+UrZ9n9P6ar5VzLz9qJ8N0p/LGxG6YE9p3bpgUiSpDaJ\niN9RmpLf4jMRJEna0BzJ7yIRsTVwPLBrZn4I6ElpFOAsSk8o3oHS/ZBnFduPofQ6nzGUHoZ0Wdk9\nipcDx2XmaGB0RBzYhYciSZLapzNvM5AkaR2G/K6zgtL9bH0johelpyMvpvQO4unFNtOBg4vlzwPX\nZWZDZj5N6V3Ae0bEcKAmM2cX280oqyNJkjY+TpuUJHUZX6HXRTLzpYj4IaV75V4DfpuZd0TE0Mxc\n+9qepZReTQSl1wXdV7aL54AtKF0oeK6sfFFRLkmSNjKZ+elK90GS1L0Y8rtIRGwHnEbpVTXLgRsj\n4qjybTIzI2KDXO3fUPuRJEmSJG2cMvNtt4QZ8rvOR4H/zcxlABFxE7AXsCQihmXmkmIq/gvF9ouA\nLcvqj6Q0gr+oWC4vb/H9wT5UUZIkSZKq01uPbFuX9+R3nceBjxXvDQ5gP2Ae8Gvg6GKbo4Gbi+WZ\nwKSI2CQitgFGA7MzcwmwIiL2LPYzpayOJEmSJKkbcyS/i2TmIxExg9K7kBuBhyi967gGuCEijqN4\nhV6x/byIuIHShYA1wEn51tD8SZReodeH0iv0buvCQ5EkSZIkbaTCKd3VKSLS31aSJEmSqlNEtHhP\nvtP1JUmSJEmqEk7Xl9qptQdcbGjOxJAkSdp4ddXfhBK0LxsY8qUO6Oz47X8yJEmSNn4OyqgrtPeC\nktP1JUmSJEmqEoZ8SZIkSZKqhCFfkiRJkqQqYciXJEmSJKlKGPIlSZIkqcodc8wxnHfeeZXuxkar\nI+fntddeY/z48QwYMICJEye+4/Yf/OAHufvuuzvaxTbz6fqSJEmStAF0xWv1OvpE/4ioutf+zZo1\niylTpvDss8++63115Pz88pe/5IUXXuCll16iR493Hj+fO3duR7vXLoZ8SZIkSdpgOvO1eu8upPvK\nv/Vr7/lZuHAhO+ywQ5sC/jt588036dmz57veDzhdX5IkSZKqzsMPP8yuu+5KbW0tkyZN4vXXX2/6\n7pZbbuHDH/4wAwcO5OMf/zh//vOfW603adKkpmnsV111FWPHjl2nnR49evDUU08BsHr1as4880xG\njRrFsGHDOPHEE5vafTd1W/Lqq69y0EEHsXjxYmpqaqitrWXJkiXMnj2bvfbai4EDBzJixAhOOeUU\nGhoamuqdfvrpDB06lP79+7Pzzjszb968t+27vr6eT3/605x22mmttj9t2jQuuOACfvGLX1BTU8OV\nV17JU089xT777MPgwYMZMmQIRx11FMuXL2+qs/XWW3PXXXcBUFdXx2GHHcaUKVPo378/06dPb7Wt\n9jLkS5IkSVIVeeONNzj44IM5+uijefnllzn88MP5z//8TyKChx9+mOOOO44rrriCl156iRNOOIEJ\nEybQ0NDQYr2bbrqpzdPYzzrrLBYsWMAjjzzCggULWLRoEd/61rc6pW6/fv247bbbGDFiBPX19axY\nsYJhw4bRq1cvLrnkEpYtW8a9997LnXfeyWWXXQbAb3/7W/7whz/wxBNPsHz5cm688UYGDRrUtM+I\nYNmyZey7776MHTuWiy++uNX2zz//fM455xwmTZpEfX09xx57LJnJueeey/PPP89jjz3Gs88+S11d\n3Tr7Lzdz5kwOP/xwli9fzpFHHtmm89QWhnxJkiRJqiL33Xcfa9as4dRTT6Vnz54ceuih7L777mQm\nV1xxBSeccAK77747EcEXv/hFNt10U+69995W67XF2n1fdNFFDBgwgPe9732cffbZXH/99Z1Wt6Xp\n9bvuuit77LEHPXr0YNSoUUydOpXf//73APTu3Zv6+noee+wxGhsb2XHHHRk2bFhT3UWLFjFu3Dgm\nTpzYposTmblOH7bbbjv23XdfevfuzeDBgzn99NOb2m7J3nvvzYQJEwDYbLPN3rG9tvKefEmSJEmq\nIosXL2aLLbZYp2zUqFFA6T7y6dOn8+Mf/7jpu4aGBp5//nkys9V67+TFF19k1apV7Lbbbk1lmUlj\nY2On1m1u/vz5nHHGGTz44IOsWrWKNWvW8NGPfhSAffbZh5NPPpkvf/nLLFy4kEMOOYQLL7yQmpoa\nMpNbb72VmpoaTjjhhHa3C7B06VJOPfVU7rnnHurr62lsbFxnpkBzI0eO7FA778SRfEmSJEmqIsOH\nD2fRokXrlC1cuBCALbfcknPPPZeXX3656bNy5UomTpy43npQmiK/atWqpvUlS5Y0LQ8ePJg+ffow\nb968pv2+8sorrFix4l3XbU1LtxGceOKJjBkzhgULFrB8+XK+853vrHOx4JRTTmHOnDnMmzeP+fPn\n84Mf/KBpX8cffzwHHHAAn/3sZ9fpa1vbP+ecc+jZsydz585l+fLlXH311eu9UNFZbzsw5EuSJElS\nFdl7773p1asXl156KQ0NDdx000088MADTUH2X/7lX5g9ezaZyauvvsqtt97KypUrW6231i677MKj\njz7KI488wuuvv77O/eY9evTg+OOP57TTTuPFF18EStPfb7/99nddtzVDhw5l2bJl61wMWLlyJTU1\nNfTt25fHH3+cyy+/vClMz5kzh/vvv5+Ghgb69u3LZptt1vRE+7XT7n/yk5+w4447Mn78+PU++K+8\nTnnb/fr1o7a2lkWLFjVdQOhqhnxJkiRJ2mCiEz9t07t3b2666SauuuoqNt98c2644QYOPfRQAHbb\nbTeuuOIKTj75ZAYNGsTo0aOZMWNGq/UOOeSQpjC7ww478M1vfpP99tuPHXfckbFjx64zGv3973+f\n7bffno997GP079+fz3zmM8yfP/9d123NTjvtxOTJk9l2220ZNGgQS5Ys4cILL+Taa6+ltraWqVOn\nMmnSpKbtV6xYwdSpUxk0aBBbb701gwcP5mtf+1rpV4to6s/PfvYzRo4cycEHH8zq1atbbb+8DpSe\nuP/QQw/Rv39/xo8fz6GHHtrqaH3zuhtS+K7E6hQR6W/bOSKiU99+CqX/C/f3kyRJ2nhFRLf4e+3Y\nY49l5MiRXHDBBZXuSrfV2r+1ovxtVwocyZckSZIktag7XMioNoZ8SZIkSVKLOnNaeVt897vfpaam\n5m2fz33uc13S/gc+8IEW27/uuuu6pP2OcLp+lXK6fudxur4kSZK6y3R9VZ7T9SVJkiRJ6qYM+ZIk\nSZIkVQlDviRJkiRJVcKQL0mSJElSlTDkS5IkSZJUJQz5kiRJkqRu7ZhjjuG8885rV53XXnuN8ePH\nM2DAACZOnPiO23/wgx/k7rvv7mgX26xXp7cgSZIkSd1AV7xP3tf2vWXWrFlMmTKFZ5999l3vKyLa\n/fv98pe/5IUXXuCll16iR493Hj+fO3duR7vXLoZ8SZIkSdpQ6t6j+1a7L6AsXLiQHXbYoU0B/528\n+eab9OzZ813vB5yuL0mSJElVZ/HixRx66KG8//3vZ9ttt+XHP/4xAHV1dRxxxBEcffTR1NbW8sEP\nfpAHH3ywqd7DDz/MrrvuSm1tLZMmTWLSpElN09ivuuoqxo4du047PXr04KmnngJg9erVnHnmmYwa\nNYphw4Zx4okn8vrrr7/rui159dVXOeigg1i8eDE1NTXU1tayZMkSZs+ezV577cXAgQMZMWIEp5xy\nCg0NDU31Tj/9dIYOHUr//v3ZeeedmTdv3tv2XV9fz6c//WlOO+20VtufNm0aF1xwAb/4xS+oqanh\nyiuv5KmnnmKfffZh8ODBDBkyhKOOOorly5c31dl666256667mn6Hww47jClTptC/f3+mT5/ealvt\nZciXJEmSpCrS2NjI+PHj+chHPsLixYu58847ufjii7n99tsB+PWvf83kyZNZvnw5EyZM4OSTTwbg\njTfe4OCDD+boo4/m5Zdf5vDDD+emm25q8zT2s846iwULFvDII4+wYMECFi1axLe+9a1OqduvXz9u\nu+02RowYQX19PStWrGDYsGH06tWLSy65hGXLlnHvvfdy5513ctlllwHw29/+lj/84Q888cQTLF++\nnBtvvJFBgwY17TMiWLZsGfvuuy9jx47l4osvbrX9888/n3POOYdJkyZRX1/PscceS2Zy7rnn8vzz\nz/PYY4/x7LPPUldXt87+y82cOZPDDz+c5cuXc+SRR7bpPLWFIV+SJEmSqsgDDzzAX//6V77xjW/Q\nq1cvttlmG770pS9x/fXXExGMHTuWAw88kIjgqKOO4pFHHgHgvvvuY82aNZx66qn07NmTQw89lN13\n371NbWYmV1xxBRdddBEDBgzgfe97H2effTbXX399p9VtaXr9rrvuyh577EGPHj0YNWoUU6dO5fe/\n/z0AvXv3pr6+nscee4zGxkZ23HFHhg0b1lR30aJFjBs3jokTJ7bp4kRmrtOH7bbbjn333ZfevXsz\nePBgTj/99Ka2W7L33nszYcIEADbbbLN3bK+tvCdfkiRJkqrIwoULWbx4MQMHDmwqe/PNN/nkJz/J\nqFGjGDp0aFN53759ef3112lsbGTx4sVsscUW6+xr1KhRbWrzxRdfZNWqVey2225NZZlJY2Njp9Zt\nbv78+Zxxxhk8+OCDrFq1ijVr1vDRj34UgH322YeTTz6ZL3/5yyxcuJBDDjmECy+8kJqaGjKTW2+9\nlZqaGk444YR2twuwdOlSTj31VO655x7q6+tpbGxcZ6ZAcyNHjuxQO+/EkXxJkiRJqiJbbbUV22yz\nDS+//HLTZ8WKFdxyyy3rrTd8+HAWLVq0TtnChQublvv168eqVaua1pcsWdK0PHjwYPr06cO8efOa\n2nzllVdYsWLFu67bmpZuIzjxxBMZM2YMCxYsYPny5XznO99Z52LBKaecwpw5c5g3bx7z58/nBz/4\nQdO+jj/+eA444AA++9nPrtPXtrZ/zjnn0LNnT+bOncvy5cu5+uqr13uhorPexmDIlyRJkqQqssce\ne1BTU8M///M/89prr/Hmm28yd+5c5syZs956e+21F7169eLSSy+loaGBm266iQceeKDp+1122YVH\nH32URx55hNdff32d+8179OjB8ccfz2mnncaLL74IlKa/r30OwLup25qhQ4eybNmydS4GrFy5kpqa\nGvr27cvjjz/O5Zdf3hSm58yZw/33309DQwN9+/Zls802a3qi/dpp9z/5yU/YcccdGT9+/Hof/Fde\np7ztfv36UVtby6JFi5ouIHQ1Q74kSZIkbSh1nfhpox49enDLLbfwxz/+kW233ZYhQ4YwderUpie9\nNx9BXru+ySabcNNNN3HVVVex+eabc8MNN3DIIYc0hdkddtiBb37zm+y3337suOOOjB07dp19ff/7\n32f77bfnYx/7GP379+czn/kM8+fPf9d1W7PTTjsxefJktt12WwYNGsSSJUu48MILufbaa6mtrWXq\n1KlMmjSpafsVK1YwdepUBg0axNZbb83gwYP52te+1nQO1vbnZz/7GSNHjuTggw9m9erVrbZfXgdK\nT9x/6KGH6N+/P+PHj+fQQw9tdbS+ed0NKdr7LkC9N0RE+tt2joigs89s0P73dEqSJKnrRES3+Hvt\n2GOPZeTIkVxwwQWV7kq31dq/taL8bVcKHMmXJEmSJLWoO1zIqDaGfEmSJElSizpzWnlbfPe736Wm\npuZtn8997nNd0v4HPvCBFtu/7rrruqT9jnC6fpVyun7ncbq+JEmSust0fVWe0/UlSZIkSeqmDPmS\nJEmSJFUJQ74kSZIkSVXCkC9JkiRJUpUw5EuSJEmSVCUM+ZIkSZLUzT399NP06NGDxsbGSnel3erq\n6pgyZUrF2v/Vr37FlltuSU1NDY888sh6t73mmms44IADOrU/hnxJkiRJ2gDWvlO+Mz8bu6233pq7\n7rrrHbfbkBcVKn1ezjzzTC677DLq6+vZZZdd1rvtF77wBX772992an8M+V0kInaMiIfLPssj4isR\nMSgi7oiI+RFxe0QMKKtzdkQ8ERGPR8T+ZeW7RcSfi+8uqcwRSZIkSWouO/HzXtDaO91b055tO3Mf\nb775ZofbfuaZZxgzZsy77sOaNWve9T7AkN9lMvP/MvMjmfkRYDdgFfAr4CzgjszcAbizWCcixgAT\ngTHAgcBl8dYlqsuB4zJzNDA6Ig7s2qORJEmStDH7/ve/z8iRI6mtrWWnnXbirrvuIjP53ve+x/bb\nb8/gwYOZOHEiL7/8cov1ly9fznHHHceIESMYOXIk55133jqj7ldccQVjxoyhtraWD3zgAzz88MNM\nmTKFZ555hvHjx1NTU8OFF17Yav8++clPAjBgwABqamq4//77efLJJ9lnn30YPHgwQ4YM4aijjmL5\n8uXrPabmGhoamDx5MocddhgNDQ2ttl9XV8dhhx3GlClT6N+/P9OnT+cvf/kLn/rUp6itrWX//ffn\n5JNPXu9tAKtXr6ampoY333yTXXbZhdGjRwM0neO15+bmm29uqnPVVVcxduzYpvUePXpw2WWXMXr0\naHbcccdW22oPQ35l7AcsyMxngQnA9KJ8OnBwsfx54LrMbMjMp4EFwJ4RMRyoyczZxXYzyupIkiRJ\n6ub+7//+j5/+9KfMmTOHFStWcPvtt7P11ltz6aWXMnPmTO6++26ef/55Bg4cyJe//OUW93HMMcew\nySab8OSTT/Lwww9z++238/Of/xyAG2+8kfPPP5+rr76aFStWMHPmTDbffHOuvvpqttpqK2655Rbq\n6+s588wzW+3jH/7wB6B0MaG+vp4999wTgHPPPZfnn3+exx57jGeffZa6urr1HlO5119/nYMPPpg+\nffpw44030rt37/Wep5kzZ3L44YezfPlyjjzySI488kh23313li1bxnnnnceMGTPWeyvApptuysqV\nKwH405/+xBNPPAHA9ttvzz333MOKFSuYNm0aRx11FEuXLm11P//1X//FAw88wLx589bb37Yy5FfG\nJOC6YnloZq79xZcCQ4vlEcBzZXWeA7ZooXxRUS5JkiRJ9OzZk9WrV/Poo4/S0NDAVlttxbbbbsu/\n/uu/8u1vf5sRI0bQu3dvpk2bxi9/+cu33Re/dOlS/vu//5sf/ehH9OnThyFDhnDaaadx/fXXA/Dz\nn/+cr3/96+y2224AbLfddmy11Vbt6mNLU+y322479t13X3r37s3gwYM5/fTT+f3vf7/eY4LSLQIr\nVqzggAMOYPTo0fz7v/97m+7T33vvvZkwYQIAL7zwAnPmzOGCCy6gd+/ejB07lvHjx3foVoDDDjuM\nYcOGAXDEEUcwevRo7r///la3P/vssxkwYACbbrppu9tqSa8Nshe1WURsAowHvt78u8zMiNhgt9us\nveoFMG7cOMaNG7ehdi1JkiRpI7X99ttz8cUXU1dXx6OPPsoBBxzAD3/4Q55++mn+7u/+jh493hrr\n7dWr19tGmRcuXEhDQwPDhw9vKmtsbGwK8s899xzbbbfdBu/30qVLOfXUU7nnnnuor6+nsbGRQYMG\ntXpMF110EcOHDyczue+++1izZk3ThYi2GDlyZNPy4sWLGThwIH369GkqGzVqFM8++2y7j2PGjBn8\n6Ec/4umnnwZg5cqVLFu2rNXtt9xyyzbtd9asWcyaNesdtzPkd72DgAcz88VifWlEDMvMJcVU/BeK\n8kVA+a89ktII/qJiubx8UUsNlYd8SZIkSd3H5MmTmTx5MvX19Zxwwgl8/etfZ6uttuLKK69kr732\netv2awMplELnpptuyrJly9a5IFD+/YIFC1pst61Pum9pu3POOYeePXsyd+5cBgwYwM0338wpp5yy\n3mOaMWMGAPvvvz8777wz++67L7NmzeL973//O7Zf3ofhw4fz8ssvs2rVKvr27QuULna0dPzrs3Dh\nQqZOncpdd93FXnvtRUTwkY98ZL0zAtp6zpoP3J5//vktbud0/a43mbem6gPMBI4ulo8Gbi4rnxQR\nm0TENsBoYHZmLgFWRMSexYP4ppTVkSRJktTNzZ8/n7vuuovVq1ez6aabstlmm9GrVy/+4R/+gXPO\nOYdnnnkGgBdffJGZM2e+rf7w4cPZf//9OeOMM5pG1J988knuvvtuAL70pS9x4YUX8tBDD5GZLFiw\noGmfQ4cO5cknn3zHPg4ZMoQePXqss+3KlSvp168ftbW1LFq0iB/84AfrPaaePXuus8+vfe1rHHnk\nkey7777rHTmHt98uMGrUKD760Y8ybdo0GhoauOeee7jlllva/Xq+V199lYhg8ODBNDY2cuWVVzJ3\n7tx27eMlj/vaAAAgAElEQVTdMuR3oYjoR+mhezeVFX8P+ExEzAf2KdbJzHnADcA84L+Bk/Ktf4kn\nAT8HnqD0AL/buuYIJEmSJK1PdOKnrVavXs3ZZ5/NkCFDGD58OH/961/5p3/6J0499VQmTJjA/vvv\nT21tLXvttRezZ89uqlceaGfMmMEbb7zBmDFjGDRoEIcffjhLliwBSvecn3vuuRx55JHU1tZyyCGH\nND2l/+yzz+bb3/42AwcO5KKLLmq1j3379uXcc8/l4x//OIMGDWL27NlMmzaNhx56iP79+zN+/HgO\nPfTQpj61dkxr+712u2984xscfPDB7Lfffrzyyiuttt98JB/g2muv5f7772fQoEF861vf4otf/GKb\n7skv38+YMWP46le/yl577cWwYcOYO3cun/jEJ1ptt70XEdoiNsQ7BbXxiYj0t+0cEdHp7ykNNsz7\nPiVJktQ52vs+eL33nH/++SxYsICrr766ov1o7d9aUf62qwSO5EuSJEmS1Mx79SKOIV+SJEmStMFd\nc8011NTUvO3zoQ99qEvaP+igg1ps/3vf+16b6q+dWn/ttddW9Djay+n6Vcrp+p3H6fqSJElyur66\nitP1JUmSJEnqpgz5kiRJkiRVCUO+JEmSJElVolelOyBJkiRJ70Wd8Y5z6d0y5EuSJElSO/nQPW2s\nnK4vSZIkSVKVMORLkiRJklQlDPmSJEmSJFUJQ74kSZIkSVXCkC9JkiRJUpUw5EuSJEmSVCUM+ZIk\nSZIkVQlDviRJkiRJVcKQL0mSJElSlTDkS5IkSZJUJQz5kiRJkiRVCUO+JEmSJElVwpAvSZIkSVKV\n6FXpDkiSJEmSul5EdEk7mdkl7ajEkC9JkiRJ3VZnB/CuuZCgtzhdX5IkSZKkKmHIlyRJkiSpShjy\nJUmSJEmqEoZ8SZIkSZKqhCFfkiRJkqQqYciXJEmSJKlKGPIlSZIkSaoShnxJkiRJkqqEIV+SJEmS\npCphyJckSZIkqUoY8iVJkiRJqhKGfEmSJEmSqoQhX5IkSZKkKmHIlyRJkiSpShjyJUmSJEmqEoZ8\nSZIkSZKqhCFfkiRJkqQqYciXJEmSJKlKGPIlSZIkSaoShnxJkiRJkqqEIV+SJEmSpCphyJckSZIk\nqUoY8iVJkiRJqhKGfEmSJEmSqoQhvwtFxICI+GVEPBYR8yJiz4gYFBF3RMT8iLg9IgaUbX92RDwR\nEY9HxP5l5btFxJ+L7y6pzNFIkiRJkjY2hvyudQnwm8z8G2Bn4HHgLOCOzNwBuLNYJyLGABOBMcCB\nwGUREcV+LgeOy8zRwOiIOLBrD0OSJEmStDEy5HeRiOgPjM3MfwfIzDWZuRyYAEwvNpsOHFwsfx64\nLjMbMvNpYAGwZ0QMB2oyc3ax3YyyOpIkSZKkbqxXpTvQjWwDvBgRVwK7AA8CpwFDM3Npsc1SYGix\nPAK4r6z+c8AWQEOxvNaiolySJEmSNjpvTUjuPJnZ6W28Vxjyu04vYFfg5Mx8ICIuppiav1ZmZkRs\nsH+ddXV1Tcvjxo1j3LhxG2rXkiRJktQ2de/x/W8kZs2axaxZs95xu/CKR9eIiGHAvZm5TbH+CeBs\nYFvg05m5pJiK/7vM3CkizgLIzO8V298GTAMWFtv8TVE+GfhUZv5Ds/bS37ZzRASdfWYDr0ZKkiSp\nc5VG2LvgL9u6Tm6irnv+7RwRZObbpkl4T34XycwlwLMRsUNRtB/wKPBr4Oii7Gjg5mJ5JjApIjaJ\niG2A0cDsYj8riifzBzClrI4kSZIkqRtzun7XOgW4JiI2AZ4EjgV6AjdExHHA08ARAJk5LyJuAOYB\na4CTyobmTwKuAvpQelr/bV15EJIkSZKkjZPT9auU0/U7j9P1JUmSVA2crv/e5nR9SZIkSZKqnCFf\nkiRJkqQqYciXJEmSJKlKGPIlSZIkSaoShnxJkiRJkqqEIV+SJEmSpCphyJckSZIkqUoY8iVJkiRJ\nqhKGfEmSJEmSqoQhX5IkSZKkKmHIlyRJkiSpShjyJUmSJEmqEoZ8SZIkSZKqhCFfkiRJkqQqYciX\nJEmSJKlKGPIlSZIkSaoShnxJkiRJkqqEIV+SJEmSpCphyJckSZIkqUoY8iVJkiRJqhKGfEmSJEmS\nqoQhX5IkSZKkKmHIlyRJkiSpShjyJUmSJEmqEoZ8SZIkSZKqhCFfkiRJkqQqYciXJEmSJKlKGPIl\nSZIkSaoShnxJkiRJkqpEr0p3QJIkSZKkdyMiOr2NzOz0NjYEQ74kSZIk6T2ts+N3519C2HCcri9J\nkiRJUpUw5EuSJEmSVCUM+ZIkSZIkVQlDviRJkiRJVcKQL0mSJElSlTDkS5IkSZJUJQz5kiRJkiRV\nCUO+JEmSJElVwpAvSZIkSVKVMORLkiRJklQlDPmSJEmSJFUJQ74kSZIkSVXCkC9JkiRJUpUw5EuS\nJEmSVCUM+ZIkSZIkVQlDviRJkiRJVcKQ34Ui4umI+FNEPBwRs4uyQRFxR0TMj4jbI2JA2fZnR8QT\nEfF4ROxfVr5bRPy5+O6SShyLJEmSJGnjY8jvWgmMy8yPZOYeRdlZwB2ZuQNwZ7FORIwBJgJjgAOB\nyyIiijqXA8dl5mhgdEQc2JUHIUmSJEnaOBnyu140W58ATC+WpwMHF8ufB67LzIbMfBpYAOwZEcOB\nmsycXWw3o6yOJEmSJKkbM+R3rQT+JyLmRMTxRdnQzFxaLC8FhhbLI4Dnyuo+B2zRQvmiolySJEmS\n1M31qnQHupmPZ+bzETEEuCMiHi//MjMzInJDNVZXV9e0PG7cOMaNG7ehdi1JkiRJ6kKzZs1i1qxZ\n77hdZG6wTKl2iIhpwErgeEr36S8ppuL/LjN3ioizADLze8X2twHTgIXFNn9TlE8GPpWZ/9Bs/+lv\n2zkigs4+swH4+0mSJKkzlR751QV/2dZ1chN1XXIUG93f5xFBZja/Hdzp+l0lIvpGRE2x3A/YH/gz\nMBM4utjsaODmYnkmMCkiNomIbYDRwOzMXAKsiIg9iwfxTSmrI0mSJEnqxpyu33WGAr8qHpDfC7gm\nM2+PiDnADRFxHPA0cARAZs6LiBuAecAa4KSyofmTgKuAPsBvMvO2rjwQSZIkSdLGyen6Vcrp+p3H\n6fqSJEmqBk7Xb7uN8e9zp+tLkiRJklTlDPmSJEmSJFUJQ74kSZIkSVXCB++1Q0QcSul2j7fd91Dm\ntcz8TRd1SZIkSZKkJob89vkZpVfbtSaAsYAhX5IkSZLU5Qz57XNbZh67vg0i4pqu6owkSZIkSeW8\nJ78dMvMLG2IbSZIkSZI6gyG/AyLiiIioLZbPi4hfRcSule6XJEmSJKl7M+R3zHmZuSIiPgHsC/wb\ncHmF+yRJkiRJ6uYM+R3zZvG/fwtckZm3AJtUsD+SJEmSJBnyO2hRRPwMmAjcGhGb4bmUJEmSJFWY\nwbRjjgB+C+yfma8AA4GvVbZLkiRJkqTuzlfodczmwBwgI2KrouzxCvZHkiRJkiRDfgf9BshieTNg\nG+D/gA9UrEeSJEmSpG7PkN8BmfnB8vXi9XlfrlB3JEmSJEkCvCd/g8jMh4A9K90PSZIkSVL35kh+\nB0TEV8tWewC7Aosq1B1JkiRJkgBDfkfV8NY9+WuAW4D/rFx3JEmSJEky5HdIZtZVug+SJEmSJDXn\nPfntEBF1G2IbSZIkSZI6gyP57fOliFgBxHq2mQzUdU13JEmSJEl6iyG/fX5O6X789flZV3REkiRJ\nkqTmDPnt4L34kiRJkqSNmffkS5IkSZJUJQz5kiRJkiRVCUO+JEmSJElVwpDfARGxY0TcGRGPFus7\nR8Q3Kt0vSZIkSVL3ZsjvmCuAc4A3ivU/U3p1niRJkiRJFWPI75i+mXn/2pXMTKChgv2RJEmSJMmQ\n30EvRsT2a1ci4jDg+Qr2R5IkSZIkelW6A+9RJwM/A3aKiMXAX4AvVLZLkiRJkqTuzpDfAZn5JLBv\nRPQDemRmfaX7JEmSJEmSIb8DImIg8EVga6BXREDp1vyvVLJfkiRJkqTuzZDfMb8B7gX+BDQCAWRF\neyRJkiRJ6vYM+R2zaWaeUelOSJIkSZJUzqfrd8y1ETE1IoZHxKC1n0p3SpIkSZLUvTmS3zGvAz8A\nzqU0XR9K0/W3rViPJEmSJEndniG/Y74KbJeZf610RyRJkiRJWsvp+h3zBPBapTshSZIkSVI5R/I7\nZhXwx4j4HbC6KPMVepIkSZKkijLkd8zNxaecr9CTJEmSJFWUIb8DMvOqSvdBkiRJkqTmDPntEBE3\nZubhEfHnFr7OzNy5yzslSZIkSVLBkN8+FxX/O76ivZAkSZIkqQWG/Pa5DPhIZj5d6Y5IkiRJktSc\nr9CTJEmSJKlKOJLfPltExKVAtPBdm16hFxE9gTnAc5k5PiIGAb8ARgFPA0dk5ivFtmcDfw+8CXwl\nM28vyncDrgI2A36Tmae+2wOTJEmSJL33OZLfPq8BDxafOWWftWVtcSowj7deuXcWcEdm7gDcWawT\nEWOAicAY4EDgsohYe3HhcuC4zBwNjI6IA9/lcUmSJEmSqoAj+e3zUmZO72jliBgJfBb4DnBGUTwB\n+FSxPB2YRSnofx64LjMbgKcjYgGwZ0QsBGoyc3ZRZwZwMHBbR/slSZIkSaoOjuS3z+p3Wf9HwNeA\nxrKyoZm5tFheCgwtlkcAz5Vt9xywRQvli4pySZIkSVI3Z8hvh8z8WEfrRsTfAi9k5sO0fE8/mZm8\nNY1fkiRJkqR2cbp+19kbmBARn6X0wLzaiLgaWBoRwzJzSUQMB14otl8EbFlWfySlEfxFxXJ5+aKW\nGqyrq2taHjduHOPGjdswRyJJkiRJ6lKzZs1i1qxZ77hdlAaP1ZUi4lPAmcXT9f8ZWJaZ34+Is4AB\nmXlW8eC9a4E9KE3H/x9g+8zMiLgf+AowG7gVuDQzb2vWRvrbdo6I6PTpFgH4+0mSJKkzlZ7r3QV/\n2dZ1chN1XXIUG93f5xFBZr5tlrgj+R1UvApvKGXnMDOfaccu1v4L+R5wQ0QcR/EKvWJf8yLiBkpP\n4l8DnFSW2k+i9Aq9PpReoedD9yRJkiRJjuR3REScAkyjNLX+zbXlmfmhinWqGUfyO48j+ZIkSaoG\njuS33cb497kj+RvWacCOmbms0h2RJEmSJGktn67fMc8AKyrdCUmSJEmSyjmS3zF/AX4XEbcCbxRl\nmZkXVbBPkiRJkqRuzpDfMc8Un02KT1fczCJJkiRJ0noZ8jsgM+sAIqKmWK+vaIckSZIkScJ78jsk\nIj4UEQ8DjwKPRsSDEfHBSvdLkiRJktS9GfI75mfAGZm5VWZuBXy1KJMkSZIkqWIM+R3TNzN/t3Yl\nM2cB/SrXHUmSJEmSvCe/o/4SEecBV1N66N4XgKcq2yVJkiRJUnfnSH7H/D3wfuAm4D+BIUWZJEmS\nJEkV40h+B2TmS8Aple6HJEmSJEnlDPntEBGXZOapEfHrFr7OzJzQ5Z2SJEmSJKlgyG+fGcX//rCF\n77IrOyJJkiRJUnOG/HbIzAeLxQ9n5sXl30XEacDvu75XkiRJkiSV+OC9jjm6hbJjuroTkiRJkiSV\ncyS/HSJiMnAksE2z+/JrgGWV6ZUkSZIkSSWG/Pb5X+B5Sq/MuxCIorweeKRSnZIkSZIkCQz57ZKZ\nC4GFwMcq3RdJkiRJkpoz5HdARNSXrW4C9AZWZmZthbokSZIkSZIhvyMys2btckT0ACbg6L4kSZIk\nqcJ8uv67lJmNmXkzcGCl+yJJkiRJ6t4cye+AiDi0bLUHsBvwWoW6I0mSJEkSYMjvqPFAFstrgKeB\nz1esN5IkSZIkYcjvkMw8ptJ9kCRJkiSpOe/J74CImB4RA8rWB0bEv1eyT5IkSZIkGfI7ZpfMfGXt\nSma+DOxawf5IkiRJkmTI76CIiEFlK4OAnhXsjyRJkiRJ3pPfQT8E7o2IG4AADge+U9kuSZIkSZK6\nO0N+B2TmjIh4EPh0UfR3mTmvkn2SJEmSJMnp+h03CHg1M38CvBgR21S6Q5IkSZKk7s2Q3wERUQf8\nI3B2UbQJ8B8V65AkSZIkSRjyO+rvgM8DrwJk5iKgpqI9kiRJkiR1e4b8jlmdmY1rVyKiXyU7I0mS\nJEkSGPI76saI+FdgQERMBe4Efl7hPkmSJEmSujmfrt8BmfmDiNgfqAd2AM7LzDsq3C1JkiRJUjdn\nyO+AiDguM/8NuL1Y7xUR0zLz/Ap3TZIkSZLUjTldv2P2i4jfRMSIiPggcC9QW+lOSZIkSZK6N0fy\nOyAzJ0fEJOBPlJ6w/4XMvKfC3ZIkSZIkdXOO5HdAROwAfAW4CXgGOMon7EuSJEmSKs2Q3zEzgW9m\n5lTgU8ATwAOV7ZIkSZIkqbtzun7H7JmZywEysxH4YUT8usJ9kiRJkiR1c47kt0NE/CNAZi6PiMOb\nfX1M1/dIkiRJkqS3GPLbZ3LZ8jnNvjuoKzsiSZIkSVJzhnxJkiRJkqqEIV+SJEmSpCrhg/faZ+eI\nqC+W+5QtA/SpRIckSZIkSVrLkN8Omdmz0n2QJEmSJKk1TtfvIhGxWUTcHxF/jIh5EfFPRfmgiLgj\nIuZHxO0RMaCsztkR8UREPB4R+5eV7xYRfy6+u6QSxyNJkiRJ2vgY8rtIZr4OfDozPwzsDHw6Ij4B\nnAXckZk7AHcW60TEGGAiMAY4ELgsIqLY3eXAcZk5GhgdEQd27dFIkiRJkjZGhvwulJmrisVNgJ7A\ny8AEYHpRPh04uFj+PHBdZjZk5tPAAmDPiBgO1GTm7GK7GWV1JEmSJEndmCG/C0VEj4j4I7AU+F1m\nPgoMzcylxSZLgaHF8gjgubLqzwFbtFC+qCiXJEmSJHVzPnivC2VmI/DhiOgP/DYiPt3s+4yI3FDt\n1dXVNS2PGzeOcePGbahdS5IkSZK60KxZs5g1a9Y7bheZGyxTqh0i4jzgNeBLwLjMXFJMxf9dZu4U\nEWcBZOb3iu1vA6YBC4tt/qYonwx8KjP/odn+09+2c0QEnX1mA/D3kyRJUmcqPfKrC/6yrevkJuq6\n5Cg2ur/PI4LMjOblTtfvIhExeO2T8yOiD/AZ4GFgJnB0sdnRwM3F8kxgUkRsEhHbAKOB2Zm5BFgR\nEXsWD+KbUlZHkiRJktSNOV2/6wwHpkdED0oXV67OzDsj4mHghog4DngaOAIgM+dFxA3APGANcFLZ\n0PxJwFVAH+A3mXlblx6JJEmSJGmj5HT9KuV0/c7jdH1JkiRVA6frt93G+Pe50/UlSZIkSapyhnxJ\nkiRJkqqEIV+SJEmSpCphyJckSZIkqUoY8iVJkiRJqhKGfEmSJEmSqoQhX5IkSZKkKmHIlyRJkiSp\nShjyJUmSJEmqEoZ8SZIkSZKqhCFfkiRJkqQqYciXJEmSJKlKGPIlSZIkSaoShnxJkiRJkqqEIV+S\nJEmSpCphyJckSZIkqUoY8iVJkiRJqhKGfEmSJEmSqkSvSndA2pAiotJdkCRJkqSKMeSr+tS9x/cv\nSZIkSR3kdH1JkiRJkqqEIV+SJEmSpCphyJckSZIkqUoY8iVJkiRJqhKGfEmSJEmSqoQhX5IkSZKk\nKmHIlyRJkiSpShjyJUmSJEmqEoZ8SZIkSZKqhCFfkiRJkqQqYciXJEmSJKlKGPIlSZIkSaoShnxJ\nkiRJkqqEIV+SJEmSpCphyJckSZIkqUoY8iVJkiRJqhKGfEmSJEmSqoQhX5IkSZKkKmHIlyRJkiSp\nShjyJUmSJEmqEoZ8SZIkSZKqhCFfkiRJkqQqYciXJEmSJKlKGPIlSZIkSaoShnzp/7d372FRVfv/\nwN/b2zdUvGSkxGgQAjLAXABRNAgVL+UtLxmYlQrn/KqTWadMPaFf/Xa0TM30dDmdTmpqeSnLS492\ntNREDYmLYVhKOSAY3lJULjZcPr8/BvYBmUHUAZzx/Xqengf27LX2Gvm09vrsvfbaREREREREToJJ\nPhEREREREZGTYJJPRERERERE5CSY5DcSRVG6KoqyW1GUTEVRflQU5bnK7XcqirJTUZRjiqLsUBSl\nQ7UyMxVFyVIU5WdFUQZV2x6iKMrhys+WNsX3ISIiIiIiolsPk/zGUwrgBREJANAbwF8URfEHMAPA\nThHxBfBN5e9QFEUL4FEAWgBDALyrKIpSWdd7AOJExAeAj6IoQxr3qxAREREREdGtiEl+IxGRUyJy\nqPLnQgA/AfAAMALAR5W7fQTg4cqfRwJYKyKlIpIN4BcAvRRFcQfgKiLJlfutqlaGiIiIiIiIbmNM\n8puAoiieAIwADgLoLCKnKz86DaBz5c/3AMirViwPlosCV28/WbmdiIiIiIiIbnMtmroBtxtFUdoC\n2Ahgqohc/u8MfEBERFEUsdex5syZo/4cFRWFqKgoe1VNREREREREjWjPnj3Ys2fPNfdjkt+IFEVp\nCUuCv1pENlVuPq0oShcROVU5Ff9M5faTALpWK66B5Q7+ycqfq28/ae141ZN8IiIiIiIiclxX37id\nO3eu1f04Xb+RVC6a9yGAIyLyVrWPtgB4svLnJwFsqrY9RlGUVoqieAHwAZAsIqcAXFIUpVdlnY9X\nK0NERERERES3Md7Jbzx9AUwAkKEoSnrltpkAXgewQVGUOADZAMYBgIgcURRlA4AjAMoAPCMiVVP5\nnwGwEoALgG0i8lVjfQkiIiIiIiK6dTHJbyQisg+2Z05E2ygzH8B8K9tTAQTZr3VERERERETkDDhd\nn4iIiIiIiMhJMMknIiIiIiIichJM8omIiIiIiIicBJN8IiIiIiIiIifBJJ+IiIiIiIjISTDJJyIi\nIiIiInISTPKJiIiIiIiInASTfCIiIiIiIiInwSSfiIiIiIiIyEkwySciIiIiIiJyEkzyiYiIiIiI\niJwEk3wiIiIiIiIiJ8Ekn4iIiIiIiMhJtGjqBtDtQ1GUpm4CERERERGRU2OST41MGrh+XkggIiIi\nIqLbF6frExERERERETkJJvlEREREREREToJJPhEREREREZGTYJJPRERERERE5CSY5BMRERERERE5\nCSb5RERERERERE6CST4RERERERGRk2CST0REREREROQkmOQTEREREREROQkm+UREREREREROokVT\nN4CIiIjIWSmK0uDHEJEGPwYRETkOJvlEREREDaohk/CGv4hARESOhdP1iYiIiIiIiJwEk3wiIiIi\nIiIiJ8Ekn4iIiIiIiMhJMMknIiIiIiIichJM8omIiIiIiIicBJN8IiIiIiIiIifBJJ+IiIiIiIjI\nSTDJJyIiIiIiInISTPKJiIiIiIiInASTfCIiIiIiIiInwSSfiIiIiIiIyEkwySciIiIiIiJyEkzy\niYiIiIiIiJwEk3wiIiIiIiIiJ8Ekn4iIiIiIiMhJMMknIiIiIiIichJM8omIiIiIiIicBJN8IiIi\nIiIiIifBJJ+IiIiIiIjISTDJJyIiIiIiInISTPIbiaIoyxVFOa0oyuFq2+5UFGWnoijHFEXZoShK\nh2qfzVQUJUtRlJ8VRRlUbXuIoiiHKz9b2tjfg4iIiIiIiG5dTPIbzwoAQ67aNgPAThHxBfBN5e9Q\nFEUL4FEA2soy7yqKolSWeQ9AnIj4APBRFOXqOomIiIiIiOg2xSS/kYhIIoALV20eAeCjyp8/AvBw\n5c8jAawVkVIRyQbwC4BeiqK4A3AVkeTK/VZVK0NERERERES3OSb5TauziJyu/Pk0gM6VP98DIK/a\nfnkAPKxsP1m5nYiIiIiIiAgtmroBZCEioiiK2LPOOXPmqD9HRUUhKirKntUTERERERFRI9mzZw/2\n7Nlzzf2Y5Det04qidBGRU5VT8c9Ubj8JoGu1/TSw3ME/Wflz9e0nbVVePcknIiIiIiIix3X1jdu5\nc+da3Y/T9ZvWFgBPVv78JIBN1bbHKIrSSlEULwA+AJJF5BSAS4qi9KpciO/xamWIiIiIiIjoNsc7\n+Y1EUZS1AB4AcJeiKLkAZgN4HcAGRVHiAGQDGAcAInJEUZQNAI4AKAPwjIhUTeV/BsBKAC4AtonI\nV435PYiIiIiIiOjWxSS/kYhIrI2Pom3sPx/AfCvbUwEE2bFpRERERERE5CQ4XZ+IiIiIiIjISTDJ\nJyIiIiIiInISTPKJiIiIiIiInASTfCIiIiIiIiInwSSfiIiIiIiIyEkwySciIiIiIiJyEkzyiYiI\niIiIiJwEk3wiIiIiIiIiJ8Ekn4iIiIiIiMhJMMknIiIiIiIichItmroBRERERHTrUhSlUY4jIo1y\nHCIiZ8ckn4iIiIjq1NDpd+NcRiAiuj1wuj4RERERERGRk2CST0REREREROQkmOQTEREREREROQkm\n+UREREREREROgkk+ERERERERkZNgkk9ERERERETkJPgKPSIiIifCd5oTERHd3pjkExERORm+05yI\niOj2xen6RERERERERE6Cd/KJiIgqcao7EREROTom+URERDVwsjsRERE5Lk7XJyIiIiIiInISTPKJ\niIiIiIiInASn6xMRETWyxnr2n4iIiG4/TPKJiIga2xwHrZuIiIhueZyuT0REREREROQkmOQTERER\nEREROQkm+UREREREREROgs/kE5HDaqzFy0Qa+r3pRERERET2wSSfiBxcQyfgXAWdiIiIiBwHp+sT\nEREREREROQkm+UREREREREROgtP1iYiIiBxYY61PQkREjoFJPhFRE2uMAToXDyRyYnMcvH4iIrIr\nJvlERNfQKEl4A9bNe3xEREREtw8m+URE1zLHwesnIiIiotsGF94jIiIiIiIichJM8omIiIiIiIic\nBKfrExERERFRo2msN0Jw0Vm6XTHJJyIiIiJyAM6UHDf0EbjoLN3OmOQTERERETkMpsdEVDc+k09E\nRERERETkJJjkExERERERETkJTtcnIiIiIiJVYz37T0QNg0k+ERERERH91xwHr5/oNsfp+g5KUZQh\niqL8rChKlqIo05u6PURERERERNT0mOQ7IEVRmgN4G8AQAFoAsYqi+Ddtq4iIiIiIiKipMcl3TGEA\nfneFAAUAACAASURBVBGRbBEpBbAOwMgmbhMRERERERE1MSb5jskDQG613/MqtxEREREREdFtTBGR\npm4DXSdFUcYAGCIif6r8fQKAXiIypdo+/MMSERERERE5MRGp9ToMrq7vmE4C6Frt966w3M2vgRdw\nyJ4URWFMkV0xpsieGE9kb4wpsjfGFNmbrdddcrq+Y0oB4KMoiqeiKK0APApgSxO3yeF89dVX6NGj\nB3x8fLBgwYKmbg45uMmTJ6Nz584ICgpq6qaQk8jNzUW/fv0QEBCAwMBALFu2rKmbRA7sypUr6NWr\nFwwGA7RaLWbOnNnUTSInUV5eDqPRiOHDhzd1U8gJeHp6QqfTwWg0IiwsrKmb47A4Xd9BKYryIIC3\nADQH8KGIvHbV58K/rW3l5eXw8/PD119/DQ8PD/Ts2RNr166Fvz9fUmALrz7XLTExEW3btsUTTzyB\nw4cPN3VzHAJjqm6nTp3CqVOnYDAYUFhYiJCQEGzatIn9lA2Mp2srLi5G69atUVZWhvvvvx+LFi3C\n/fff39TNumUxpurnzTffRGpqKi5fvowtW3jPqS6MqWvz8vJCamoq7rzzzqZuikOojKlat/N5J99B\nich2EfETke5XJ/h0bcnJyejevTs8PT3RsmVLxMTEYPPmzU3dLHJgERER6NixY1M3g5xIly5dYDAY\nAABt27aFv78/fvvttyZuFTmy1q1bAwDMZjPKy8s5iKablpeXh23btiE+Pp7JK9kNY+nmMcmn29LJ\nkyfRtet/lzXQaDQ4efJkE7aIiMi27OxspKeno1evXk3dFHJgFRUVMBgM6Ny5M/r16wetVtvUTSIH\n98ILL2DhwoVo1owpBdmHoiiIjo5GaGgoPvjgg6ZujsPi/5F0W7K1SAUR0a2msLAQY8eOxdKlS9G2\nbdumbg45sGbNmuHQoUPIy8vD3r17sWfPnqZuEjmwL7/8EnfffTeMRiPvvJLd7N+/H+np6di+fTve\neecdJCYmNnWTHBKTfLoteXh4IDc3V/09NzcXGo2mCVtERFRbaWkpxowZgwkTJuDhhx9u6uaQk2jf\nvj2GDh2KlJSUpm4KObADBw5gy5Yt8PLyQmxsLHbt2oUnnniiqZtFDs7d3R0A4ObmhlGjRiE5ObmJ\nW+SYmOTTbSk0NBRZWVnIzs6G2WzG+vXrMWLEiKZuFhGRSkQQFxcHrVaL559/vqmbQw7u3LlzKCgo\nAACUlJRg586dMBqNTdwqcmTz589Hbm4uTCYT1q1bh/79+2PVqlVN3SxyYMXFxbh8+TIAoKioCDt2\n7OBbi24Qk3y6LbVo0QJvv/02Bg8eDK1Wi0cffZQrVtNNiY2NRZ8+fXDs2DF07doVK1asaOomkYPb\nv38/1qxZg927d8NoNMJoNOKrr75q6maRg8rPz0f//v1hMBjQq1cvDB8+HAMGDGjqZpET4aOQdLNO\nnz6NiIgItZ8aNmwYBg0a1NTNckh8hZ6T4iv0yN742heyN8YU2RPjieyNMUX2xpgie+Mr9IiIiIiI\niIicXJ138hVF4aUmIiIiIiIioluQtTv5LepRqGFaQw2K04HI3hhTZG+MKbInxhPZG2OK7I0xRfZm\nay2MBpuuP2fOHCxevLihqre7nJwcrF279obLX8+7i6dNm4bAwEBMnz7d5j5bt27FggULbrg9dGuZ\nPHkyOnfuXGuF0H/84x/w9/dHYGAgZsyYAQD4+OOP1UW2jEYjmjdvjoyMDACA2WzGn//8Z/j5+cHf\n3x+ff/65zWOeOHECbdu2daj/D6n+rly5gl69esFgMECr1WLmzJkAgOTkZISFhcFoNKJnz574/vvv\n1TKvvfYafHx80KNHD+zYscNqvdOmTYO/vz/0ej1Gjx6Nixcv1viccXX78vT0hE6ng9FoRFhYGABg\n1qxZ0Ov1MBgMGDBgQI1Xk9oj3sgx2DrHAcDixYvRrFkznD9/Xt2WkZGB8PBwBAYGQqfTwWw2AwBe\neeUVdOvWDa6urjaPtXPnToSGhkKn0yE0NBS7d++utc+IESO4IvdtxloMxsTEqGMpLy+vGm+TqE//\nBNQcp9U1bqdbX0FBAcaOHQt/f39otVokJSVhzpw50Gg0tRa3TU5OVrfpdDqsX78egGX1/6FDh6ox\nUTX2utqVK1cQGxsLnU4HrVaL119/Xf3sesbyN0VEbP5n+fjGzJkzRxYtWnTD5Rvb7t27ZdiwYTdc\nvm3btvXet3379lJRUXFDxykrK6vXfjfztyP727t3r6SlpUlgYKC6bdeuXRIdHS1ms1lERM6cOVOr\n3OHDh6V79+7q77Nnz5ZZs2apv587d87mMceMGSPjxo2z2/+HjKlbT1FRkYiIlJaWSq9evSQxMVGi\noqLkq6++EhGRbdu2SVRUlIiIZGZmil6vF7PZLCaTSby9vaW8vLxWnTt27FC3T58+XaZPn17jc3vG\nFWPKsXh6esrvv/9eY9ulS5fUn5ctWyZxcXEiYr94ux6Mp6Zj7RwnInLixAkZPHhwjdgpLS0VnU4n\nGRkZIiJy/vx5NQYOHjwo+fn5dY6p0tPTJT8/X0REfvzxR/Hw8Kjx+caNG2X8+PESFBR009+LMeU4\nbMVglRdffFFeffVVEal//1Sfcdr1Ykw1nSeeeEI+/PBDEbH0QwUFBTJnzhxZvHhxrX2Li4vVmMjP\nz5dOnTpJWVmZFBcXy549e0RExGw2S0REhGzfvr1W+RUrVkhMTIxal6enp+Tk5IjI9Y3l66Mypmrl\n8Xa9kz9v3jz4+fkhIiICR48eBQD8+uuvePDBBxEaGorIyEh1u8lkQnh4OHQ6HRISEtSrtnv27MHw\n4cPVOp999ll89NFHAIDU1FRERUUhNDQUQ4YMwalTpwAAUVFRSE1NBWB5D6yXlxcAoLy8HNOmTUNY\nWBj0ej3+9a9/2Wz7jBkzkJiYCKPRiKVLlyInJweRkZEICQlBSEgIvvvuOwCWV9BERkbCaDQiKCgI\n+/fvr1HPuXPn0KdPH2zfvt3qcUaMGIHCwkIEBwdjw4YN+PLLL9G7d28EBwdj4MCBOHPmDABg5cqV\nmDJlCgBg4sSJeOqpp9C7d29eRXRQERER6NixY41t7733HmbOnImWLVsCANzc3GqV++STTxATE6P+\nvmLFihpXDTt16mT1eJs2bcJ9990HrVZrj+bTLap169YALFeFy8vL0bFjR3Tp0kW9G1pQUAAPDw8A\nwObNmxEbG4uWLVvC09MT3bt3R3Jycq06Bw4ciGbNLKeGXr16IS8vT/2McUVy1TTT6ndcCwsLcddd\ndwGwT7yR47B2jgOAv/71r3jjjTdqbNuxYwd0Op16x7Vjx45qDISFhaFLly51HstgMKj7aLValJSU\noLS0FIAlBpcsWYKEhAROib7N2IpBwNJvbdiwAbGxsQDq3z/VZ5xGjuHixYtITEzE5MmTAVhepd2+\nfXsA1h9Nd3FxUfulkpIStG/fHs2bN4eLiwseeOABAEDLli0RHByMkydP1irv7u6OoqIilJeXo6io\nCK1atUK7du0A1H8sf7PsluSnpqZi/fr1+OGHH7Bt2zZ1iuj/+3//D//4xz+QkpKChQsX4plnngEA\nTJ06FX/5y1+QkZGBe+65x2a9iqJAURSUlpZiypQp2LhxI1JSUjBp0iS88sorNfa52ocffogOHTog\nOTkZycnJ+OCDD5CdnW31OAsWLEBERATS09MxdepU3H333di5cydSU1Oxbt06PPfccwAsSdeQIUOQ\nnp6OH374AXq9Xq3jzJkzGDZsGF599VU8+OCDVo+zZcsWuLi4ID09HePGjcP999+PpKQkpKWl4dFH\nH1VPhld/n99++w3fffcdFi1aZPPfihxLVlYW9u7di969eyMqKgopKSm19ql+UiooKAAAJCQkICQk\nBOPGjVMvClVXWFiIN954A3PmzGnQ9lPTq6iogMFgQOfOndGvXz8EBATg9ddfx4svvohu3bph2rRp\neO211wBY+hCNRqOW1Wg0Vk9M1S1fvhwPPfQQAMYVWc5L0dHRCA0NxQcffKBur5pivXLlSnXgcrPx\nRo5v8+bN0Gg00Ol0NbZnZWVBURQMGTIEISEhWLhw4Q0fY+PGjQgJCVGTsFmzZuGll15SL4ASAUBi\nYiI6d+4Mb29vAPXvn+ozTiPHYDKZ4ObmhkmTJiE4OBh/+tOfUFxcDMDySIZer0dcXJw61gYsU/YD\nAgIQEBCAN998s1adBQUF2Lp1KwYMGFDrs8GDB6Ndu3Zwd3eHp6cnpk2bhg4dOtR7LG8PdkvyExMT\nMXr0aNxxxx1wdXXFiBEjcOXKFRw4cACPPPIIjEYjnnrqKfXu+4EDB9TkZcKECXXWLSI4evQoMjMz\nER0dDaPRiHnz5l1zwLBjxw6sWrUKRqMRvXv3xvnz5/HLL7/YPEZ1ZrMZ8fHx0Ol0GDduHH766ScA\nlqvMK1aswNy5c3H48GH1WXyz2YwBAwZg4cKFVv/YtuTm5mLQoEHQ6XRYtGgRjhw5Uqs9iqLgkUce\nsbmwAjmmsrIyXLhwAUlJSVi4cCHGjRtX4/ODBw+idevW6l3TsrIy5OXloW/fvkhNTUV4eDheeuml\nWvXOmTMHL7zwAlq3bs07GU6uWbNmOHToEPLy8rB3717s2bMHcXFxWLZsGU6cOIElS5aoV62tqatP\nmTdvHlq1aoXx48cDYFwRsH//fqSnp2P79u145513kJiYCMASKydOnMCkSZPw/PPP2yx/PfFGjq24\nuBjz58/H3Llz1W1V/UZpaSn27duHTz75BPv27cMXX3yBXbt2XfcxMjMzMWPGDLz//vsAgEOHDuH4\n8eMYOXIk+yiqYe3atdfsW6z1T9cap5HjKCsrQ1paGp555hmkpaWhTZs2eP311/HMM8/AZDLh0KFD\ncHd3x4svvqiWCQsLQ2ZmJtLS0jB16tQaa8aUlZUhNjYWU6dOhaenZ63jrVmzBiUlJcjPz4fJZMKi\nRYuQnZ1d77G8Pdgtybe2WmRFRQU6dOiA9PR09b/MzMw662nRogUqKirU369cuaL+HBAQoNaTkZGh\nLo5QvUz1/QHg7bffVsv8+uuviI6Ortf3WbJkCdzd3ZGRkYGUlBT88ccfACzTgRITE+Hh4YGJEydi\n9erVACxTNkJDQ9U21deUKVPw3HPPISMjA++//z5KSkqs7ser0s5Ho9Fg9OjRAICePXuiWbNm+P33\n39XP161bV+Ok1KlTJ7Ru3VotM3bsWKSlpdWqNzk5GS+//DK8vLywdOlSzJ8/H++++24DfxtqSu3b\nt8fQoUORkpKC5ORkjBo1CoAlRqqmIHp4eNRYFC0vL0+dyn+1lStXYtu2bfj444/VbYwrcnd3B2CZ\nsjpq1Kha01vHjx+vzuK72Xgjx/brr78iOzsber0eXl5eyMvLQ0hICE6fPo2uXbsiMjISd955J1xc\nXPDQQw9ZPZfVJS8vD6NHj8bq1avVRzSTkpKQkpICLy8vRERE4NixY+jfv39DfD1yIGVlZfjiiy/w\n6KOPqtvq2z9da5xGjkOj0UCj0aBnz54A/juGdnNzU2eEx8fHW31so0ePHvD29q5xo7hq4byqmd5X\nO3DgAEaNGoXmzZvDzc0Nffv2RUpKSr3H8vZgtyQ/MjISmzZtwpUrV3D58mVs3boVrVu3hpeXFz77\n7DMAlqu4VauE9+3bF+vWrQOAGif2e++9F0eOHIHZbEZBQQG++eYbKIoCPz8/nD17FklJSQAsV4Kr\n7np7enqqU2iqjgVYpkq8++67KCsrAwAcO3ZMnZpxtXbt2uHy5cvq75cuXVKf+Vq1ahXKy8sBWFaW\ndnNzQ3x8POLi4pCeng7AcpFj+fLl+Pnnn2s9f1aXS5cuqY8rrFy5st7lyPE9/PDD6t2LY8eOwWw2\nq8/lVFRU4NNPP63xPL6iKBg+fLi6kvA333yDgICAWvXu3bsXJpMJJpMJzz//PF555RX1MRlyHufO\nnVOnfZWUlGDnzp0wGAzo3r07vv32WwDArl274OvrC8CyHsi6detgNpthMpmQlZWlrpBe3VdffYWF\nCxdi8+bNuOOOO9TtjKvbW3FxsXqOLCoqwo4dOxAUFFRj0LN582Z19eqbjTdybEFBQTh9+rTaZ2g0\nGqSlpaFz584YPHgwDh8+jJKSEpSVleHbb7+1ei6zpaCgAEOHDsWCBQsQHh6ubn/qqadw8uRJmEwm\n7Nu3D76+vjc0Q4Ccy9dffw1/f/8ajwbXt3+qa5xGjqVLly7o2rUrjh07BsASFwEBAeoMcwD44osv\n1LVCqu66A5Y3sGVlZcHHxweAZar9pUuXsGTJEpvH69Gjhxo7RUVFSEpKQo8ePeo9lrcLa6vxyQ2u\nrj9v3jzx9fWV+++/Xx577DFZvHixmEwmGTJkiOj1etFqterKliaTScLDwyUoKEgSEhJqrKT68ssv\ni4+PjwwaNEjGjBkjH330kYiIHDp0SCIjI0Wv10tAQID8+9//FhGRn3/+WXQ6nRiNRklISBAvLy8R\nEamoqJC//e1vEhQUJIGBgdK/f3+5ePGi1baXlpZK//79Ra/Xy1tvvSVZWVmi0+lEr9fL9OnTxdXV\nVUREVq5cKYGBgWI0GiUyMlKys7NFRNTP//jjDxk8eLC89957Nv+dqvYVEdm8ebPcd999EhISItOm\nTZN+/fqpx5kyZYqIiEycOFE2btx4XX+L6/3bUcOKiYkRd3d3adWqlWg0Glm+fLmYzWaZMGGCBAYG\nSnBwsOzevVvdf/fu3RIeHl6rnpycHImMjBSdTifR0dGSm5srIiJbtmyR2bNn19rf1qqhN4IxdWvJ\nyMgQo9Eoer1egoKC5I033hARke+//17CwsJEr9dL7969JS0tTS0zb9488fb2Fj8/P3UFfhGR+Ph4\nSU1NFRGR7t27S7du3cRgMIjBYJCnn3661rHtFVeMKcdx/Phx0ev16vl3/vz5ImJ520JgYKDo9XoZ\nPXq0nD59Wi1jr3irL8ZT07F2jqvOy8urxpsZ1qxZIwEBARIYGFjjjQrTpk0TjUYjzZs3F41GI3Pn\nzhWRmue4V199Vdq0aaPGjMFgkLNnz9Y4nslk4ur6txlbMThx4kR5//33a+1fV/+UkpIiIlLnOO1G\nMaaazqFDhyQ0NFR0Op2MGjVKLly4II8//rgEBQWJTqeTkSNHyqlTp0REZPXq1RIQECAGg0F69uyp\nrqCfm5sriqKIVqtV+5+qFfur91NXrlyRxx57TAIDA0Wr1dZ4I5GtsfyNgo3V9RWp47klRVGkrs/t\nydXVtcaddLo51h6fILoZjCmyN8YU2RPjieyNMUX2xpgie6uMqVqLStj1FXo3g4vKEREREREREd2c\na97Jb8S2EBEREREREVE9WbuT36IehRqmNdSgOB2I7I0xRfbGmCJ7YjyRvTGmyN4YU2RvtmbD3zLT\n9ZtaTk4O1q5de8Pl27ZtW+99p02bhsDAQEyfPt3mPlu3bsWCBQtuuD3UNHJzc9GvXz8EBAQgMDAQ\ny5YtUz/7xz/+AX9//1p/+9deew0+Pj7o0aMHduzYoW5/5ZVX0K1bN7i6uto83pUrVxAbGwudTget\nVovXX38dgGUl7KFDh6rHmzlzZgN8W7oV2YrBOXPmQKPRwGg0wmg0qq/7/Pjjj9VtRqMRzZs3V9+C\nUl1ycjLCwsJgNBrRs2dP9VVp5HzKy8thNBoxfPhwdZu1/is7OxsuLi5q7NT1tgVr5Xfu3InQ0FDo\ndDqEhoaqqw2T87DVH/3www8IDw+HTqfDiBEj1DWZkpOT1XjS6XRYv3691Xpt9UeMKec3efJkdO7c\nWV0FHQDOnz+PgQMHwtfXF4MGDVLfPFPfeLB1fmQ8OZeCggKMHTsW/v7+0Gq1OHjwoM3YAWyPz9ev\nXw+9Xo/AwEDMmDHD5vEyMjIQHh6OwMBA6HQ6mM3mxh2fW1uNr+o/3EYrQO7evVuGDRt2w+Wrvx3g\nWtq3by8VFRU3dJyysrJ67Xc7/e1uJfn5+ZKeni4iIpcvXxZfX185cuSI7Nq1S6Kjo8VsNouIyJkz\nZ0REJDMzU/R6vZjNZjGZTOLt7a3GxsGDByU/P7/O2FqxYoXExMSIiEhxcbF4enpKTk6OFBcXy549\ne0TEsjpsRESEujLojWJMOQZbMVifFfEPHz4s3bt3t/rZAw88oK5AvG3bNomKirrptjKmbk2LFy+W\n8ePHy/Dhw0VEbPZfJpNJAgMDr1mfrfLp6emSn58vIiI//vijeHh43FS7GU+3Hlv9UWhoqOzdu1dE\nRJYvXy6zZs0SEct5rLy8XC3bqVMnq+MeW/0RY8r57d27V9LS0mr0PdOmTZMFCxaIiMjrr7+uvrGh\nvvFg6/xo73gSYUw1pSeeeEJdCb+0tFQKCgpsxo6t8fm5c+ekW7ducu7cORERefLJJ+Wbb76pdazS\n0lLR6XSSkZEhIiLnz5+X8vLyhhyf18rj7Xonf82aNejVqxeMRiOeeuoplJeXo23btkhISIDBYEB4\neDjOnDkDADCZTOpV3ISEBPVu5Z49e2rcPXj22Wfx0UcfAQBSU1MRFRWF0NBQDBkyRH23YVRUFFJT\nUwFY3h3t5eUFwHI3Ytq0aQgLC4Ner8e//vUvm22fMWMGEhMTYTQasXTpUuTk5CAyMhIhISEICQnB\nd999BwDIz89HZGQkjEYjgoKCsH///hr1nDt3Dn369MH27dutHmfEiBEoLCxEcHAwNmzYgC+//BK9\ne/dGcHAwBg4cqP77rFy5ElOmTAEATJw4EU899RR69+5d591/anpdunSBwWAAYJnd4e/vj5MnT+Kf\n//wnZs6ciZYtWwIA3NzcAFjeKx0bG4uWLVvC09MT3bt3x8GDBwEAYWFh6NKlS53Hc3d3R1FREcrL\ny1FUVIRWrVqhXbt2cHFxwQMPPAAAaNmyJYKDg3Hy5MmG+tp0C7EVg8C1H7/65JNPEBMTY/Uzd3d3\nXLx4EYDlariHh4cdW023iry8PGzbtg3x8fFqvLz33ntW+6/6slXeYDCofZxWq0VJSQlKS0vt9VXo\nFmCrP8rKykJERAQAIDo6Ghs3bgQAuLi4oFkzy9C0pKQE7du3R/PmzWvVa6s/Ykw5v4iICHTs2LHG\nti1btuDJJ58EADz55JPYtGkTgOuLB2vnR8aT87h48SISExMxefJkAECLFi3Qvn17m7Fja3x+/Phx\n+Pj4oFOnTgCAAQMGqP1XdTt27IBOp1NnnHTs2BHNmjVr1PG53ZL8n376CRs2bMCBAweQnp6O5s2b\n4+OPP0ZxcTHCw8Nx6NAhREZG4oMPPgAATJ06FX/5y1+QkZGBe+65x2a9iqJAURSUlpZiypQp2Lhx\nI1JSUjBp0iS88sorNfa52ocffogOHTogOTkZycnJ+OCDD5CdnW31OAsWLEBERATS09MxdepU3H33\n3di5cydSU1Oxbt06PPfccwAsg+AhQ4YgPT0dP/zwA/R6vVrHmTNnMGzYMLz66qt48MEHrR5ny5Yt\ncHFxQXp6OsaNG4f7778fSUlJSEtLw6OPPoo33nhD/U7V/fbbb/juu++waNEim/9WdGvJzs5Geno6\nevXqhWPHjmHv3r3o3bs3oqKikJKSAsDyd9VoNGoZjUZzXf+zDx48GO3atYO7uzs8PT0xbdo0dOjQ\nocY+BQUF2Lp1KwYMGGCfL0YOoyoGe/fuDcAyZVqv1yMuLq7GlLQqGzZsQGxsrNW6Xn/9dbz44ovo\n1q0bpk2bhtdee61B205N44UXXsDChQvVRAsAsrKyrPZfgOWCvdFoRFRUFPbt22e1zrrKV9m4cSNC\nQkLUCwHkfKqfEwMCArB582YAwKefforc3Fx1v+TkZAQEBCAgIABvvvmm1brq0x8xpm4fp0+fRufO\nnQEAnTt3xunTp2vtc614uNb5kfHk2EwmE9zc3DBp0iQEBwfjT3/6E4qKimzGjrXx+W+//QYfHx8c\nPXoUOTk5KCsrw6ZNm2r0X1WysrKgKAqGDBmCkJAQLFy4sNY+DT0+t1uS/8033yA1NRWhoaEwGo3Y\ntWsXTCYTWrVqhaFDhwIAQkJC1CT7wIED6mBywoQJddYtIjh69CgyMzMRHR0No9GIefPmXTMZ2rFj\nB1atWgWj0YjevXvj/Pnz+OWXX2weozqz2Yz4+HjodDqMGzcOP/30EwDL3dUVK1Zg7ty5OHz4sPos\nvtlsxoABA7Bw4cLr+mPl5uZi0KBB0Ol0WLRoEY4cOVKrPYqi4JFHHuFrBh1IYWEhxo4di6VLl8LV\n1RVlZWW4cOECkpKSsHDhQowbN85m2ev5O69ZswYlJSXIz8+HyWTCokWLYDKZ1M/LysoQGxuLqVOn\nwtPT82a+EjmY6jHYtm1bPP300zCZTDh06BDc3d3x4osv1tj/4MGDaN26NbRardX64uLisGzZMpw4\ncQJLlixRr4aT8/jyyy9x9913w2g01jgH2eq/7rnnHuTm5iI9PR1vvvkmxo8frz5bXd21+r/MzEzM\nmDED77//fsN+QWoyV58Tly9fjnfffRehoaEoLCxEq1at1H3DwsKQmZmJtLQ0TJ06Vb1jX921+iPG\n1O3L2o2/a8XDtc6PjCfHV1ZWhrS0NDzzzDNIS0tDmzZt1HWsqti6aVxdhw4d8N577+HRRx9FZGQk\nvLy8rM42Ki0txb59+/DJJ59g3759+OKLL7Br164a7Wno8bldp+s/+eSTSE9PR3p6On766Sf87//+\nb40rXs2aNUNZWVmddbRo0QIVFRXq71euXFF/DggIUOvPyMhQF8aoXqb6/gDw9ttvq2V+/fVXREdH\n1+u7LFmyBO7u7sjIyEBKSgr++OMPAJZpQomJifDw8MDEiROxevVqAJYpF6GhoWqb6mvKlCl47rnn\nkJGRgffffx8lJSVW92vduvV11UtNp7S0FGPGjMGECRPw8MMPA7BcARw9ejQAoGfPnmjWrBnOnTsH\nDw+PGlcA8/Lyrmsa9IEDBzBq1Cg0b94cbm5u6Nu3b427ZH/+85/h5+enzkSh24O1GLz77rvV/YMT\nUAAAFMFJREFUE1h8fDySk5NrlFm3bh3Gjx9vs87k5GSMGjUKADB27Nha5cnxHThwAFu2bIGXlxdi\nY2Oxa9cuPP7441b7r99//x2tWrVSp80GBwfD29sbWVlZteq1VR6w9HmjR4/G6tWr1UftyLlY64/8\n/Pzwn//8BykpKYiJiYG3t3etcj169IC3t7fVmzN19UeMqdtP586d1Ud48/Pzcffdd6uf1Sce6jo/\nMp6cg0ajgUajQc+ePQFY+o20tDR06dLFauzUNT4fNmwYkpKScODAAfj6+sLPz6/W8bp27YrIyEjc\neeedcHFxwUMPPYS0tDT188YYn9styR8wYAA+++wznD17FoBlpcucnByb+/ft2xfr1q0DYFnducq9\n996LI0eOwGw2o6CgAN988w0URYGfnx/Onj2LpKQkAJaTRtVdb09PTzWx+eyzz9S6Bg8ejHfffVe9\nsHDs2DEUFxdbbU+7du1q3IG4dOmS+hzOqlWrUF5eDgA4ceIE3NzcEB8fj7i4OKSnpwOwXP1Zvnw5\nfv75Z3XKfX1cunRJfVxh5cqV9S5HtyYRQVxcHLRaLZ5//nl1+8MPP6xewTt27BjMZjPuuusujBgx\nAuvWrYPZbIbJZEJWVhbCwsLqfbwePXqo9RYVFSEpKQn+/v4AgISEBFy6dAlLliyx4zekW52tGMzP\nz1d//uKLL2qsTFxRUYFPP/3U5vP4ANC9e3d8++23AIBdu3bB19e3AVpPTWn+/PnIzc2FyWTCunXr\n0L9/f6xevdpq/9WpUyecO3dOPTceP34cWVlZuO+++2rVa6t8QUEBhg4digULFiA8PLzxvig1Glv9\nUdVYsaKiAn//+9/x9NNPA7BM6a8as+Xk5CArKws+Pj616rXVHzGmbk8jRoxQ1+/66KOP1ItJ9Y0H\nW+dHxpPz6NKlC7p27Ypjx44BAL7++msEBARg+PDhVmOnrvF51fppFy5cwHvvvYf4+Phaxxs8eDAO\nHz6MkpISlJWV4dtvv0VAQACARhyfW1uNT25wdf3169eLwWAQnU4noaGhkpSUJK6ururnn332mUya\nNElELKvyhoeHS1BQkCQkJNRYQfzll18WHx8fGTRokIwZM0Y++ugjERE5dOiQREZGil6vl4CAAPn3\nv/8tIiI///yz6HQ6MRqNkpCQIF5eXiIiUlFRIX/7298kKChIAgMDpX///nLx4kWrbS8tLZX+/fuL\nXq+Xt956S7KyskSn04ler5fp06er32PlypUSGBgoRqNRIiMjJTs7W0RE/fyPP/6QwYMHy3vvvWfz\n36n6v8nmzZvlvvvuk5CQEJk2bZr069dPPc6UKVNERGTixImycePG+v4ZRISrdzaVxMREURRF9Hq9\nGAwGMRgMsn37djGbzTJhwgQJDAyU4OBg2b17t1pm3rx54u3tLX5+fupqwSKW1WI1Go00b95cNBqN\nzJ07V0REtmzZIrNnzxYRkStXrshjjz0mgYGBotVqZdGiRSIikpubK4qiiFarVdtRtaLojWJMOQZr\nMbht2zZ5/PHHJSgoSHQ6nYwcOVJOnTqlltm9e7eEh4fXqis+Pl5SUlJEROT777+XsLAw0ev10rt3\nb0lLS7vptjKmbl179uxRV9e31X9t3LhRAgICxGAwSHBwsHz55Zdq+eqxY6v8q6++Km3atFHj1GAw\nyNmzZ2+4zYynW4+t/mjp0qXi6+srvr6+MnPmTHX/1atXqzHVs2fPGqtO16c/Ykw5v5iYGHF3d5eW\nLVuKRqOR5cuXy++//y4DBgwQHx8fGThwoFy4cEFE6o6H+Ph4SU1NFRGxeX60dzyJMKaa0qFDhyQ0\nNFR0Op2MGjVKCgoKbMaOiO3xeWxsrGi1WtFqtbJ+/Xp1e/XxuYjImjVrJCAgQAIDA9VV+xtwfF4r\nj1ekjtWWFUWRuj63J1dXV6vP8tGNURTlmitpE10PxhTZG2OK7InxRPbGmCJ7Y0yRvVXGVK3FBOz6\nTP7N4KJyRERERERERDfnmnfyG7EtRERERERERFRP1u7kt6hHoYZpDTUoTgcie2NMkb0xpsieGE9k\nb4wpsjfGFNmbrdnwTTJdf+LEidi4ceN1l8vJycHatWvr3OeHH37A9u3bb6hd2dnZNVacbkiffvop\ntFotBgwYYHOf3377DY888kijtIfs4+jRozAajep/7du3x7Jly/DDDz8gPDwcOp0OI0aMqLH+xGuv\nvQYfHx/06NEDO3bsULebzWb1FRv+/v74/PPPax0vOTlZPZZOp8P69esBAMXFxRg6dCj8/f0RGBiI\nmTNnNvyXp1tCbm4u+vXrh4CAAAQGBmLZsmUALLESFhYGo9GInj174vvvvwdgee1obGwsdDodtFpt\nrffGVrFVnm4Pnp6e0Ol0MBqN6grDtmLCVr90tbr6RXIO1s6JS5cuxezZs6HX62EwGDBgwAD1VVU7\nd+5EaGgodDodQkNDsXv3bqv1fvrppwgICEDz5s2Rmpqqbq9veXI+kydPRufOnWuM4231MefPn0e/\nfv3g6uqKKVOm2KyzepxVf/0ZOSZr57FZs2ZZ7YvqGhvVZ3wO2B7fVxkxYkTD5p3WVuOr+g8NtALk\njawWL2JZAXrYsGF17rNixQp59tlnb6hdJpNJAgMDr7tcaWnpdZcZPHiw7N+//7rL1fd4DfW3o/or\nLy+XLl26SE5OjoSGhsrevXtFRGT58uUya9YsERHJzMwUvV4vZrNZTCaTeHt7S0VFhYiIzJ49W91P\nROTcuXO1jlFcXCzl5eUiIpKfny+dOnWSsrIyKS4ulj179oiIZWXriIiIGqsU3wjGlGPIz8+X9PR0\nERG5fPmy+Pr6ypEjR+SBBx5QV4fdtm2bREVFiYilz4yJiRERSzx5enpKTk5OrXptlb8ZjCnH4enp\nKb///nuNbbZiwla/dDVb/eKNYjzd2qrOiSdOnJBLly6p25ctWyZxcXEiIpKeni75+fkiIvLjjz+K\nh4eH1bp++uknOXr0qERFRakrpF9P+fpiTDmOvXv3SlpaWo1xvK0+pqioSPbt2yf//Oc/68wZbMXZ\nzWBMNR1r5zFbfVFdY6P6jM+tje+rzosilrfTjB8/XoKCgm76e8HG6vp2u5NfVFSEoUOHwmAwICgo\nCBs2bEBqaiqioqIQGhqKIUOG4NSpUzUuLgCwuc8vv/yC6OhoGAwGhIaG4vjx45gxYwYSExNhNBqx\ndOnSWm0wm82YPXs21q9fD6PRiA0bNuD7779Hnz59EBwcjL59+6rvR8zMzESvXr1gNBqh1+vx66+/\n1qjr+PHjCA4OrnGFuLqVK1dixIgRGDBgAAYOHIgrV64gJiYGWq0Wo0ePRu/evW2W/b//+z/s378f\nkydPxssvv4ycnBxERkYiJCQEISEh+O677wDUnFlw9fHo1vf111+je/fu6NatG7KyshAREQEAiI6O\nVmeybN68GbGxsWjZsiU8PT3RvXt3JCcnAwBWrFhR4w58p06dah3DxcUFzZpZ/jcuKSlB+/bt0bx5\nc7i4uOCBBx4AALRs2RLBwcE4efJkg35fujV06dIFBoMBANC2bVv4+/vj5MmTcHd3x8WLFwFY3v3r\n4eEBAHB3d0dRURHKy8tRVFSEVq1aoV27drXqtVWebh9y1RRTWzFhq1+6mq1+kZzT119/DW9vb3Tt\n2hWurq7q9sLCQtx1110AAIPBgC5dugAAtFotSkpKUFpaWquuHj16wNfXt9b2+pYn5xMREYGOHTvW\n2Garj2ndujX69u2L//mf/6mzTltxRo7r6vOYrb6orrFRfcbndY3vCwsLsWTJEiQkJDTsoxvWMn+5\ngTv5n332mfzpT39Sf7948aL06dNHvbqxbt06mTx5soj8906+2WyW8PBwq/uEhYXJpk2bRMTy7vmq\nO5PXupNf/f3yIpYrNFV3EHbu3CljxowREZFnn31WPv74YxGx3BkvKSlR7+T//PPPYjQaJSMjw+Zx\nVqxYIRqNRn2f4uLFi9WrPxkZGdKiRYs6r/pVvypYXFwsV65cERGRY8eOSWhoqIjUnFlw9fGu5Xr+\ndtQwJk2aJO+8846IiPTp00eN58WLF4urq6uIWOJwzZo1apm4uDjZuHGjXLhwQbp27Sp//etfJTg4\nWB555BE5ffq01eMcPHhQtFqtuLi4qMeo7sKFC3LfffeJyWS6qe/DmHI8JpNJunXrJpcvX5bs7GzR\naDTStWtX8fDwqHG3/rHHHhM3Nzdp06aNfPDBB1brurr8iRMnbrp9jCnH4eXlJQaDQUJCQuRf//qX\niNSOieoxda1+ScR2v3ijGE+3turnRBGRv/3tb9K1a1fx8/OzOrb59NNPZeDAgXXWWdcd1vqUvxbG\nlGO5ekbutfqYlStX1mv2L+/kOwdr5zER232RtbFRfcfntsb3IiLPP/+8bNq0SbKzs29oBvnV0NB3\n8nU6HXbu3IkZM2Zg3759OHHiBH788UdER0fDaDRi3rx5Ne4kigiOHj2KzMzMWvsUFhbit99+w8iR\nIwEArVq1gouLS72udsh/L1AAsNxdGDt2LIKCgvDXv/4VR44cAQD06dMH8+fPxxtvvIHs7Gzccccd\nAIAzZ87g4YcfxieffFLncxKKomDgwIHo0KEDACAxMRETJkwAAAQFBUGn09WrrYBlBkJ8fDx0Oh3G\njRuntvFqgwYNUo9Htzaz2YytW7eqayosX74c7777LkJDQ1FYWIhWrVrVWb6srAx5eXno27cvUlNT\nER4ejpdeesnqvmFhYcjMzERaWhqmTp2q3lmrqic2NhZTp06Fp6en3b4f3foKCwsxduxYLF26FG3b\ntkVcXByWLVuGEydOYMmSJYiLiwMArFmzBiUlJcjPz4fJZMKiRYtgMplq1Xd1+cmTJzf2V6ImtH//\nfqSnp2P79u145513kJiYaDOmgLr7pSrX2y+S47r6nAgA8+bNw4kTJzBx4kS88MILNfbPzMzEjBkz\n8P7779/Q8W62PDkH9jFUnbXzGGC9L7I2NsrOzr6u8fnVRASHDh3C8ePHMXLkyAZfgNFuSb6Pjw/S\n09MRFBSEhIQEbNy4EQEBAUhPT0d6ejoyMjLw1Vdf1SpnbZ+b+dJXrzA4a9YsDBgwAIcPH8bWrVtR\nUlICAIiNjcXWrVvh4uKChx56CLt374aiKOjQoQPuvfde9Q9flzZt2tT4/XrbXdXWJUuWwN3dHRkZ\nGUhJSYHZbLa6f+vWra+rfmo627dvR0hICNzc3AAAfn5++M9//oOUlBTExMTA29sbAODh4aEu8gEA\neXl58PDwQKdOndC6dWuMHj0aADB27NhrLvrSo0cPeHt745dfflG3VS0M8txzz9n7K9ItrLS0FGPG\njMGECRPw8MMPA7AshjZq1CgAlniqmjZ24MABjBo1Cs2bN4ebmxv69u2LlJSUWnXaKk+3B3d3dwCA\nm5sbRo0aheTk5HrFhLV+qYqtfpGcz9XnxOrGjx9fYyHPvLw8jB49GqtXr4aXl9d1H+tmy5PzYB9D\n1Vk7j1VXvS+yNTaq7/jc2vheo9EgKSkJKSkp8PLyQkREBI4dO4b+/fs3yPe1W5Kfn5+PO+64A489\n9hheeuklJCcn49y5c0hKSgJgGXRWv0OtKAr8/Pxw9uzZWvu4urpCo9Fg8+bNAIA//vgDJSUlaNeu\n3TVX33V1da2xz6VLl3DPPfcAsDxDUeX48ePw8vLClClTMHLkSBw+fBiAZdbA559/jlWrVtW5kv/V\nCX1kZCQ++eQTAMCPP/6IjIyMuv/Bqrl06ZL6DNmqVatQXl5e77J0a1q7di1iY2PV38+ePQsAqKio\nwN///nc8/fTTACwra65btw5msxkmkwlZWVkICwuDoigYPny4ujLwN998g4CAgFrHqbqqCFjePpGV\nlQUfHx8AQEJCAi5duoQlS5Y06HelW4uIIC4uDlqtFs8//7y6vXv37vj2228BALt27VKfM+zRowd2\n7doFwLK2SlJSEvz9/WvVa6s8Ob/i4mL1vFpUVIQdO3YgMDDQZkzU1S9VZ6tfJOdz9TkxKytL/Xnz\n5s0wGo0ALLMvhw4digULFiA8PLxedV89e/N6y5PzulYfcz035xr6ris1LGvnsaCgoBoXoKv3RdbG\nRj169Kj3+NzW+P6pp57CyZMnYTKZsG/fPvj6+qrHsTtrc/irTXmv9/MA//nPf0Sn04nBYJCwsDBJ\nTU2VQ4cOSWRkpOj1egkICJB///vfIlJzdX1b+2RlZUn//v1Fp9NJSEiImEwmKS0tlf79+4ter5e3\n3nrLajvOnz8vPXv2FIPBIOvXr5fvvvtOfH19xWg0SkJCgnh5eYmIyGuvvSYBAQFiMBjkwQcflAsX\nLojJZFJXOSwoKJCePXvK1q1brR7n6mf/S0pKJCYmRvz9/WX06NHSq1evej+Tn5WVJTqdTvR6vUyf\nPl19Zqh6e64+3rVcz9+O7KuwsFA6depUY8XOpUuXiq+vr/j6+srMmTNr7D9v3jzx9vYWPz8/daVq\nEZGcnByJjIwUnU4n0dHRkpubKyIiW7ZskdmzZ4uIyOrVq9U47tmzp7qCfm5uriiKIlqtVgwGgxgM\nBvnwww9v6nsxphxDYmKiKIoier1e/dtv27ZNvv/+ewkLCxO9Xi+9e/eWtLQ0ERG5cuWKPPbYYxIY\nGCharVYWLVqk1hUfHy8pKSkiIjbL3wzGlGM4fvy46PV69Tw9f/58EbEdE7b6JRFLTFWd++rqF28E\n4+nWZO2cOGbMGAkMDBS9Xi+jR49Wn2l99dVXpU2bNmrfZTAY5OzZsyJSsz/6/PPPRaPRyB133CGd\nO3eWIUOGXLP8jWBMOY6YmBhxd3eXli1bikajkQ8//LDOPubee++VO++8U9q2bSsajUZ++uknEalf\nnN0MxlTTsHUes9UX1TU2qs/4XMT2+L5K9TzvZsDGM/mK1HFlSlEUqetzsq1fv35YvHgxgoODm+T4\niqLwqiPZFWOK7I0xRfbEeCJ7Y0yRvTGmyN4qY0q5ervdpusTERERERERUdO65p38RmwLERERERER\nEdWTtTv5dSb5REREREREROQ4OF2fiIiIiIiIyEkwySciIiIiIiJyEkzyiYiIiIiIiJwEk3wiIiIi\nIiIiJ8Ekn4iIiIiIiMhJ/H9CzMT0cZNUbgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fc7513c7510>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot Average and Total execution time for the specified\n",
+    "# list of kernel functions\n",
+    "ta.plotFunctionStats(\n",
+    "    functions = [\n",
+    "        'select_task_rq_fair',\n",
+    "        'enqueue_task_fair',\n",
+    "        'dequeue_task_fair'\n",
+    "    ],\n",
+    "    metrics = [\n",
+    "        'avg',\n",
+    "        'time',\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+wAAAHzCAYAAAC6xpfvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xm4ZGV5L+zf0zQoHAZBEGRQlGgOk4GDAYLTJh497YSi\nEIMKKkRjjsagJ5+o+dRGvzhiomiOIQqoKEFRVDhBNJ7Q2ipR0FYxTgxpGmxBxJYhEBn6/f6o6maz\n2UND995rVe/7vq6+qFX1Vq2ndjX97t96n7WqWmsBAAAA+mVB1wUAAAAA9yawAwAAQA8J7AAAANBD\nAjsAAAD0kMAOAAAAPSSwAwAAQA8J7ADABlFVi6vqjPV4/s1VtfuGq2id9vnDqnriXO4TANaVwA7A\nvFNVS6rq11W1Wde1bAhV9eiqOruqrq+q31TV96vqNVU11/N8W9eBw8/guHs8ubWtWmvLN2RBVXXL\n8EDAzVW1uqpuHbd9VGttn9ba1zbkPrtSVQdW1flVtaqqbqiqb1XVS4aPjQ3f/81VdVNV/WTCY1dP\n8nr3+owAmFsCOwDzynAF98Akv0xy2Cy8/sIN/Zoz7G+PJN9KclWSfVprD0pyZJIDkmw1l7Ukqfsw\ndp3D/fporW05PBCwVQY/o2eu2W6t/eNc1LChVdUmk9z3B0n+b5ILk+zRWntwkj9LsmjcsJ8P3/fW\nSU5I8uGq2nOaXbXM0ecEwOQEdgDmm2OSfCXJGUlenCRV9YDhyvTeawZV1Q7D1djth9vPrKrvDVcv\nv1FV+44bu7yqXldVP0hyc1VtUlWvr6rLh6uZ/1ZVzxk3fkFVvXe4In5lVb1quPq5YPj4NlV1alWt\nrKprqupt06yWn5jk6621v2ytXZckrbWftdZe1Fq7cfh6hw1rWFVVF1bVf51Q+19W1Q+Gq6+nVtWO\nVfXFqrqxqv65qh40HLv7sM6XVdXPh/X9r6l+0FV1cFV9c7jf71XVk4b3/3WSJyT54HCfJw/vX11V\njxz3M/h4Vf1yWONfVVUNH3tJVX29qt4z7JS4sqoWTVXHdIav/YfD24uHnQpnDD+3H1TVo6rqDVV1\nXVVdVVVPGffcdf6chq/9mao6a/ja36mqx4x7fOeq+uzw/V5ZVX8+yXPPqKobM/x7O8F7kny0tfae\n1tqvk6S19t3W2h9PVk9r7QtJViWZLrCPr//Aqrpk+Hfi2qp677o8D4D1I7ADMN8ck+RTST6d5H9U\n1Q6ttd8m+WySo8aN+6MkS1prv6qq/ZOcmuRlSbZLckqSc6tq03Hj/zjJ05I8qLV2V5LLkzx+uJp5\nYpJPVNWOw7Evz2Dl8/eS/Lckz8k9VzI/muT2JHsk2T/JU5P8yRTv58lJPjPVm62qRyc5M8mrk2yf\n5Pwk543rBGhJnjt8nd9N8swkX0zy+iQPyeB3hVdPeNmxJL8zrOuEqnryJPvdJcn/SfLW1tq2Sf4y\nyWer6sGttb9KsjTJK4crvhNfP0k+kEGHwCOSPCmDz+2l4x4/MMlPkjw4ybsz+Hzuj4kryM9M8vEk\n2yZZluSfh/fvnORtGXz2a3w06/45JYOOjk8PX/vMJJ8fHtxZkOS84f52zuCzOL6qnjrhuWe31rYZ\nPnetqtoiycGZ5u/BhPELqurwJA9Kcum6PCfJ+5P87XD/jxy+DwBmmcAOwLxRVY9PskuSc1trlyX5\nUZIXDh8+M4PQvcYLcncwenmSU1prF7eBjyf5bQYhKRmEvpNbaz8fhv+01j7TWrt2ePvTSS7LIGQm\ng4MB72utrWyt/SbJOzJsJx+G+qcleU1r7bbW2vVJ3jehtvEenOQX07zt5yf5P621/zs8kHBSks2T\nHDJuzAdaa9e31lZmEKQvaq19f/hePpdBGB3vxGFtP0xyeu55oGONFyU5v7V2wfBn8JUklyR5xrgx\nk7bQ16Dl+/lJ3tBa+4/W2lVJ3pvk6HHDrmqtndpaaxkE7IdW1UOm+Tmsq6+11v55+LP6TAY/33cO\ntz+VZPeq2vp+fE5Jcklr7Zzha/1Nkgcm+YMkv59k+9ba/9dau7O19u9JPjLhtb7ZWjs3SVpr/znh\ndbfN4He66f4eJMnOVbUqyfVJ3pTkRcP/D9bF7UkeVVXbt9Zuba19ax2fB8B6mNPz7ACgYy9O8uXW\n2s3D7bOH970vyZIkW1TVmvPbfy+DsJokD09yzPg25SSbZrAausY9LtpVVcckeU2S3Yd3bZnBCneS\nPHTC+GvG3X748LV/MewATwZhbMUU7+mGCXVM9NDxz22ttRpcYGyXcWOuG3f7tgnb/zmsfbzxta9I\nsm/u7eFJjqyqZ427b2GSfxm3PdX50dtn8DO4asJ+xtd87doXae3W4c9qyww+u/Ux/vm3JfnV8KDA\nmu01+9k19+1zSsZ9zsPP4ZoMPruWu8P0Gpsk+dpkz53EqiSrM/isfzbNuJWttd0muf/ODN7LRJsm\nuWN4+7gkb03y46r69wwO2vzTNPsCYAMQ2AGYF6pq8wxWthdU1ZqVyAckeVBVPaa19oOq+nQGq8W/\nTHJea+0/huNWJPnr1trbp9nF2vBZVQ9P8g9J/jCD1epWVcty94ryL5KMD07jb1+dwer9g1trq9fh\nrX0lyfMyaM+ezMqMC9TD88B3S/LzaV5zpovHPSzJT8fdnuy1ViQ5o7X28ileY7qLmf0qg6C4e5If\nj9vPdKF1rt3XzykZ9zkP2+B3zeBnd1eSf2+tPXqK50178bfhAYuLkhyR5KvrWMt4K5JsX1X/Zc3f\n+eHfk4dneNCktXZ5Bl0nqarnJflMVW3XWrttitcEYAPQEg/AfPGcDFYS98xg9fz3hreXZnB+dHJ3\nW/z4dvgk+XCSVwwvvFVV9V+q6hlVNXHleY3/kkHA+lUGBwhemmSfcY9/OslfDC809qAMrtjdkqS1\n9oskX07yN1W11fB84z1q6u8Kf0uSQ6rq3WvOka+q3xleoGzr4b6eUVV/ODzn/n9lsGr+zXX4mU3l\n/62qzWtwkb6XZNAqPtEnkjyrqp46PE/7gTX4+rA1q+TXZXDu970MW8Y/neSvq2rL4QGQ1wxfsxfu\nx+eUJAdU1eHD6wccn8Hn8K9JLs7gYoWvG/5cN6mqfarqscPnrcvV91+X5CU1uIDgg5Okqn6vqma8\nEn5rbUUG3zTwruHf7Qck+X8yaIP/1+Frvaiqdhg+5cYM/r6u64EKAO4ngR2A+eKYJKe11q5prf1y\n+Oe6JB9M8oKqWtBa+3aSWzJoLf7imie21r6TwQXnPpjk1xmcj35Mplj1bK39KINzri/KoHV7nyRf\nHzfkwxmEvR8k+U6Sf0py17iV2mOSbJbBOfa/zqB1f6cp9nVlBudB757k36rqNxmce31xkltaaz/L\n4HzyD2Rw7vIzkjyrtXbnND+rNuH2xPf51QwuqveVJO8Znp9+j7GttWuSPDvJGzPoWFiRwcGCNeHz\n/UmOqMFV3t83SQ1/nuQ/klyZwUGVT2ZwvvxUNW2Irx9bl9cdv73On9PweV/I4Nz8X2dw7YTnttbu\nGh6geGaS/TJ4v9dn0KGx9TR13fPFW7sog46OP0xyRVXdkMEF8sa3rU/3Gs/P4CKDl2fQyXBokme0\n1m4fPv4/kvywqm5O8rdJ/njN9RoAmD1192lZbEhVdVoGvxT9srU22bl9qaqxDCa9TTM4R25szgoE\noDeq6mlJPtRa273rWqZTg++wvzLJwvvQBk6SqnpLkt9prR0942AAGLLCPntOz+AreyY1bIH8uwxW\nOfbJ4LwzAOaBYXv406tq4bBF/C1Jzum6LmbVurS1A8A9COyzpLW2NIOrtk7lBUk+O2wZTGvtV3NS\nGAB9UEkWZ9Aa/d0k/5bkzV0WdB9ozbt/ZmxrB4CJtMTPomHr4HmTtcRX1ZpW+L2TbJXk/a21M+a0\nQAAAAHrL17p1Z9Mk/y3Jk5NskeSiqvrX1tpl4wdVlSMqAAAAG7HW2qSnTgns3bk6gwvN3Zbktqr6\nWgZfMXTZxIG6IAAAADZOVVNf5sQ57N35QpLHD79rdYskB2XwtTAAAABghX22VNU/JnlSku2r6uoM\nrgC8aZK01k5prf2kqi7I4Dt4Vyf58PB7ewEAAMBF5/quqprPCAAAYONUVVOew64lHgAAAHpISzwA\nAMB9NN2FwmAq97V7WmAHAAC4H5y6yn1xfw7yaIkHAACAHhLYAQAAoIcEdgAAAOghgR0AAAB6SGAH\nAABgUh/96EfzhCc8oesy5sxLX/rSbLfddjn44INnHPv0pz89Z5xxxqzW4yrxAAAAG8BcfNVbn69M\nv3jx4lxxxRWzHmJny9KlS/OVr3wlK1euzAMf+MAZx59//vmzXpMVdgAAgA2mzeIf7os777zzXvfd\nddddU46/6qqrsvvuu69TWJ/JdPu5LwR2AACAjciCBQty5ZVXrt1+yUtekje96U1JkiVLlmTXXXfN\nO97xjuywww55xCMekTPPPHPt2BtuuCGHHXZYttlmmxx00EG54oor7vHaf/EXf5GHPexh2WabbfLY\nxz42X//615MkF1xwQd7xjnfkU5/6VLbaaqvsv//+SZIbb7wxxx13XHbeeefsuuuuedOb3pTVq1fP\n+B4+/OEPZ6+99srWW2+dvffeO9/73vfW+b29+93vzkMf+tAce+yxOfHEE3PEEUfk6KOPzjbbbJOP\nfexjk+7v1FNPzcte9rJcdNFF2WqrrXLiiSfmN7/5TZ75zGfmIQ95SLbbbrs861nPys9//vO1zxkb\nG8upp56aZHDqwOMe97i89rWvzfbbb58TTzxxxve4LgR2AACAjVhV3aNd/7rrrssNN9yQlStX5mMf\n+1he/vKX57LLLkuSvPKVr8wWW2yRa6+9NqeddlpOP/30ezz3wAMPzPe///2sWrUqL3jBC3LkkUfm\n9ttvz6JFi/LGN74xf/zHf5ybb745y5YtSzII1JtttlmuuOKKLFu2LF/+8pfzkY98ZNp6zz777Jx4\n4ok544wzctNNN+Xcc8/Ndtttt87vbdWqVVmxYkX+4R/+Ia21nHvuuTnyyCNz44035gUveMGkr3Pc\nccfl7//+7/MHf/AHufnmm/OWt7wlq1evznHHHZcVK1ZkxYoV2XzzzfOqV71qyn1/+9vfzh577JFf\n/vKXeeMb3zjte1xXAjsAAMBGbuK5729729uy6aab5olPfGKe8Yxn5FOf+lTuuuuunHPOOXnrW9+a\nzTffPHvvvXde/OIX3+O5L3zhC7PttttmwYIFee1rX5vf/va3+elPf7p2H+PHXnfddfniF7+Yv/3b\nv83mm2+eHXbYIccff3zOOuusaWv9yEc+khNOOCEHHHBAkmSPPfbIwx72sHV6bwsWLMiJJ56YTTfd\ndG1r+yGHHJLDDjssSaZtd5/4M9puu+1y+OGH54EPfGC23HLLvPGNb8xXv/rVKZ+/884755WvfGUW\nLFiwQdrqExedAwAAmFe23XbbbL755mu3H/7wh+cXv/hFfvWrX+XOO+/MbrvttvaxiUH5pJNOymmn\nnZaVK1emqnLTTTflV7/61aT7ueqqq3LHHXfkoQ996Nr7Vq9ePW34TpJrrrkme+yxx/15a9lhhx2y\n2Wab3eO+XXfd9X691q233prXvOY1+dKXvpRVq1YlSW655Za01ia9wOD4n9uGYoUdAABgI7LFFlvk\n1ltvXbv9i1/84h4Bc9WqVfd4/KqrrsrOO++cHXbYIQsXLsyKFSvWPjb+9tKlS/Oe97wnZ599dn7z\nm99k1apV2WabbdauTE8Msbvttlse8IAH5IYbbsiqVauyatWq3Hjjjbn00kunrX+33XbL5Zdffr/e\n28QaJrat3xfvfe9787Of/Szf/va3c+ONN+arX/3qvboIJu5rQxPYAQAANiL77bdfPvnJT+auu+7K\nBRdckK997Wv3GvOWt7wld9xxR5YuXZp/+qd/ypFHHpkFCxbkuc99bhYvXpzbbrstP/rRj/Kxj31s\nbRC9+eabs3Dhwmy//fa5/fbb89a3vjU33XTT2tfcaaedsnz58rWB9qEPfWie+tSn5rWvfW1uvvnm\nrF69OldcccWk9Yz3J3/yJznppJPy3e9+N621XH755WsPHKzLextvfb4G75Zbbsnmm2+ebbbZJr/+\n9a832IXk7guBHQAAYIOpWfyzbt7//vfnvPPOy7bbbpszzzwzhx9++D0e32mnnbLttttm5513ztFH\nH51TTjklj370o5MkH/zgB3PLLbdkp512yrHHHptjjz127fMWLVqURYsW5dGPfnR23333bL755vdo\nbz/yyCOTJA9+8IPz2Mc+Nkny8Y9/PLfffnv22muvbLfddjnyyCNz7bXXTlv/EUcckb/6q7/KC17w\ngmy99dZ57nOfu7Ylfab3tj4r7BPHHn/88bntttuy/fbb55BDDsnTnva0KV9rfVbyp61pfY44MPuq\nqvmMAACgX6pqvVZvu7JkyZIcffTRufrqq7suZd6Z6u/M8P5J074VdgAAAOghgR0AAGAemY3W7fvq\nFa94Rbbaaqt7/fmf//N/zup+n/a0p02633e+852zut/7S0t8z2mJBwCA/hnVlni6oyUeAAAANhIC\nOwAAAPSQwA4AAAA9tLDrAgAAAEZRHy7exsZNYAcAALiPXHCOuaAlHgAAAHpIYAcAAIAeEtgBAACg\nhwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2\nAAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA6CGBHQAAAHpoYdcFwMasqrouAeat1lrXJQAA\nrBeBHWad0ABzz8Ey6IID1dAtB6s3PgI7AAAbkMAA3XDAbGPkHHYAAADoIYF9llTVaVV1XVVdOsO4\n36+qO6vquXNVGwAAAP0nsM+e05Msmm5AVW2S5F1JLogeFgAAAMYR2GdJa21pklUzDPvzJJ9Jcv3s\nVwQAAMAoEdg7UlW7JHl2kg8N73KFFgAAANZylfjuvC/J61trrQbfgTJlS/zixYvX3h4bG8vY2Nis\nFwcAAMCGt2TJkixZsmSdxpbv6ps9VbV7kvNaa/tO8tiVuTukb5/k1iQva62dO2Fc8xmNrsGxGJ8f\nzL3yXbTQAfMedMncN6qqKq21SRdwrbB3pLX2yDW3q+r0DIL9udM8BQAAgHlEYJ8lVfWPSZ6UZPuq\nujrJW5JsmiSttVO6rA0AAID+0xLfc1riR5vWQOiKtkDognkPumTuG1XTtcS7SjwAAAD0kMAOAAAA\nPSSwAwAAQA8J7AAAANBDAjsAAAD0kMAOAAAAPSSwAwAAQA8J7AAAANBDAjsAAAD0kMAOAAAAPSSw\nAwAAQA8J7AAAANBDAjsAAAD0kMAOAAAAPSSwAwAAQA8J7AAAANBDAjsAAAD0kMAOAAAAPSSwAwAA\nQA8J7AAAANBDAjsAAAD0kMAOAAAAPSSwAwAAQA8J7AAAANBDAjsAAAD0kMAOAAAAPSSwAwAAQA8J\n7AAAANBDAjsAAAD0kMAOAAAAPSSwAwAAQA8J7AAAANBDAjsAAAD0kMAOAAAAPSSwAwAAQA8J7AAA\nANBDAjsAAAD0kMAOAAAAPSSwAwAAQA8J7AAAANBDAjsAAAD0kMAOAAAAPSSwAwAAQA8J7AAAANBD\nAjsAAAD0kMAOAAAAPSSwAwAAQA8J7LOoqk6rquuq6tIpHn9hVX2/qn5QVd+oqsfMdY0AAAD0k8A+\nu05Psmiax69M8sTW2mOSvC3JP8xJVQAAAPSewD6LWmtLk6ya5vGLWms3Dje/lWTXOSkMAACA3hPY\n++O4JOd3XQQAAAD9sLDrAkiq6tAkxyZ53GSPL168eO3tsbGxjI2NzUldAAAAbFhLlizJkiVL1mls\ntdZmt5p5rqp2T3Jea23fKR5/TJJzkixqrV0+yePNZzS6qiqJzw/mXsW/nTD3zHvQJXPfqKqqtNZq\nsse0xHeoqh6WQVh/0WRhHQAAgPnLCvssqqp/TPKkJNsnuS7JW5JsmiSttVOq6iNJDk+yYviUO1pr\nB054DSvsI8xKA3TFKgN0wbwHXTL3jarpVtgF9p4T2EebX1ygK35pgS6Y96BL5r5RpSUeAAAARozA\nDgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAA\nAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0k\nsAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMA\nAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAP\nCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewA\nAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCeyzpKpOq6rrqurSacacXFWXVdX3q2r/uawPAACAfhPY\nZ8/pSRZN9WBVPT3J77TWHpXk5Uk+NFeFAQAA0H8C+yxprS1NsmqaIYcl+dhw7LeSPKiqdpyL2gAA\nAOg/gb07uyS5etz2NUl27agWAAAAemZh1wXMczVhu002aPHixWtvj42NZWxsbPYqAgAAYNYsWbIk\nS5YsWaex1dqkGZENoKp2T3Jea23fSR77+yRLWmtnDbd/kuRJrbXrJoxrPqPRVVWZ4jgMMKsq/u2E\nuWfegy6Z+0ZVVaW1NnExN4mW+C6dm+SYJKmqg5P8ZmJYBwAAYP7SEj9LquofkzwpyfZVdXWStyTZ\nNElaa6e01s6vqqdX1eVJ/iPJS7urFgAAgL7REj+FqjogM/d03dFam/J71jdQHVriR5jWQOiKtkDo\ngnkPumTuG1XTtcQL7FOoqpuTXDLDsEe01naf5ToE9hHmFxfoil9aoAvmPeiSuW9UTRfYtcRP7ZLW\n2qHTDaiqC+eqGAAAAOYXK+w9Z4V9tFlpgK5YZYAumPegS+a+UeUq8euhqh5fVVsObx9dVX9bVQ/v\nui4AAAA2bgL7zD6U5D+q6veSvDbJ5Uk+3m1JAAAAbOwE9pndOexJf06Sv2ut/V2SrTquCQAAgI2c\ni87N7OaqemOSFyV5QlVtkuH3qQMAAMBsscI+s+cn+W2SY1tr1ybZJclJ3ZYEAADAxs5V4nvOVeJH\nm6vlQldcKRe6YN6DLpn7RpXvYV8PVXVL7p55NsugHf6W1trW3VUFAADAxk5gn0Frbcs1t6tqQZLD\nkhzcXUUAAADMB1ri74eq+l5rbb852peW+BGmNRC6oi0QumDegy6Z+0aVlvj1UFXPG7e5IMkBSW7r\nqBwAAADmCYF9Zs/K3YeK70yyPMmzO6sGAACAeUFLfM9piR9tWgOhK9oCoQvmPeiSuW9UTdcS73vY\np1BVL98QYwAAAOD+sMI+haq6MslfJpnsSEcb3v+21tpes1yHFfYRZqUBumKVAbpg3oMumftGlYvO\n3T9fy+D89el8eS4KAQAAYP6xwt5zVthHm5UG6IpVBuiCeQ+6ZO4bVc5hBwAAgBEjsAMAAEAPCewA\nAADQQwL7DKpqp6o6taouGG7vVVXHdV0XAAAAGzeBfWYfzeBq8DsPty9L8prOqgEAAGBeENhntn1r\n7VNJ7kqS1todSe7stiQAAAA2dgL7zG6pqgev2aiqg5Pc2GE9AAAAzAMLuy5gBPyvJOcleWRVfTPJ\nDkmO6LYkAAAANnbVWuu6ht6rqk2TPDpJJfnpsC1+rvbdfEajq6qS+Pxg7lX82wlzz7wHXTL3jaqq\nSmutJn3Mhzq9qlqY5BlJds/dHQmttfY3c7R/gX2E+cUFuuKXFuiCeQ+6ZO4bVdMFdi3xMzsvyW1J\nLk2yuuNaAAAAmCcE9pnt0lp7TNdFAAAAML+4SvzMvlxV/6PrIgAAAJhfrLDP7JtJPldVC5Ksudhc\na61t3WFNAAAAbORcdG4GVbU8yWFJftham/Nz2F10brS5+A50xYV3oAvmPeiSuW9UTXfROS3xM1uR\n5N+6COsAAADMX1riZ/bvSS6sqi8muX1435x9rRsAAADzk8A+s38f/tls+EevFwAAALPOOew95xz2\n0eZcPuiK8/igC+Y96JK5b1RNdw67FfYpVNX7W2t/UVXnTfJwa60dNudFAQAAMG8I7FP7xPC/753k\nMYeuAAAAmFVa4qdQVctaa/v3oA4t8SNMayB0RVsgdMG8B10y940qX+sGAAAAI0ZL/NR2qKrXZnBV\n+Il8rRsAAACzSmCf2iZJtuq6CAAAAOYn57BPwTnsbAjO5YOuOI8PumDegy6Z+0aVc9gBAABgxAjs\nU/vv6/sCVbWoqn5SVZdV1QmTPL59VV1QVd+rqh9W1UvWd58AAABsHLTEz5Kq2iTJTzMI/j9PcnGS\no1prPx43ZnGSB7TW3lBV2w/H79hau3PcGC3xI0xrIHRFWyB0wbwHXTL3jSot8d04MMnlrbXlrbU7\nkpyV5NkTxvwiydbD21snuWF8WAcAAGD+cpX42bNLkqvHbV+T5KAJYz6c5F+qamUGV6T/ozmqDQAA\ngJ6zwj6Dqnre8Bz0m6rq5uGfm9bhqevSj/LGJN9rre2cZL8kf1dVvkoOAAAAK+zr4N1Jnjn+3PN1\n9PMku43b3i2DVfbxDkny10nSWruiqv49ye8muWT8oMWLF6+9PTY2lrGxsftYCgAAAH2wZMmSLFmy\nZJ3GuujcDKrqG621x92P5y3M4CJyT06yMsm3c++Lzv1NkhtbaydW1Y5JvpPkMa21X48b46JzI8zF\nd6ArLrwDXTDvQZfMfaNquovOWWGf2SVV9akkn09y+/C+1lo7Z7ontdburKpXJflSkk2SnNpa+3FV\n/enw8VOSvD3J6VX1/QxOT3jd+LAOAADA/GWFfQZV9dHhzXv8oFprL52j/VthH2FWGqArVhmgC+Y9\n6JK5b1RNt8IusPecwD7a/OICXfFLC3TBvAddMveNKt/Dvh6qareq+lxVXT/889mq2rXrugAAANi4\nCewzOz2PQNoTAAAYEUlEQVTJuUl2Hv45b3gfAAAAzBot8TOoqu+31n5vpvtmcf9a4keY1kDoirZA\n6IJ5D7pk7htVWuLXzw1VdXRVbVJVC6vqRUl+1XVRAAAAbNwE9pkdm+SPklyb5BdJjkwyJ1eIBwAA\nYP7SEt9zWuJHm9ZA6Iq2QOiCeQ+6ZO4bVdO1xC+c62JGRVWd0Fp7V1V9YJKHW2vt1XNeFAAAAPOG\nwD61Hw3/+53c81CxQ8cAAADMOoF9Cq2184Y3b22tfXr8Y1X1Rx2UBAAAwDziHPYZVNWy1tr+M903\ni/t3DvsIcy4fdMV5fNAF8x50ydw3qpzDfj9U1dOSPD3JLlV1cgat8EmyVZI7OisMAACAeUFgn9rK\nDM5ff/bwv2sOGd+c5DUd1gUAAMA8oCV+BlW1aZJNkzystfaTDvavJX6EaQ2ErmgLhC6Y96BL5r5R\nNV1L/IK5LmYEPS3JsiQXJElV7V9V53ZbEgAAABs7gX1mi5MclGRVkrTWliV5ZJcFAQAAsPET2Gd2\nR2vtNxPuW91JJQAAAMwbLjo3s3+rqhcmWVhVj0ry6iTf7LgmAAAANnJW2Gf250n2TvLbJP+Y5KYk\nx3daEQAAABs9V4nvOVeJH22ulgtdcaVc6IJ5D7pk7htV010lXkv8FKrqvGkebq21w+asGAAAAOYd\ngX1q753mMYeuAAAAmFVa4tdBVT0gyX/N4OrwP22t3T6H+9YSP8K0BkJXtAVCF8x70CVz36jSEr8e\nquoZSf4+yZXDux5ZVX/aWju/w7IAAADYyFlhn0FV/TTJM1prlw+390hyfmvtd+do/1bYR5iVBuiK\nVQbognkPumTuG1XTrbD7WreZ3bQmrA9dmcFXuwEAAMCs0RI/s+9U1flJPj3cPjLJJVX13CRprZ3T\nWWUAAABstLTEz6CqPjq8ueYHdY9er9baS2d5/1riR5jWQOiKtkDognkPumTuG1XTtcQL7D0nsI82\nv7hAV/zSAl0w70GXzH2jylXi10NVPTLJnyfZPXf/vFpr7bDOigIAAGCjJ7DP7PNJPpLkvAy+hz1x\n6BgAAIBZJrDP7D9bayd3XQQAAADzi3PYZ1BVRyfZI8mXkvx2zf2tte/O0f6dwz7CnMsHXXEeH3TB\nvAddMveNKuewr5+9kxyd5NDc3RKf4TYAAADMCivsM6iqK5Ls2Vq7vaP9W2EfYVYaoCtWGaAL5j3o\nkrlvVE23wr5grosZQZcm2bbrIgAAAJhftMTPbNskP6mqi3P3Oey+1g0AAIBZJbDP7C3D/67pL9Hr\nBQAAwKxzDvs6qKqdkvx+BkH92621X87hvp3DPsKcywddcR4fdMG8B10y940q57Cvh6r6oyTfSnJk\nkj9K8u2qOrLbqgAAANjYWWGfQVX9IMl/X7OqXlU7JPm/rbXHzNH+rbCPMCsN0BWrDNAF8x50ydw3\nqqywr59Kcv247RuG9wEAAMCscdG5mV2Q5EtVdWYGQf35Sb7YbUkAAABs7LTEr4Oqel6Sxw03l7bW\nPjeH+9YSP8K0BkJXtAVCF8x70CVz36iariVeYJ9CVT0qyY6tta9PuP/xSX7RWrtijuoQ2EeYX1yg\nK35pgS6Y96BL5r5R5Rz2++d9SW6a5P6bho8BAADArBHYp7Zja+0HE+8c3veIDuoBAABgHhHYp/ag\naR574Lq8QFUtqqqfVNVlVXXCFGPGqmpZVf2wqpbcn0IBAADY+AjsU7ukql4+8c6qelmS78z05Kra\nJMkHkyxKsleSo6pqzwljHpTk75I8q7W2T5IjNkThAAAAjD5f6za145N8rqpemLsD+gFJHpDk8HV4\n/oFJLm+tLU+SqjorybOT/HjcmBck+Wxr7Zokaa39asOUDgAAwKgT2KfQWru2qg5JcmiSfTK45On/\naa39yzq+xC5Jrh63fU2SgyaMeVSSTavqwiRbJXl/a+2M9ascAACAjYHAPo3h96n9y/DPfX76OozZ\nNMl/S/LkJFskuaiq/rW1dtn4QYsXL157e2xsLGNjY/ejHAAAALq2ZMmSLFmyZJ3G+h72WVJVBydZ\n3FpbNNx+Q5LVrbV3jRtzQpLNW2uLh9sfSXJBa+0z48b4HvYR5vtooSu+ixa6YN6DLpn7RpXvYe/G\nJUkeVVW7V9VmSZ6f5NwJY76Q5PFVtUlVbZFBy/yP5rhOAAAAekhL/Cxprd1ZVa9K8qUkmyQ5tbX2\n46r60+Hjp7TWflJVFyT5QZLVST7cWhPYAQAA0BLfd1riR5vWQOiKtkDognkPumTuG1Va4gEAAGDE\nCOwAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewA\nAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQ\nQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7\nAAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA\n9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDADgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDA\nDgAAAD0ksAMAAEAPCewAAADQQwI7AAAA9JDAPouqalFV/aSqLquqE6YZ9/tVdWdVPXcu6wMAAKC/\nBPZZUlWbJPlgkkVJ9kpyVFXtOcW4dyW5IEnNaZEAAAD0lsA+ew5McnlrbXlr7Y4kZyV59iTj/jzJ\nZ5JcP5fFAQAA0G8C++zZJcnV47avGd63VlXtkkGI/9DwrjY3pQEAANB3C7suYCO2LuH7fUle31pr\nVVWZoiV+8eLFa2+PjY1lbGxsQ9QHAADAHFuyZEmWLFmyTmOrNYu6s6GqDk6yuLW2aLj9hiSrW2vv\nGjfmytwd0rdPcmuSl7XWzh03pvmMRtfgOIzPD+Zexb+dMPfMe9Alc9+oqqq01iZdvBXYZ0lVLUzy\n0yRPTrIyybeTHNVa+/EU409Pcl5r7ZwJ9wvsI8wvLtAVv7RAF8x70CVz36iaLrBriZ8lrbU7q+pV\nSb6UZJMkp7bWflxVfzp8/JROCwQAAKDXrLD3nBX20WalAbpilQG6YN6DLpn7RtV0K+yuEg8AAAA9\nJLADAABADwnsAAAA0EMCOwAAAPSQwA4AAAA9JLADAABADwnsAAAA0EMCOwAAAPSQwA4AAAA9JLAD\nAABADwnsAAAA0EMCOwAAAPSQwA4AAAA9JLADAABADwnsAAAA0EMCOwAAAPSQwA4AAAA9JLADAABA\nDwnsAAAA0EMCOwAAAPSQwA4AAAA9JLADAABADwnsAAAA0EMCOwAAAPSQwA4AAAA9JLADAABADwns\nAAAA0EMCOwAAAPSQwA4AAAA9JLADAABADwnsAAAA0EMCOwAAAPSQwA4AAAA9JLADAABADwnsAAAA\n0EMCOwAAAPSQwA4AAAA9JLADAABADwnsAAAA0EMCOwAAAPSQwA4AAAA9JLADAABADwnsAAAA0EMC\nOwAAAPSQwA4AAAA9JLADAABADwnsAAAA0EMC+yyqqkVV9ZOquqyqTpjk8RdW1fer6gdV9Y2qekwX\ndQIAANA/AvssqapNknwwyaIkeyU5qqr2nDDsyiRPbK09JsnbkvzD3FYJAABAXwnss+fAJJe31pa3\n1u5IclaSZ48f0Fq7qLV243DzW0l2neMaAQAA6CmBffbskuTqcdvXDO+bynFJzp/VigAAABgZC7su\nYCPW1nVgVR2a5Ngkj5vs8cWLF6+9PTY2lrGxsfUsDQAAgC4sWbIkS5YsWaex1do650rug6o6OMni\n1tqi4fYbkqxurb1rwrjHJDknyaLW2uWTvE7zGY2uqsp9OHYDbDAV/3bC3DPvQZfMfaOqqtJaq8ke\n0xI/ey5J8qiq2r2qNkvy/CTnjh9QVQ/LIKy/aLKwDgAAwPylJX6WtNburKpXJflSkk2SnNpa+3FV\n/enw8VOSvDnJtkk+NDginTtaawd2VTMAAAD9oSW+57TEjzatgdAVbYHQBfMedMncN6q0xAMAAMCI\nEdgBAACghwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgB\nAACghwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgBAACg\nhwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2\nAAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA\n6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA6CGBHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA6CGB\nHQAAAHpIYAcAAIAeEtgBAACghwR2AAAA6CGBfRZV1aKq+klVXVZVJ0wx5uTh49+vqv3nukYAAAD6\nSWCfJVW1SZIPJlmUZK8kR1XVnhPGPD3J77TWHpXk5Uk+NOeFAgAA0EsC++w5MMnlrbXlrbU7kpyV\n5NkTxhyW5GNJ0lr7VpIHVdWOc1smAAAAfSSwz55dklw9bvua4X0zjdl1lusCAABgBCzsuoCNWFvH\ncTXT86omDmG0+PygC/7thK74fw+6Yu7b+Ajss+fnSXYbt71bBivo043ZdXjfPbS2rtkfAEZfVZn7\nAJg3pjvQoiV+9lyS5FFVtXtVbZbk+UnOnTDm3CTHJElVHZzkN6216+a2TGC8Y489NjvuuGP23Xff\nrksBgDlx9dVX59BDD83ee++dffbZJyeffHLXJQFD5Qj27KmqpyV5X5JNkpzaWntHVf1pkrTWThmO\nWXMl+f9I8tLW2ncnvEbzGcHcWbp0abbccsscc8wxufTSS7suB+YlK+wwt6699tpce+212W+//XLL\nLbfkgAMOyOc///nsueeeMz8ZWG/DeW/SZXYt8bOotfbFJF+ccN8pE7ZfNadFAdN6whOekOXLl3dd\nBgDMmZ122ik77bRTkmTLLbfMnnvumZUrVwrs0ANa4gEAgCTJ8uXLs2zZshx00EFdlwJEYAcAAJLc\ncsstOeKII/L+978/W265ZdflABHYAQBg3rvjjjvyvOc9Ly960YvynOc8p+tygCGBHQAA5rHWWo47\n7rjstddeOf7447suBxhHYAcY56ijjsohhxySn/3sZ9ltt91y+umnd10SAMyqb3zjG/nEJz6RCy+8\nMPvvv3/233//XHDBBV2XBcTXuvWer3UDYL7xtW4AzCfTfa2bFXYAAADooWm/h72qHN7ugapJD7YA\nwEbL3AcAMwT2JFrSOqYtEID5xtwHwHwy3UHqXrTE77777vn1r3897Zi3v/3tc1TN/XP22Wdnr732\nypOf/OQpx6xcuTJHHnnkHFYFwKg59thjs+OOO2bfffeddtzFF1+chQsX5rOf/WyS5D//8z9z0EEH\nZb/99stee+2VN7zhDXNRLgCsk/s6v51zzjlJkquvvjqHHnpo9t577+yzzz45+eST7zH+Ax/4QPbc\nc8/ss88+OeGEE2at/q5Me9G5ubrg2SMe8Yh85zvfyXbbbTflmK222io333zzrNcy3pr3vuaIx8Tt\n8RYtWpQ3v/nNOeSQQ+7zfu68884sXDh5s4NVBoD5ZenSpdlyyy1zzDHH5NJLL510zF133ZWnPOUp\n2WKLLfLSl740z3ve85Ikt956a7bYYovceeedefzjH5+TTjopj3/84+ey/A3C3Aew8bm/89u1116b\na6+9Nvvtt19uueWWHHDAAfn85z+fPffcMxdeeGHe/va35/zzz8+mm26a66+/PjvssMMcv7P1N+sX\nnVu+fPk9jpScdNJJOfHEE3PooYfm+OOPz/7775999903F198cZLkhhtuyFOf+tTss88+ednLXnaP\nSfnwww/PYx/72Oyzzz758Ic/nCR5/etfn9tuuy37779/jj766CTJJz7xiRx00EHZf//984pXvCKr\nV6+esr4LLrggBxxwQPbbb7885SlPSZIsXrw4733ve9eO2WeffbJixYosX748v/u7v5sXv/jF2Xff\nfbN06dJ7bF9zzTX3ev23vvWt+cY3vpFjjz02r3vd63LVVVfliU98Yg444IAccMABueiii+71c/ro\nRz+aww47LE9+8pPX1gQAT3jCE7LttttOO+YDH/hAjjjiiHv9UrLFFlskSW6//fbcdddd0x4IB4C5\ndH/nt5122in77bdfkmTLLbfMnnvumZUrVyZJPvShD+UNb3hDNt100yQZybA+k1lpiR+/An3bbbdl\n2bJl+d//+3/n2GOPTZKceOKJeeITn5gf/vCHOfzww7NixYq140877bRccsklufjii3PyySdn1apV\neec735nNN988y5YtyxlnnJEf//jH+fSnP51vfvObWbZsWRYsWJBPfvKTk9Zy/fXX5+Uvf3nOOeec\nfO9738vZZ599rxonbl9++eV55StfmR/+8Id52MMedo/t3Xbb7V77ePOb35zHPvaxOfPMM/Pud787\nD3nIQ/LP//zP+c53vpOzzjorr371qyetbdmyZfnsZz+bCy+8cB1/sgDMdz//+c/zhS98IX/2Z3+W\n5J7z1+rVq7Pffvtlxx13zKGHHpq99tqrqzIB4D6Zbn5bY/ny5Vm2bFkOOuigJMlll12Wr33tazn4\n4IMzNjaWSy65ZE5rngszXnRufR111FFJBkdUbrrpptx4441ZunRpPve5/7+9+3tp6o/jOP7MOnFA\nSSPEQmuXkpTgrIldZCNYK0FERyQkAwUF8cK/IBEivAnZTUYXXWxRBMG3i2BELFYoHCgl70Rh606w\nOS28sLmtLsSD89uW3/DXN1+Pu8M+n/d5n918+JzP+3M+/wBw48aNnDctgUCAly9fAmv7FWZnZ3G5\nXDkxI5EIExMTXLhwAVh7KXDy5Mlf3t+yLJqamnA4HACUlZX9NmeHw5Fzz83X+axXCqRSKfr7+5ma\nmuLw4cPMzMz8sr3H49lSPiIiIusGBgYYHh62y8Y3VqkVFRXx6dMnvn79yrVr14hGo1y5cmXvkhUR\nEdmiQuMbwPLyMj6fj0AgQElJCbC2tXhxcRHLsvjw4QM3b94kFovtRfo7Zlsm7EeOHMkpSV9ZWcnb\ndvN+8I2i0SiRSATLsjBNE7fbnTeW3+/f0ofo8u2DK5RzcXFxTtvN14XuBTAyMsKpU6cIhUJkMhlM\n0/xl+/XSRRERka2amJjg1q1bACQSCcLhMIZh0NLSYrcpLS2lubmZjx8/asIuIiL/C4XGt9XVVdrb\n27l9+zatra12n6qqKtra2gC4ePEiRUVFLCwscOLEiT15hp2wLSXxFRUVzM/Pk0wm+f79O69evbJ/\ne/78OQBjY2OUlZVx7NgxLl++zNOnTwEIh8MsLi4C8O3bN44fP45pmkxPT2NZlh3HMAzS6TQAV69e\n5cWLF3z58gWAZDKZU1a/UUNDA+/fv+fz5892W1j7Mv3k5CQAk5OTxOPx7fgr7OdYX/EPBoNkMplt\niy0iIgdbLBYjHo8Tj8fx+XyMjo7S0tJCIpFgaWkJWKs8e/PmDXV1dXucrYiIyNbkG99+/PhBd3c3\nNTU1DAwM5PRpbW3l7du3AMzMzJBKpf6qyTps0wq7YRjcuXMHl8tFZWUlZ8+etX8zTROn00k6nebx\n48cADA4O0tHRwbNnz7h06ZJdru71enn48CE1NTVUV1fT2Nhox+np6aG2tpb6+npCoRB3797F4/GQ\nzWYxDIMHDx5w5syZf+VWXl7Oo0ePaGtrI5vNUlFRwevXr2lvbycYDHLu3DkaGhqorq62+xTa374V\nfX19dnyv12uXbGyMdejQof8cV0RE/n4dHR28e/eORCLB6dOnGRoaYnV1FYDe3t68/ebm5vD7/WSz\nWbLZLJ2dnQWPGhUREdlNfzq+jY+P8+TJE2pra+0X0ffu3eP69et0dXXR1dXF+fPnOXr0KMFgcFee\nZTft6LFubreb+/fv43Q6/zjGQaejbURE5KDR2CciIgfJjh/rJiIiIiIiIiLb67cr7LuYi4iIiIiI\niMiBk2+FveCEXURERERERET2hkriRURERERERPYhTdhFRERERERE9iFN2EVERERERET2IU3YRURE\nRERERPYhTdhFRERERERE9qGfhAfwbyDrC/4AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fc770202290>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot Average execution time for the single specified kernel function\n",
+    "ta.plotFunctionStats(\n",
+    "    functions = 'update_curr_fair',\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Since this commit:
  082a82c7c ftrace: add support to report function profiling data
devlib provides support to profile a list of specified kernel functions
by specifying them in the TestEnv configurations, e.g.

```python
my_conf = {
    #... other settings ...
    "ftrace" : {
        "functions" : [
            "select_task_rq_fair",
            "pick_next_task_fair",
        ],
    },
}
```
This patch adds the required support from the LISA side to parse the
functions profiling data and return a data frame for a specified list
of functions.

With such a configuration, functions profiling data can be collected using
this API:

```python
# Collect and keep track of the performance data
stats_file = os.path.join(te.res_dir, 'trace.stats')
te.ftrace.get_stats(stats_file)
```

This series adds the required LISA support in Trace and TraceAnalysis to:
1) build a DataFrame out of kernel functions profiling data
2) plot kernel functions profiling data

Moreover, an example Notebook is added as well to show how to use the new API.