### PR TITLE
tests/eas/acceptance: enable sched_is_big_little sysctl

### DIFF
--- a/tests/eas/acceptance.config
+++ b/tests/eas/acceptance.config
@@ -10,6 +10,7 @@
     "EXPECTED_RESIDENCY_PCT" : 85,
     "OFFLOAD_MIGRATION_MIGRATOR_DELAY": 1,
     "OFFLOAD_EXPECTED_BUSY_TIME_PCT": 99,
+    "SET_IS_BIG_LITTLE": true,
     "TEST_CONF" : {
         "modules"  : [ "bl", "cpufreq" ],
         "tools"    : [ "rt-app" ],

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -17,6 +17,8 @@
 
 from env import TestEnv
 from wlgen import RTA, Periodic, Step
+from devlib.target import TargetError
+
 import trappy
 import shutil
 import os
@@ -44,6 +46,13 @@ def local_setup(env):
         env.target.execute(
             "echo ENERGY_AWARE > /sys/kernel/debug/sched_features")
 
+    if SET_IS_BIG_LITTLE:
+        try:
+            env.target.write_value("/proc/sys/kernel/sched_is_big_little", 1)
+        except TargetError:
+            # That flag doesn't exist on mainline-integration kernels, so don't
+            # worry if the file isn't present.
+            pass
 
 def between_threshold_pct(a, b):
     THRESHOLD_PERCENT = 3


### PR DESCRIPTION
Where this sysctl is present, if it isn't enabled the EAS wake path
views the CPUs as a flat list, so that LITTLE CPUs are not necessarily
preferred over big when selecting CPUs for a low-load task. Set it, so
that the WakeMigration and other tests can pass.

Since this flag isn't used by the mainline-integration version of EAS,
we only attempt to set it if the procfs file is present.