### PR TITLE
Rework EAS acceptance tests to inherit from LisaTest

### DIFF
--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -99,8 +99,9 @@ class Executor():
         self.te = TestEnv(target_conf, tests_conf)
         self.target = self.te.target
 
+        self._iterations = self._tests_conf.get('iterations', 1)
         # Compute total number of experiments
-        self._exp_count = self._tests_conf['iterations'] \
+        self._exp_count = self._iterations \
                 * len(self._tests_conf['wloads']) \
                 * len(self._tests_conf['confs'])
 
@@ -116,7 +117,7 @@ class Executor():
 
         logging.info('%14s -   %3d workloads (%d iterations each)',
                      'Executor', len(self._tests_conf['wloads']),
-                     self._tests_conf['iterations'])
+                     self._iterations)
         wload_confs = ', '.join(self._tests_conf['wloads'])
         logging.info('%14s -       %s', 'Executor', wload_confs)
 
@@ -138,7 +139,7 @@ class Executor():
             for wl_idx in self._tests_conf['wloads']:
                 # TEST: configuration
                 wload = self._wload_init(tc, wl_idx)
-                for itr_idx in range(1, self._tests_conf['iterations']+1):
+                for itr_idx in range(1, self._iterations + 1):
                     # WORKLOAD: execution
                     self._wload_run(exp_idx, tc, wl_idx, wload, itr_idx)
                     exp_idx += 1
@@ -491,7 +492,7 @@ class Executor():
         self._print_title('Executor', 'Experiment {}/{}, [{}:{}] {}/{}'\
                 .format(exp_idx, self._exp_count,
                         tc_idx, wl_idx,
-                        run_idx, self._tests_conf['iterations']))
+                        run_idx, self._iterations))
 
         # Setup local results folder
         self._wload_run_init(run_idx)

--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -485,12 +485,6 @@ class Executor():
         logging.debug(r'%14s - out_dir [%s]', 'Executor', self.te.out_dir)
         os.system('mkdir -p ' + self.te.out_dir)
 
-        logging.debug(r'%14s - cleanup target output folder', 'Executor')
-
-        target_dir = self.target.working_directory
-        logging.debug('%14s - setup target directory [%s]',
-                'Executor', target_dir)
-
     def _wload_run(self, exp_idx, tc, wl_idx, wload, run_idx):
         tc_idx = tc['tag']
 

--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -130,19 +130,28 @@ class Executor():
     def run(self):
         self._print_section('Executor', 'Experiments execution')
 
+        self.experiments = []
+
         # Run all the configured experiments
-        exp_idx = 1
         for tc in self._tests_conf['confs']:
             # TARGET: configuration
             if not self._target_configure(tc):
                 continue
             for wl_idx in self._tests_conf['wloads']:
                 # TEST: configuration
-                wload = self._wload_init(tc, wl_idx)
+                wload, test_dir = self._wload_init(tc, wl_idx)
                 for itr_idx in range(1, self._iterations + 1):
-                    # WORKLOAD: execution
-                    self._wload_run(exp_idx, tc, wl_idx, wload, itr_idx)
-                    exp_idx += 1
+                    self.experiments.append({
+                        'wload_name' : wl_idx,
+                        'wload'      : wload,
+                        'conf'       : tc,
+                        'iteration'  : itr_idx,
+                        'out_dir'    : os.path.join(test_dir, str(itr_idx))
+                    })
+
+            # WORKLOAD: execution
+            for exp_idx, experiment in enumerate(self.experiments):
+                self._wload_run(exp_idx, experiment)
 
         self._print_section('Executor', 'Experiments execution completed')
         logging.info('%14s - Results available in:', 'Executor')
@@ -464,38 +473,38 @@ class Executor():
         wload = self._wload_conf(wl_idx, wlspec)
 
         # Keep track of platform configuration
-        self.te.test_dir = '{}/{}:{}:{}'\
-            .format(self.te.res_dir, wload.wtype, tc_idx, wl_idx)
-        os.system('mkdir -p ' + self.te.test_dir)
-        self.te.platform_dump(self.te.test_dir)
+        test_dir = '{}/{}:{}:{}'.format(self.te.res_dir, wload.wtype,
+                                        tc_idx, wl_idx)
+        os.system('mkdir -p ' + test_dir)
+        self.te.platform_dump(test_dir)
 
         # Keep track of kernel configuration and version
         config = self.target.config
