### PR TITLE
ipynb: remove the add_parsed_event() hack in the UseCaseExamples notebook

### DIFF
--- a/ipynb/tutorial/UseCaseExamples_SchedTuneAnalysis.ipynb
+++ b/ipynb/tutorial/UseCaseExamples_SchedTuneAnalysis.ipynb
@@ -1628,26 +1628,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false,
-    "hidden": true
-   },
-   "outputs": [],
-   "source": [
-    "# Get the boost events related to the RTApp task\n",
-    "df = trace.data_frame.trace_event('sched_boost_task')\n",
-    "df = df[df.comm == 'task_ramp']\n",
-    "\n",
-    "# Use them to create a new \"boost_task_rtapp\" TRAPpy class\n",
-    "trace.ftrace.add_parsed_event(\"boost_task_rtapp\", df)\n",
-    "\n",
-    "# df = trace.data_frame.trace_event('boost_task_rtapp')\n",
-    "# df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 7,
    "metadata": {
     "collapsed": false,
@@ -1661,12 +1641,11 @@
     "analyzer_config = {\n",
     "    \"SCALE\" : 1024,\n",
     "    \"BOOST\" : 15,\n",
-    "    \"RTAPP\" : trace.ftrace.boost_task_rtapp,\n",
     "}\n",
     "\n",
     "# Verify that the margin is properly computed for each event:\n",
     "# margin := (scale - util) * boost\n",
-    "margin_check_statement = \"(((SCALE - RTAPP:util) * BOOST) // 100) == RTAPP:margin\""
+    "margin_check_statement = \"(((SCALE - sched_boost_task:util) * BOOST) // 100) == sched_boost_task:margin\""
    ]
   },
   {
@@ -1683,7 +1662,8 @@
     "# Create an Assertion Object\n",
     "a = Analyzer(trace.ftrace,\n",
     "             analyzer_config,\n",
-    "             window=last_phase)"
+    "             window=last_phase,\n",
+    "             filters={\"comm\": \"task_ramp\"})"
    ]
   },
   {


### PR DESCRIPTION
The bart check of util estimation in the UseCaseExamples_SchedTuneAnalysis notebook starts with code to add the sched_boost_task event filtered by comm back to the trappy `FTrace` object
which is a hack.  This is needed because trappy's grammar module couldn't do it when the notebook was originally written.  trappy learned to apply filters in its `Parser()` object in version 5.7.0, which led to
the simplification of the similar SchedTune test in b9d488f58ab2 ("tests: simplify stune's boosted utilization signal test").

Apply a similar change to the UseCaseExamples_SchedTuneAnalysis ipython notebook.  This way the test is simpler and we educate our users on the ability to use filters with the Analyzer :heart: 