### PR TITLE
executor: add flag to freeze userspace while running experiments

### DIFF
--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -44,7 +44,7 @@ OFFLOAD_MIGRATION_MIGRATOR_DELAY = 1
 
 energy_aware_conf = {
     "tag" : "energy_aware",
-    "flags" : "ftrace",
+    "flags" : ["ftrace", "freeze_userspace"],
     "sched_features" : "ENERGY_AWARE",
 }
 
@@ -64,6 +64,7 @@ class EasTest(LisaTest):
                 "sched_switch"
             ],
         },
+        "modules": ["cgroups"],
     }
 
     @classmethod


### PR DESCRIPTION
Note that if you manually stopped services before running the LISA tests, this will re-start them after running the workload. We could modify this to actually look at the services that are running before we run `stop` to determine if we should re-`start`, but I don't want to add that complexity unless it's definitely necessary.