-        with gzip.open(os.path.join(self.te.test_dir, 'kernel.config'), 'wb') as fh:
+        with gzip.open(os.path.join(test_dir, 'kernel.config'), 'wb') as fh:
             fh.write(config.text)
         output = self.target.execute('{} uname -a'\
                 .format(self.target.busybox))
-        with open(os.path.join(self.te.test_dir, 'kernel.version'), 'w') as fh:
+        with open(os.path.join(test_dir, 'kernel.version'), 'w') as fh:
             fh.write(output)
 
-        return wload
+        return wload, test_dir
 
-    def _wload_run_init(self, run_idx):
-        self.te.out_dir = '{}/{}'\
-                .format(self.te.test_dir, run_idx)
-        logging.debug(r'%14s - out_dir [%s]', 'Executor', self.te.out_dir)
-        os.system('mkdir -p ' + self.te.out_dir)
+    def _wload_run_init(self, experiment):
+        experiment['out_dir'] = _get_experiment_out_dir(experiment)
 
-    def _wload_run(self, exp_idx, tc, wl_idx, wload, run_idx):
+    def _wload_run(self, exp_idx, experiment):
+        tc = experiment['conf']
+        wload = experiment['wload']
         tc_idx = tc['tag']
 
         self._print_title('Executor', 'Experiment {}/{}, [{}:{}] {}/{}'\
-                .format(exp_idx, self._exp_count,
-                        tc_idx, wl_idx,
-                        run_idx, self._iterations))
+                .format(exp_idx, self._exp_count, # todo len(self.experiments?)
+                        tc_idx, experiment['wload_name'],
+                        experiment['iteration'], self._iterations))
 
         # Setup local results folder
-        self._wload_run_init(run_idx)
+        logging.debug(r'%14s - out_dir [%s]', 'Executor', experiment['out_dir'])
+        os.system('mkdir -p ' + experiment['out_dir'])
 
         # FTRACE: start (if a configuration has been provided)
         if self.te.ftrace and self._target_conf_flag(tc, 'ftrace'):
@@ -507,23 +516,23 @@ class Executor():
             self.te.emeter.reset()
 
         # WORKLOAD: Run the configured workload
-        wload.run(out_dir=self.te.out_dir, cgroup=self._cgroup)
+        wload.run(out_dir=experiment['out_dir'], cgroup=self._cgroup)
 
         # ENERGY: collect measurements
         if self.te.emeter:
-            self.te.emeter.report(self.te.out_dir)
+            self.te.emeter.report(experiment['out_dir'])
 
         # FTRACE: stop and collect measurements
         if self.te.ftrace and self._target_conf_flag(tc, 'ftrace'):
             self.te.ftrace.stop()
 
-            trace_file = self.te.out_dir + '/trace.dat'
+            trace_file = experiment['out_dir'] + '/trace.dat'
             self.te.ftrace.get_trace(trace_file)
             logging.info(r'%14s - Collected FTrace binary trace:', 'Executor')
             logging.info(r'%14s -    %s', 'Executor',
                          trace_file.replace(self.te.res_dir, '<res_dir>'))
 
-            stats_file = self.te.out_dir + '/trace_stat.json'
+            stats_file = experiment['out_dir'] + '/trace_stat.json'
             self.te.ftrace.get_stats(stats_file)
             logging.info(r'%14s - Collected FTrace function profiling:', 'Executor')
             logging.info(r'%14s -    %s', 'Executor',

--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -376,9 +376,7 @@ class Executor():
         if conf['class'] == 'profile':
             params = {}
             # Load each task specification
-            for task_name in conf['params']:
-                task = conf['params'][task_name]
-                task_name = conf['prefix'] + task_name
+            for task_name, task in conf['params'].items():
                 if task['kind'] not in wlgen.__dict__:
                     logging.error(r'%14s - RTA task of kind [%s] not supported',
                             'RTApp', task['kind'])

--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -385,7 +385,12 @@ class Executor():
                         'in RT-App workload specification'\
                         .format(task))
                 task_ctor = getattr(wlgen, task['kind'])
