### PR TITLE
[Analysis] crop data to user-defined x range - v2

### DIFF
--- a/libs/utils/analysis/frequency_analysis.py
+++ b/libs/utils/analysis/frequency_analysis.py
@@ -446,7 +446,6 @@ class FrequencyAnalysis(AnalysisModule):
 # Utility Methods
 ###############################################################################
 
-    @memoized
     def _getFrequencyResidency(self, cluster):
         """
         Get a DataFrame with per cluster frequency residency, i.e. amount of
@@ -479,7 +478,8 @@ class FrequencyAnalysis(AnalysisModule):
             self._log.warning('Cluster frequency is NOT coherent,'
                               'cannot compute residency!')
             return None
-        cluster_freqs = freq_df[freq_df.cpu == _cluster[0]]
+        cluster_freqs = freq_df[freq_df.cpu == _cluster[0]].frequency
+        cluster_freqs = self._trace._cropToXTimeRange(cluster_freqs)
 
         # Compute TOTAL Time
         time_intervals = cluster_freqs.index[1:] - cluster_freqs.index[:-1]
@@ -490,7 +490,8 @@ class FrequencyAnalysis(AnalysisModule):
         total_time = total_time.groupby(['frequency']).sum()
 
         # Compute ACTIVE Time
-        cluster_active = self._trace.getClusterActiveSignal(_cluster)
+        cluster_active = self._getClusterActiveSignal(_cluster)
+        cluster_active = self._trace._cropToXTimeRange(cluster_active)
 
         # In order to compute the active time spent at each frequency we
         # multiply 2 square waves:

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -167,14 +167,31 @@ class Trace(object):
         :param t_max: upper bound
         :type t_max: int or float
         """
-        if t_min is None:
-            self.x_min = 0
-        else:
-            self.x_min = t_min
-        if t_max is None:
-            self.x_max = self.time_range
-        else:
-            self.x_max = t_max
+        self.x_min = self.window[0]
+        self.x_max = self.window[1]
+
+        if t_min is not None:
+            if t_min < self.x_min:
+                self._log.warning('t_min out of range: '
+                                  'capping to trace minimum %.6f [s]',
+                                  self.x_min)
+            elif t_min > self.x_max:
+                raise ValueError('t_min out of range: '
+                                 'trace boundaries are ({:.6f}, {:.6f}) [s]'\
+                                 .format(self.x_min, self.x_max))
+            else:
+                self.x_min = t_min
+        if t_max is not None:
+            if t_max > self.x_max:
+                self._log.warning('t_max out of range: '
+                                  'capping to trace maximum %.6f [s]',
+                                  self.x_max)
+            elif t_max < self.x_min:
+                raise ValueError('t_max out of range: '
+                                 'trace boundaries are ({:.6f}, {:.6f}) [s]'\
+                                 .format(self.window[0], self.x_max))
+            else:
+                self.x_max = t_max
         self._log.debug('Set plots time range to (%.6f, %.6f)[s]',
                        self.x_min, self.x_max)
 

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -319,18 +319,7 @@ class Trace(object):
         """
         Compute time axis range, considering all the parsed events.
         """
-        ts = sys.maxint
-        te = 0
-
-        for events in self.available_events:
-            df = self._dfg_trace_event(events)
-            if len(df) == 0:
-                continue
-            if (df.index[0]) < ts:
-                ts = df.index[0]
-            if (df.index[-1]) > te:
-                te = df.index[-1]
-            self.time_range = te - ts
+        self.time_range = self.ftrace.get_duration()
 
         self._log.debug('Collected events spans a %.3f [s] time interval',
                        self.time_range)

--- a/tests/lisa/test_trace.py
+++ b/tests/lisa/test_trace.py
@@ -78,3 +78,38 @@ class TestTrace(TestCase):
         self.assertEqual(trace.getTaskByName('father'), [1234])
 
         os.remove(self.test_trace)
+
+    def test_setXTimeRange(self):
+        """
+        TestTrace: setXTimeRange() properly update user-specified trace time
+        boundaries.
+        """
+        # Test min and max values out of range
+        t_min = self.trace.window[1] + 10
+        with self.assertRaises(ValueError):
+            self.trace.setXTimeRange(t_min=t_min)
+
+        t_max = self.trace.window[0] - 10
+        with self.assertRaises(ValueError):
+            self.trace.setXTimeRange(t_max=t_max)
+
+        # Test min/max set to valid values in the range
+        # [trace.window[0], trace.window[1]]
+        t_min = self.trace.window[0] + 1
+        t_max = self.trace.window[1] - 1
+        self.trace.setXTimeRange(t_min, t_max)
+        self.assertEqual(self.trace.x_min, t_min)
+        self.assertEqual(self.trace.x_max, t_max)
+
+        # Test min/max reset to trace.window[0]/trace.window[1]
+        self.trace.setXTimeRange()
+        self.assertEqual(self.trace.x_min, self.trace.window[0])
+        self.assertEqual(self.trace.x_max, self.trace.window[1])
+
+        # Test min value and max capped to trace minimum and maximum
+        # respectively
+        t_min = self.trace.window[0] - 10
+        t_max = self.trace.window[1] + 10
+        self.trace.setXTimeRange(t_min, t_max)
+        self.assertEqual(self.trace.x_min, self.trace.window[0])
+        self.assertEqual(self.trace.x_max, self.trace.window[1])

--- a/tests/lisa/test_trace.py
+++ b/tests/lisa/test_trace.py
@@ -113,3 +113,18 @@ class TestTrace(TestCase):
         self.trace.setXTimeRange(t_min, t_max)
         self.assertEqual(self.trace.x_min, self.trace.window[0])
         self.assertEqual(self.trace.x_max, self.trace.window[1])
+
+    def test_cropToXTimeRange(self):
+        """
+        TestTrace: cropToXTimeRange() properly crops the data frame to the X
+        time range specified by the user through setXTimeRange().
+        """
+        series = self.trace.data_frame.trace_event('sched_switch').prev_state
+
+        t_min = self.trace.window[0] + 2
+        t_max = self.trace.window[1] - 2
+        self.trace.setXTimeRange(t_min, t_max)
+
+        cropped_series = self.trace._cropToXTimeRange(series)
+        self.assertTrue(cropped_series.index[0] >= t_min)
+        self.assertTrue(cropped_series.index[-1] <= t_max)


### PR DESCRIPTION
This is v2 of #142. Differences with respect to previous PR:
- Simplified time range computation by getting it from TRAPpy
- Added a method to compute the plot window instead of calculating it in `__parseTrace()`. Also, it avoids the `window` attribute to have `None` values, but rather sets the two plot bounds to the actual plot window. This provides a reference from where to get the range of values that represent the boundaries for the x time range.

close #142 
