### PR TITLE
lisa_shell: ensure submodules are in sync

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -105,7 +105,7 @@ if [ $ret -ne 0 ]; then
     return $ret
 fi
 
-git diff-index --quiet HEAD
+git diff-index --quiet --ignore-submodules HEAD
 ret=$?
 if [ $ret -ne 0 ]; then
     echo "There are outstanding uncommitted changes."


### PR DESCRIPTION
A "lisa-update all" command fails if submodules are not pointing to
the current tracked head. This can happen if you worked on a submodule's
branch.

This patch ensure that all submodules are reset to point the current
tracked head just before doing an update all. This should ensure to:
1) the submodules reset fails in case there are not commited changes
2) update all checks just for pending modifications in the main project

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>