-                params[task_name] = task_ctor(**task['params']).get()
+                task_idxs = self._wload_task_idxs(wl_idx, task['tasks'])
+                for idx in task_idxs:
+                    idx_name = str(idx) if len(task_idxs) > 0 else ""
+                    task_name_idx = conf['prefix'] + task_name + idx_name
+                    params[task_name_idx] = task_ctor(**task['params']).get()
+
             rtapp = wlgen.RTA(self.target,
                         wl_idx, calibration = self.te.calibration())
             rtapp.conf(kind='profile', params=params, loadref=loadref,

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -20,7 +20,6 @@ from wlgen import RTA, Periodic, Step
 from devlib.target import TargetError
 
 import trappy
-import shutil
 import os
 import unittest
 import logging

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -54,26 +54,6 @@ def local_setup(env):
             # worry if the file isn't present.
             pass
 
-def between_threshold_pct(a, b):
-    THRESHOLD_PERCENT = 3
-    lower = b - THRESHOLD_PERCENT
-    upper = b + THRESHOLD_PERCENT
-
-    if a >= lower and a <= upper:
-        return True
-    return False
-
-
-def between_threshold_abs(a, b):
-    THRESHOLD = 0.25
-    lower = b - THRESHOLD
-    upper = b + THRESHOLD
-
-    if a >= lower and a <= upper:
-        return True
-    return False
-
-
 SMALL_WORKLOAD = {
 
     "duty_cycle_pct": SMALL_DCYCLE,

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -457,11 +457,7 @@ class OffloadMigrationAndIdlePull(unittest.TestCase):
         tasks = self.params.keys()
         num_offloaded_tasks = len(tasks) / 2
 
-        first_task_finish_time = None
-        for task in tasks:
-            end_time = self.end_times[task]
-            if not first_task_finish_time or (end_time < first_task_finish_time):
-                first_task_finish_time = end_time
+        first_task_finish_time = min(self.end_times.values())
 
         window = (self.get_migrator_activation_time(), first_task_finish_time)
         busy_time = self.a_assert.getCPUBusyTime("cluster",

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -135,7 +135,7 @@ class EasTest(LisaTest):
                 rank=len(tasks)),
             msg="Not all the new generated tasks started on a big CPU")
 
-class ForkMigration(unittest.TestCase):
+class ForkMigration(EasTest):
     """
     Goal
     ====
@@ -154,67 +154,7 @@ class ForkMigration(unittest.TestCase):
     The threads start on a big core.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.params = {}
-        cls.task_prefix = "fmig"
-        cls.env = TestEnv(test_conf=TEST_CONF)
-        cls.trace_file = os.path.join(cls.env.res_dir, "fork_migration.dat")
-        cls.log_file = os.path.join(cls.env.res_dir, "fork_migration.json")
-        cls.populate_params()
-        cls.tasks = cls.params.keys()
-        cls.num_tasks = len(cls.tasks)
-        local_setup(cls.env)
-        cls.run_workload()
-        cls.log_fh = open(os.path.join(cls.env.res_dir, cls.log_file), "w")
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.log_fh.close()
-
-    @classmethod
-    def populate_params(cls):
-        big_prefix = cls.task_prefix + "_big"
-        for idx in range(len(cls.env.target.bl.bigs)):
-            task = big_prefix + str(idx)
-            cls.params[task] = Periodic(**BIG_WORKLOAD).get()
-
-        little_prefix = cls.task_prefix + "_little"
-        for idx in range(len(cls.env.target.bl.littles)):
-            task = little_prefix + str(idx)
-            cls.params[task] = Periodic(**SMALL_WORKLOAD).get()
-
-    @classmethod
-    def run_workload(cls):
-        wload = RTA(
-            cls.env.target,
-            "fork_migration",
-            calibration=cls.env.calibration())
-        wload.conf(kind="profile", params=cls.params)
-        cls.env.ftrace.start()
-        wload.run(
-            out_dir=cls.env.res_dir,
-            background=False)
-        cls.env.ftrace.stop()
-        trace = cls.env.ftrace.get_trace(cls.trace_file)
-
-    def test_first_cpu(self):
-        "Fork Migration: Test First CPU"
-
-        logging.info("Fork Migration: Test First CPU")
-        f_assert = SchedMultiAssert(
-            self.trace_file,
-            self.env.topology,
-            execnames=self.tasks)
-
-        log_result(
-            f_assert.getFirstCpu(), self.log_fh)
-
-        self.assertTrue(
-            f_assert.assertFirstCpu(
-                self.env.target.bl.bigs,
-                rank=self.num_tasks),
-            msg="Not all the new generated tasks started on a big CPU")
+    conf_basename = "fork_migration.config"
 
 
 class SmallTaskPacking(unittest.TestCase):

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -28,7 +28,6 @@ from bart.sched.SchedAssert import SchedAssert
 from bart.sched.SchedMultiAssert import SchedMultiAssert
 from devlib.target import TargetError
 
-from wlgen import RTA, Periodic, Step
 from env import TestEnv
 from devlib.utils.misc import memoized
 from test import LisaTest
@@ -43,50 +42,6 @@ CONF_FILE = os.path.join(
 with open(CONF_FILE, "r") as fh:
     conf_vars = json.load(fh)
     globals().update(conf_vars)
-
-
-def local_setup(env):
-    env.target.cpufreq.set_all_governors("performance")
-
-    if ENABLE_EAS:
-        env.target.execute(
-            "echo ENERGY_AWARE > /sys/kernel/debug/sched_features")
-
-    if SET_IS_BIG_LITTLE:
-        try:
-            env.target.write_value("/proc/sys/kernel/sched_is_big_little", 1)
-        except TargetError:
-            # That flag doesn't exist on mainline-integration kernels, so don't
-            # worry if the file isn't present.
-            pass
-
-SMALL_WORKLOAD = {
-
-    "duty_cycle_pct": SMALL_DCYCLE,
-    "duration_s": WORKLOAD_DURATION_S,
-    "period_ms": WORKLOAD_PERIOD_MS,
-}
-
-BIG_WORKLOAD = {
-
-    "duty_cycle_pct": BIG_DCYCLE,
-    "duration_s": WORKLOAD_DURATION_S,
-    "period_ms": WORKLOAD_PERIOD_MS,
-}
-
-STEP_WORKLOAD = {
-
-    "start_pct": STEP_LOW_DCYCLE,
-    "end_pct": STEP_HIGH_DCYCLE,
-    "time_s": WORKLOAD_DURATION_S,
-    "loops": 2
-}
-
-
-def log_result(data, log_fh):
-    result_str = json.dumps(data, indent=3)
-    logging.info(result_str)
-    log_fh.write(result_str)
 
 @wrapt.decorator
 def experiment_test(wrapped_test, instance, args, kwargs):

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -15,16 +15,20 @@
 # limitations under the License.
 #
 
-from env import TestEnv
-from wlgen import RTA, Periodic, Step
-from devlib.target import TargetError
-
-import trappy
-import os
-import unittest
-import logging
 import json
 import logging
+import logging
+import operator
+import os
+import trappy
+import unittest
+
+from bart.sched.SchedAssert import SchedAssert
+from bart.sched.SchedMultiAssert import SchedMultiAssert
+from devlib.target import TargetError
+
+from wlgen import RTA, Periodic, Step
+from env import TestEnv
 
 logging.basicConfig(level=logging.INFO)
 # Read the config file and update the globals
@@ -74,11 +78,6 @@ STEP_WORKLOAD = {
     "time_s": WORKLOAD_DURATION_S,
     "loops": 2
 }
-
-from bart.sched.SchedAssert import SchedAssert
-from bart.sched.SchedMultiAssert import SchedMultiAssert
-import operator
-import json
 
 
 def log_result(data, log_fh):

--- a/tests/eas/fork_migration.config
+++ b/tests/eas/fork_migration.config
@@ -1,0 +1,52 @@
+{
+    "modules"  : [ "bl" ],
+    "tools"    : [ "rt-app" ],
+    "ftrace" : { // TODO make these inherited
+        "events" : [
+            "sched_energy_diff",
+            "sched_load_avg_task",
+            "sched_load_avg_cpu",
+            "sched_migrate_task",
+            "sched_switch"
+        ],
+    },
+    "wloads" : {
+        // Create N 100% tasks and M 10% tasks which run in parallel, where N is
+        // the number of big CPUs and M is the number of LITTLE CPUs.
+        "fmig" : {
+            "type" : "rt-app",
+            "conf" : {
+                "class" : "profile",
+                "params" : {
+                    "small" : {
+                        "kind" : "Periodic",
+                        "params" : {
+                            "duty_cycle_pct": 10,
+                            "duration_s": 5,
+                            "period_ms": 10,
+                        },
+                        "tasks" : "little", // Create one task for each LITTLE CPU
+                        "prefix" : "small"
+                    },
+                    "big" : {
+                        "kind" : "Periodic",
+                        "params" : {
+                            "duty_cycle_pct": 100,
+                            "duration_s" : 5,
+                            "period_ms": 10
+                        },
+                        "tasks" : "big", // Create one task for each big CPU
+                        "prefix" : "large",
+                    },
+                },
+            },
+        },
+    },
+    "confs" : [
+        {
+            "tag" : "",
+            "flags" : "ftrace",
+            "sched_features" : "ENERGY_AWARE"
+        }
+    ]
+}

--- a/tests/eas/offload_idle_pull.config
+++ b/tests/eas/offload_idle_pull.config
@@ -1,0 +1,50 @@
+{
+    "modules"  : [ "bl" ],
+    "tools"    : [ "rt-app" ],
+    "ftrace" : { // TODO make these inherited
+        "events" : [
+            "sched_energy_diff",
+            "sched_load_avg_task",
+            "sched_load_avg_cpu",
+            "sched_migrate_task",
+            "sched_switch"
+        ],
+    },
+    "wloads" : {
+        //
+        "early_and_migrators" : {
+            "type" : "rt-app",
+            "conf" : {
+                "class" : "profile",
+                "params" : {
+                    "early" : {
+                        "kind" : "Periodic",
+                        "params" : {
+                            "duty_cycle_pct": 100,
+                            "duration_s": 5,
+                            "period_ms": 10,
+                        },
+                        "tasks" : "big", // Create one task for each big CPU
+                    },
+                    "migrators" : {
+                        "kind" : "Periodic",
+                        "params" : {
+                            "duty_cycle_pct": 100,
+                            "duration_s": 5,
+                            "period_ms": 10,
+                            "delay_s": 1
+                       },
+                        "tasks" : "big", // Create one task for each big CPU
+                    },
+                },
+            },
+        },
+    },
+    "confs" : [
+        {
+            "tag" : "",
+            "flags" : "ftrace",
+            "sched_features" : "ENERGY_AWARE"
+        }
+    ]
+}

--- a/tests/eas/small_task_packing.config
+++ b/tests/eas/small_task_packing.config
@@ -1,0 +1,36 @@
+{
+    "modules"  : [ "bl" ],
+    "tools"    : [ "rt-app" ],
+    "ftrace" : { // TODO make these inherited
+        "events" : [
+            "sched_energy_diff",
+            "sched_load_avg_task",
+            "sched_load_avg_cpu",
+            "sched_migrate_task",
+            "sched_switch"
+        ],
+    },
+    "wloads" : {
+        // Create one small task for each CPU
+        "small_tasks" : {
+            "type" : "rt-app",
+            "conf" : {
+                "class" : "periodic",
+                "params" : {
+                    "duty_cycle_pct": 10,
+                    "duration_s": 5,
+                    "period_ms": 10,
+                },
+                "tasks" : "cpus", // Create one task for each CPU
+                "prefix" : "stp"
+            },
+        },
+    },
+    "confs" : [
+        {
+            "tag" : "",
+            "flags" : "ftrace",
+            "sched_features" : "ENERGY_AWARE"
+        }
+    ]
+}


### PR DESCRIPTION
- Refactor/enhance the Executor class; most importantly enable the "experiments" to be saved so that test objects can refer back to them in `test_` methods
- Add an EasTest class abstracting the common operations for all EAS acceptance tests. It's likely that some of this functionality (+ documentation which is not written) could go directly into LisaTest, but I haven't thought about that properly.
- Rework each of the acceptance test classes to inherit from EasTest

Also some miscellaneous cleanups that seem to me to be related to this.