### PR TITLE
libs/utils/env: Explicitly check 'host' setting is present for Linux

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -462,6 +462,9 @@ class TestEnv(ShareState):
 
         if platform_type.lower() == 'linux':
             logging.debug('%14s - Setup LINUX target...', 'Target')
+            if "host" not in self.__connection_settings:
+                raise ValueError('Missing "host" param in Linux target conf')
+
             self.target = devlib.LinuxTarget(
                     platform = platform,
                     connection_settings = self.__connection_settings,


### PR DESCRIPTION
For Linux targets you need a 'host' parameter to set up the SSH
connection. If it's missing, the error appears at the end of a deep dark
call stack.

Add an explicit check before constructing the LinuxTarget so it's
more obvious what you did wrong when this param is missing.