### PR TITLE
Vagrantfile: install psutil

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
         openjdk-7-jre pkg-config python-all-dev python-matplotlib \
         python-nose python-numpy python-pip python-zmq sshpass trace-cmd \
         tree wget
-    sudo pip install ipython[notebook] pandas wrapt
+    sudo pip install ipython[notebook] pandas psutil wrapt
     sudo apt-get remove -y w3m
 
     ln -s /vagrant /home/vagrant/lisa


### PR DESCRIPTION
Since 6bfc3ba409b7 ("libs/utils/energy: add support for remote IIO energy
probing") you need psutil if you want to import `TestEnv`.
Install it in the vagrant box to avoid the following error when running
tests:

```
[LISAShell lisa] \> nosetests -v tests/eas/hmp_parity.py:ForkMigration
Failure: ImportError (No module named psutil) ... ERROR

======================================================================
ERROR: Failure: ImportError (No module named psutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/loader.py", line 411, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/vagrant/tests/eas/hmp_parity.py", line 18, in <module>
    from env import TestEnv
  File "/home/vagrant/lisa/libs/utils/env.py", line 31, in <module>
    from energy import EnergyMeter
  File "/home/vagrant/lisa/libs/utils/energy.py", line 22, in <module>
    import psutil
ImportError: No module named psutil

----------------------------------------------------------------------
Ran 1 test in 0.002s

FAILED (errors=1)
```