### PR TITLE
libs/wlgen/workload: fix background execution for Android targets

### DIFF
--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -226,7 +226,10 @@ class Workload(object):
         # Start task in background if required
         if background:
             logging.debug('%14s - WlGen [background]: %s', 'WlGen', self.command)
-            self.target.kick_off(self.command, as_root=as_root)
+            if cgroup:
+                self.target.kick_off(self.command, as_root=as_root)
+            else:
+                self.target.background(self.command, as_root=as_root)
             self.output['executor'] = ''
 
         # Start task in foreground


### PR DESCRIPTION
Commit c83009d8fc9c ("libs/wlgen/workload: fix background execution when CGroups are in use") changed the command for a Workload that runs in the background from `target.background()` to `target.kick_off()`.  Sadly, `target.kick_off()` is broken for Android targets, see ARM-software/devlib#55.

As c83009d8fc9c only talked about problems with cgroups and `target.background()`, probably due to interactions with `cgroup_run_into.sh`.  As a compromise, run `target.kick_off()` for cgroup
and `target.background()` if cgroup is not set.