### PR TITLE
EAS HMP-parity test improvements

### DIFF
--- a/tests/eas/hmp_parity.config
+++ b/tests/eas/hmp_parity.config
@@ -15,6 +15,10 @@
         "tools"    : [ "rt-app" ],
         "ftrace" : {
              "events" : [
+                 "sched_energy_diff",
+                 "sched_load_avg_task",
+                 "sched_load_avg_cpu",
+                 "sched_migrate_task",
                  "sched_switch"
              ],
              "buffsize" : 10240

--- a/tests/eas/hmp_parity.config
+++ b/tests/eas/hmp_parity.config
@@ -8,6 +8,7 @@
     "STEP_LOW_DCYCLE" : 10,
     "STEP_HIGH_DCYCLE" : 50,
     "EXPECTED_RESIDENCY_PCT" : 85,
+    "OFFLOAD_MIGRATION_MIGRATOR_DELAY": 1,
     "TEST_CONF" : {
         "modules"  : [ "bl", "cpufreq" ],
         "tools"    : [ "rt-app" ],

--- a/tests/eas/hmp_parity.config
+++ b/tests/eas/hmp_parity.config
@@ -9,6 +9,7 @@
     "STEP_HIGH_DCYCLE" : 50,
     "EXPECTED_RESIDENCY_PCT" : 85,
     "OFFLOAD_MIGRATION_MIGRATOR_DELAY": 1,
+    "EXPECTED_BIG_BUSY_TIME_PCT": 90,
     "TEST_CONF" : {
         "modules"  : [ "bl", "cpufreq" ],
         "tools"    : [ "rt-app" ],

--- a/tests/eas/hmp_parity.py
+++ b/tests/eas/hmp_parity.py
@@ -340,7 +340,7 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
     def populate_tasks(cls):
         migrator_workload = BIG_WORKLOAD.copy()
         migrator_workload["duration_s"] = 9
-        migrator_workload["delay_s"] = 1
+        migrator_workload["delay_s"] = OFFLOAD_MIGRATION_MIGRATOR_DELAY
 
         for idx in range(cls.num_tasks):
             task = "early_starters" + str(idx)

--- a/tests/eas/hmp_parity.py
+++ b/tests/eas/hmp_parity.py
@@ -565,6 +565,8 @@ class WakeMigration(unittest.TestCase):
             task_name = "{}_{}".format(cls.task_prefix, i)
             cls.params[task_name] = Step(**STEP_WORKLOAD).get()
 
+        cls.phase_duration = STEP_WORKLOAD["time_s"]
+
     @classmethod
     def run_workload(cls):
         wload = RTA(
@@ -602,7 +604,7 @@ class WakeMigration(unittest.TestCase):
 
     def test_little_big_switch1(self):
         """Wake Migration: LITTLE -> BIG: 1"""
-        expected_time = self.offset + 5
+        expected_time = self.offset + self.phase_duration
         switch_window = (
             expected_time -
             SWITCH_WINDOW_HALF,
@@ -632,7 +634,11 @@ class WakeMigration(unittest.TestCase):
     def test_little_big_switch2(self):
         """Wake Migration: LITTLE -> BIG: 2"""
 
-        expected_time = self.offset + 15
+        # little - big - little - big
+        #                       ^
+        # We want to test that this little to big migration happens.  So we skip
+        # the first three phases.
+        expected_time = self.offset + 3 * self.phase_duration
         switch_window = (
             expected_time -
             SWITCH_WINDOW_HALF,
@@ -688,7 +694,11 @@ class WakeMigration(unittest.TestCase):
     def test_big_little_switch2(self):
         """Wake Migration: BIG -> LITLLE: 2"""
 
-        expected_time = self.offset + 10
+        # little - big - little - big
+        #              ^
+        # We want to test that this big to little migration happens.  So we skip
+        # the first two phases.
+        expected_time = self.offset + 2 * self.phase_duration
         switch_window = (
             expected_time -
             SWITCH_WINDOW_HALF,

--- a/tests/eas/hmp_parity.py
+++ b/tests/eas/hmp_parity.py
@@ -109,8 +109,8 @@ class ForkMigration(unittest.TestCase):
     Detailed Description
     ====================
 
-    The test spawns as many threads as there are little cores.  It
-    then checks that all threads started on a big core.
+    The test spawns as many threads as there are cores in the system.
+    It then checks that all threads started on a big core.
 
     Expected Behaviour
     ==================
@@ -138,12 +138,14 @@ class ForkMigration(unittest.TestCase):
 
     @classmethod
     def populate_params(cls):
+        big_prefix = cls.task_prefix + "_big"
         for idx in range(len(cls.env.target.bl.bigs)):
-            task = cls.task_prefix + str(idx)
+            task = big_prefix + str(idx)
             cls.params[task] = Periodic(**BIG_WORKLOAD).get()
 
+        little_prefix = cls.task_prefix + "_little"
         for idx in range(len(cls.env.target.bl.littles)):
-            task = cls.task_prefix + str(idx)
+            task = little_prefix + str(idx)
             cls.params[task] = Periodic(**SMALL_WORKLOAD).get()
 
     @classmethod

--- a/tests/eas/hmp_parity.py
+++ b/tests/eas/hmp_parity.py
@@ -521,10 +521,11 @@ class WakeMigration(unittest.TestCase):
     Detailed Description
     ====================
 
-    This test creates two tasks that alternate between being big and
-    small workload.  They start being small load for 5 seconds, they
-    become big for another 5 seconds, then small for another 5 seconds
-    and finally big for the last 5 seconds.
+    This test creates as many tasks as there are big cpus.  The tasks
+    alternate between high and low utilization.  They start being
+    small load for 5 seconds, they become big for another 5 seconds,
+    then small for another 5 seconds and finally big for the last 5
+    seconds.
 
     Expected Behaviour
     ==================
@@ -558,8 +559,11 @@ class WakeMigration(unittest.TestCase):
 
     @classmethod
     def populate_params(cls):
-        cls.params[cls.task_prefix] = Step(**STEP_WORKLOAD).get()
-        cls.params[cls.task_prefix + "1"] = Step(**STEP_WORKLOAD).get()
+        num_big_cpus = len(cls.env.target.bl.bigs)
+
+        for i in range(num_big_cpus):
+            task_name = "{}_{}".format(cls.task_prefix, i)
+            cls.params[task_name] = Step(**STEP_WORKLOAD).get()
 
     @classmethod
     def run_workload(cls):

--- a/tests/eas/hmp_parity.py
+++ b/tests/eas/hmp_parity.py
@@ -321,15 +321,12 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
 
         cls.offset = cls.get_offset(cls.early_starters[0])
 
-        cls.m_assert = SchedMultiAssert(
-            cls.trace_file,
-            cls.env.topology,
-            execnames=cls.migrators)
+        cls.trace = trappy.FTrace(cls.trace_file)
+        cls.m_assert = SchedMultiAssert(cls.trace, cls.env.topology,
+                                        execnames=cls.migrators)
+        cls.e_assert = SchedMultiAssert(cls.trace, cls.env.topology,
+                                        execnames=cls.early_starters)
 
-        cls.e_assert = SchedMultiAssert(
-            cls.trace_file,
-            cls.env.topology,
-            execnames=cls.early_starters)
         cls.log_fh = open(os.path.join(cls.env.res_dir, cls.log_file), "w")
 
     @classmethod
@@ -370,7 +367,7 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
     @classmethod
     def get_offset(cls, task_name):
         return SchedAssert(
-            cls.trace_file,
+            cls.trace,
             cls.env.topology,
             execname=task_name).getStartTime()
 


### PR DESCRIPTION
A number of improvements to fix tests failing when they shouldn't. The new "Offload migration and idle pull" test needs an updated bart.  Trappy also has a new version, so update both modules while we are at it.