### PR TITLE
tests/stune: Document the stune smoke_test_ramp test

### DIFF
--- a/tests/stune/smoke_test_ramp.py
+++ b/tests/stune/smoke_test_ramp.py
@@ -27,17 +27,40 @@ TESTS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 TESTS_CONF = os.path.join(TESTS_DIRECTORY, "smoke_test_ramp.config")
 
 class STune(LisaTest):
-    """Tests for SchedTune framework"""
+    """
+    Goal
+    ====
+
+    Verify that a task in a SchedTune cgroup is boosted
+
+    Detailed Description
+    ====================
+
+    The test runs a ramp task that has increasing load as time passes.
+    The load increases from 5% to 60% over 1 second.  It is run in
+    four different configurations: no boost, 15% boost, 30% boost and
+    60% boost.
+
+    Expected Behaviour
+    ==================
+
+    The margin of the task should match the formula
+
+    .. math::
+
+          (sched\_load\_scale - util) \\times boost
+
+    for all configurations
+
+    """
+
 
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super(STune, cls)._init(TESTS_CONF, *args, **kwargs)
 
     def test_boosted_utilization_signal(self):
-        """The boosted utilization signal is appropriately boosted
-
-        The margin should match the formula
-        (sched_load_scale - util) * boost"""
+        """Tasks in stune groups are boosted"""
 
         for tc in self.conf["confs"]:
             test_id = tc["tag"]


### PR DESCRIPTION
Similar to 55eee3cb6f1f ("tests/eas/hmp_parity: Add descriptions for tests") but for `tests/stune/smoke_test_ramp.py`.  Improve the description so that people don't have to read the code to have an idea of what the test does.