### PR TITLE
libs/wlgen/rta: Limit task name to 15 characters

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -495,6 +495,14 @@ class RTA(Workload):
 
         """
 
+        for task in params.keys():
+            if len(task) > 15:
+                # rt-app uses pthread_setname_np(3) which limits the task name
+                # to 16 characters including the terminal '\0'.
+                msg = ('Task name "{}" too long, please configure your tasks '
+                       'with names shorter than 16 characters').format(task)
+                raise ValueError(msg)
+
         if not sched:
             sched = {'policy' : 'OTHER'}
 


### PR DESCRIPTION
rt-app uses pthread_setname_np(3) to set the names of tasks on the
target [1]. This interface limits thread name length to 16 characters
including the null '\0'.

Although rt-app prints a message on the target, the workload execution
goes ahead when the provided task names are too long, and the tasks are
named "rt-app". This means they are not found when later examining the
trace.

Therefore, raise an exception on the host to prevent this situation
arising.

[1] https://github.com/scheduler-tools/rt-app/blob/dcaf5a04aa63b69d8b5e174d10a9e459f88772cf/src/rt-app.c#L152

Fixes https://github.com/ARM-software/lisa/issues/200