### PR TITLE
vagrant: do no apply filters to update Android SDK

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,8 +32,7 @@ Vagrant.configure(2) do |config|
         wget -qO- $ANDROID_SDK_URL | tar xz -C tools
         expect -c '
             set timeout -1;
-            spawn ./tools/android-sdk-linux/tools/android update sdk --no-ui \
-                -t tool,platform-tool,platform,build-tools-24.0.1;
+            spawn ./tools/android-sdk-linux/tools/android update sdk --no-ui
             expect {
                 "Do you accept the license" { exp_send "y\r" ; exp_continue }
                 eof


### PR DESCRIPTION
Let Android SDK Manager decide what to update.

Apparently with filters the build-tools are not installed. This seems to
solve the issue.