### PR TITLE
tests/eas/acceptance: Increase required busy time for idle pull test

### DIFF
--- a/tests/eas/acceptance.config
+++ b/tests/eas/acceptance.config
@@ -9,7 +9,7 @@
     "STEP_HIGH_DCYCLE" : 50,
     "EXPECTED_RESIDENCY_PCT" : 85,
     "OFFLOAD_MIGRATION_MIGRATOR_DELAY": 1,
-    "EXPECTED_BIG_BUSY_TIME_PCT": 90,
+    "EXPECTED_BIG_BUSY_TIME_PCT": 99,
     "TEST_CONF" : {
         "modules"  : [ "bl", "cpufreq" ],
         "tools"    : [ "rt-app" ],

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -344,6 +344,7 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
         all_tasks = cls.early_starters + cls.migrators
         cls.a_assert = SchedMultiAssert(cls.trace, cls.env.topology,
                                         execnames=all_tasks)
+        cls.offset = cls.get_offset()
 
         cls.end_times = cls.calculate_end_times()
         cls.log_fh = open(os.path.join(cls.env.res_dir, cls.log_file), "w")
@@ -382,6 +383,11 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
             background=False)
         cls.env.ftrace.stop()
         trace = cls.env.ftrace.get_trace(cls.trace_file)
+
+    @classmethod
+    def get_offset(cls):
+        task_start_times = cls.a_assert.getStartTime().values()
+        return min([t['starttime'] for t in task_start_times])
 
     @classmethod
     def calculate_end_times(cls):
@@ -430,7 +436,7 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
         end_times = sorted(self.end_times.values())
 
         # Window of time until the first migrator finishes
-        window = (0, end_times[-num_big_cpus])
+        window = (self.offset, end_times[-num_big_cpus])
         busy_time = self.a_assert.getCPUBusyTime("cluster",
                                                  self.env.target.bl.bigs,
                                                  window=window, percent=True)


### PR DESCRIPTION
90% is too forgiving for EXPECTED_BIG_BUSY_TIME_PCT, it allows traces to
pass the "Bug cpus are fully loaded" test even when 100% tasks have run
on LITTLE CPUs while big CPUs are idle for significant periods.

Since traces contain a perdiod of inactivity at the beinning, to require
99% busy time it's necessary to adjust the trace window over which
assertions apply. Instead of starting at t=0 we use
SchedMultiAssert.getStartTime to find the time at which the first task
started, and use that as the start of our window.