### PR TITLE
libs/utils/trace: Fix getCPUActive signal for fully-idle CPUs

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -739,8 +739,8 @@ class Trace(object):
         """
         Build a square wave representing the active (i.e. non-idle) CPU time,
         i.e.:
-            cpu_active[t] == 1 if at least one CPU is reported to be
-                               non-idle by CPUFreq at time t
+            cpu_active[t] == 1 if the CPU is reported to be non-idle by cpuidle
+                             at time t
             cpu_active[t] == 0 otherwise
 
         :param cpu: CPU ID

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -763,7 +763,10 @@ class Trace(object):
         start_time = 0.0
         if not self.ftrace.normalized_time:
             start_time = self.ftrace.basetime
-        if cpu_active.index[0] != start_time:
+
+        if cpu_active.empty:
+            cpu_active = pd.Series([0], index=[start_time])
+        elif cpu_active.index[0] != start_time:
             entry_0 = pd.Series(cpu_active.iloc[0] ^ 1, index=[start_time])
             cpu_active = pd.concat([entry_0, cpu_active])
 


### PR DESCRIPTION
If no cpu_idle events are reported for a particular CPU (but there are
cpu_idle events for other CPUs), assume that the CPU was never used
during the period of trace event collection.