### PR TITLE
Add generic boards support

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -357,16 +357,6 @@ class TestEnv(ShareState):
             platform = Platform(model='MT8173')
             self.__modules = ['bl', 'cpufreq']
 
-        # Initialize N5X device
-        elif self.conf['board'].upper() == 'N5X':
-            platform = Platform(model='bullhead',
-                                core_names = ['A53', 'A53', 'A53', 'A53',
-                                              'A57', 'A57'],
-                                core_clusters = [ 0, 0, 0, 0, 1, 1],
-                                big_core = 'A57',
-                               )
-            self.__modules = ['bl', 'cpufreq']
-
         elif self.conf['board'] != 'UNKNOWN':
             # Initilize from platform descriptor (if available)
             board = self._load_board(self.conf['board'])

--- a/libs/utils/platforms/nexus5x.json
+++ b/libs/utils/platforms/nexus5x.json
@@ -1,0 +1,9 @@
+{
+    "board" : {
+        "cores" : [
+            "A53", "A53", "A53", "A53", "A57", "A57"
+        ],
+        "big_core" : "A57",
+        "modules" : ["bl", "cpufreq"]
+    }
+}


### PR DESCRIPTION
This is a first set of small modifications to support a more generic interface to defined boards configurations. It still does not completely support a custom number of clusters but should be a nice starting point to merge, especially to simplify the description of new boards integration.

TODO: add support functions required to have a complete "more than two clusters" support.