### PR TITLE
utils: remove comments from platform JSON

### DIFF
--- a/libs/utils/platforms/juno.json
+++ b/libs/utils/platforms/juno.json
@@ -1,5 +1,4 @@
 {
-    // JUNO Energy Model
     "nrg_model" : {
         "little" : {
             "cpu" : {

--- a/libs/utils/platforms/tc2.json
+++ b/libs/utils/platforms/tc2.json
@@ -1,5 +1,4 @@
 {
-    // TC2 Energy Model
     "nrg_model" : {
         "little" : {
             "cpu" : {


### PR DESCRIPTION
Proper JSON doesn't actually allow comments -_-

Python 2.7.6's JSON parser throws a ValueError when trying to parse
these files.