### PR TITLE
tests/eas/acceptance: Reduce expected LITTLE busy time for offload test

### DIFF
--- a/tests/eas/acceptance.config
+++ b/tests/eas/acceptance.config
@@ -9,7 +9,7 @@
     "STEP_HIGH_DCYCLE" : 50,
     "EXPECTED_RESIDENCY_PCT" : 85,
     "OFFLOAD_MIGRATION_MIGRATOR_DELAY": 1,
-    "OFFLOAD_EXPECTED_BUSY_TIME_PCT": 99,
+    "OFFLOAD_EXPECTED_BUSY_TIME_PCT": 97,
     "SET_IS_BIG_LITTLE": true,
     "TEST_CONF" : {
         "modules"  : [ "bl", "cpufreq" ],


### PR DESCRIPTION
Here's a trace plot that shows an example of what I'm talking about in the commit message (note that the blue tasks are placed on the same CPU when the 'migrator' tasks start running, which reduces the busy time. IIUC although this isn't ideal behaviour it is not unexpected.):
![offload_failure](https://cloud.githubusercontent.com/assets/2939691/19034895/1c3dda42-895e-11e6-8126-8e3ce2833585.jpg)
---
Where the 'migrator' tasks in the OffloadMigrationAndIdlePull are
initially placed on the same CPU, the busy time of the LITTLE CPUs that
are exercised can be below 99% during the perdiod where big CPUs are
occupied. This shouldn't be considered a failure.

In my experiments 97% appeared to be a low enough value to prevent these
failures. In fact I observed no failures with the value at 98% either,
but it seems wise to allow a little margin for error.