### PR TITLE
libs/wlgen/workload: fix rt-app execution when using cgroups

### DIFF
--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -210,7 +210,7 @@ class Workload(object):
             self.cgroup_cmd = 'cgroups_run_into {1:s}'\
                 .format(self.target.executables_directory,
                         self.cgroup)
-            self.command = '{0:s} \'{1:s}\''\
+            self.command = '{0:s} \'{1:s} \''\
                 .format(self.cgroup_cmd, self.command)
 
         # Start FTrace (if required)


### PR DESCRIPTION
Commit 655e3f03767c ("libs/wlgen/rtapp: fix calibration for versions of Android >=N") added an innocent 2>&1 at the end of the rt-app command.  When running rt-app with cgroups enabled on an Android system this gets executed as the following monstrosity:
```
adb -s 10.1.210.35:5555 shell '(echo '\''/data/local/tmp/bin/shutils cgroups_run_into / '\''\\'\'''\''/data/local/tmp/bin/rt-app /data/local/tmp/devlib-target/run_dir/mixprof_00.json 2>&1'\''\\'\'''\'''\'' | su); echo "$?"
```

The fact that the `2>&1` has a host of `'` after it ends up confusing the shell, which tries to redirect the stderr to file descriptor `1'` , which doesn't exist and it fails (but crucially, devlib doesn't see that it
failed, `echo $?` returns 0).

If we add a space between `2>&1` and its single quotes, we avoid confusing the shell.  The command now becomes:
```
adb -s 10.1.210.35:5555 shell '(echo '\''/data/local/tmp/bin/shutils cgroups_run_into / '\''\\'\'''\''/data/local/tmp/bin/rt-app /data/local/tmp/devlib-target/run_dir/mixprof_00.json 2>&1 '\''\\'\'''\'''\'' | su); echo "$?"
```