### PR TITLE
Update workloads execution

### DIFF
--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -199,18 +199,18 @@ class Workload(object):
         # Prepend eventually required taskset command
         if self.cpus:
             cpus_mask = self.getCpusMask(self.cpus)
-            self.taskset_cmd = '{0:s}/taskset 0x{1:X}'\
+            self.taskset_cmd = '{}/taskset 0x{:X}'\
                     .format(self.target.executables_directory,
                             cpus_mask)
-            self.command = '{0:s} {1:s}'\
+            self.command = '{} {}'\
                     .format(self.taskset_cmd, self.command)
 
-        # Prepend eventually required taskset command
+        # Prepend eventually required cgroup command
         if self.cgroup and self.cgroup_cmd == '':
-            self.cgroup_cmd = 'cgroups_run_into {1:s}'\
+            self.cgroup_cmd = 'cgroups_run_into {}'\
                 .format(self.target.executables_directory,
                         self.cgroup)
-            self.command = '{0:s} \'{1:s} \''\
+            self.command = '{} \'{}\''\
                 .format(self.cgroup_cmd, self.command)
 
         # Start FTrace (if required)

--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -217,7 +217,8 @@ class Workload(object):
 
         # Prepend eventually required cgroup command
         if self.cgroup:
-            self.cgroup_cmd = 'cgroups_run_into {}'.format(self.cgroup)
+            self.cgroup_cmd = '{} cgroups_run_into {}'\
+                    .format(self.target.shutils, self.cgroup.name)
             _command = '{} {}'.format(self.cgroup_cmd, _command)
 
         # Start FTrace (if required)
@@ -233,23 +234,15 @@ class Workload(object):
         # Start task in background if required
         if background:
             logging.debug('%14s - WlGen [background]: %s', 'WlGen', _command)
-            self.target.kick_off(_command, as_root=as_root)
+            self.target.background(_command, as_root=as_root)
             self.output['executor'] = ''
 
         # Start task in foreground
         else:
-
             logging.info('%14s - Workload execution START:', 'WlGen')
             logging.info('%14s -    %s', 'WlGen', _command)
-
             # Run command and wait for it to complete
-            if cgroup:
-                results = self.target._execute_util(_command,
-                                                    as_root=True)
-            else:
-                results = self.target.execute(_command, timeout=None,
-                                              as_root=as_root)
-            # print type(results)
+            results = self.target.execute(_command, as_root=as_root)
             self.output['executor'] = results
 
         # Wait `end_pause` seconds before stopping ftrace

--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -218,7 +218,7 @@ class Workload(object):
         # Prepend eventually required cgroup command
         if self.cgroup:
             self.cgroup_cmd = 'cgroups_run_into {}'.format(self.cgroup)
-            _command = '{} \'{}\''.format(self.cgroup_cmd, _command)
+            _command = '{} {}'.format(self.cgroup_cmd, _command)
 
         # Start FTrace (if required)
         if ftrace:


### PR DESCRIPTION
This is a series of updated related to wlgen workload executions which mainly:

- simplify the code to run commands in foreground/backgroud
- allows to specify different CPUs and/or CGroups at each run (without need to reconfigure the workload)

This series should also fix and close #162 
