### PR TITLE
tests/eas/acceptance: increase accuracy of little cpus test in the Offload Migration testcase

### DIFF
--- a/tests/eas/acceptance.config
+++ b/tests/eas/acceptance.config
@@ -9,7 +9,7 @@
     "STEP_HIGH_DCYCLE" : 50,
     "EXPECTED_RESIDENCY_PCT" : 85,
     "OFFLOAD_MIGRATION_MIGRATOR_DELAY": 1,
-    "EXPECTED_BIG_BUSY_TIME_PCT": 99,
+    "OFFLOAD_EXPECTED_BUSY_TIME_PCT": 99,
     "TEST_CONF" : {
         "modules"  : [ "bl", "cpufreq" ],
         "tools"    : [ "rt-app" ],

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -458,7 +458,7 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
                                                      self.env.target.bl.bigs,
                                                      window=window, percent=True)
 
-            expected_busy_time = EXPECTED_BIG_BUSY_TIME_PCT * \
+            expected_busy_time = OFFLOAD_EXPECTED_BUSY_TIME_PCT * \
                                  big_cpus_left / num_big_cpus
             msg = "Big tasks were not running on big cpus from {} to {}".format(
                 window[0], window[1])
@@ -483,7 +483,7 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
 
         window_len = window[1] - window[0]
         expected_busy_time = window_len * num_offloaded_tasks * \
-                             EXPECTED_BIG_BUSY_TIME_PCT / 100.
+                             OFFLOAD_EXPECTED_BUSY_TIME_PCT / 100.
         msg = "Little cpus did not pick up big tasks while big cpus were fully loaded"
 
         self.assertGreater(busy_time, expected_busy_time, msg=msg)

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -400,6 +400,12 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
 
         return end_times
 
+    def get_migrator_activation_time(self):
+        start_times_dict = self.m_assert.getStartTime()
+        start_time = min(t['starttime'] for t in start_times_dict.itervalues())
+
+        return start_time + OFFLOAD_MIGRATION_MIGRATOR_DELAY
+
     def test_first_cpu_early_starters(self):
         """Offload Migration and Idle Pull: Test First CPU (Early Starters)"""
 
@@ -470,7 +476,7 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
             if not first_task_finish_time or (end_time < first_task_finish_time):
                 first_task_finish_time = end_time
 
-        window = (OFFLOAD_MIGRATION_MIGRATOR_DELAY, first_task_finish_time)
+        window = (self.get_migrator_activation_time(), first_task_finish_time)
         busy_time = self.a_assert.getCPUBusyTime("cluster",
                                                  self.env.target.bl.littles,
                                                  window=window)


### PR DESCRIPTION
The window for `test_little_cpus_run_tasks()` was loosely defined as just the migrator delay, which doesn't take into account the time it takes for rt-app to spawn and create its tasks.  After fa4bce7359ec ("tests/eas/acceptance: Increase required busy time for idle pull test"), the test is more strict, so increase the accuracy of the window to meet the new restrictions.