### PR TITLE
tests/eas/acceptance: set sched_initial_test_util

### DIFF
--- a/tests/eas/acceptance.config
+++ b/tests/eas/acceptance.config
@@ -11,6 +11,7 @@
     "OFFLOAD_MIGRATION_MIGRATOR_DELAY": 1,
     "OFFLOAD_EXPECTED_BUSY_TIME_PCT": 97,
     "SET_IS_BIG_LITTLE": true,
+    "SET_INITIAL_TASK_UTIL": true,
     "TEST_CONF" : {
         "modules"  : [ "bl", "cpufreq" ],
         "tools"    : [ "rt-app" ],

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -60,6 +60,12 @@ class EasTest(LisaTest):
             cls.target.write_value(
                 "/proc/sys/kernel/sched_is_big_little", 1, verify=False)
 
+        if SET_INITIAL_TASK_UTIL:
+            # This flag doesn't exist on all kernels, so don't worry if the file
+            # isn't present (hence verify=False)
+            cls.target.write_value(
+                "/proc/sys/kernel/sched_initial_task_util", 1024, verify=False)
+
     def _do_test_first_cpu(self, experiment, tasks):
         """Test that all tasks start on a big CPU"""
 

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -55,13 +55,10 @@ class EasTest(LisaTest):
         super(EasTest, cls)._experimentsInit(*args, **kwargs)
 
         if SET_IS_BIG_LITTLE:
-            try:
-                cls.target.write_value(
-                    "/proc/sys/kernel/sched_is_big_little", 1)
-            except TargetError:
-                # That flag doesn't exist on mainline-integration kernels, so
-                # don't worry if the file isn't present.
-                pass
+            # This flag doesn't exist on mainline-integration kernels, so
+            # don't worry if the file isn't present (hence verify=False)
+            cls.target.write_value(
+                "/proc/sys/kernel/sched_is_big_little", 1, verify=False)
 
     def _do_test_first_cpu(self, experiment, tasks):
         """Test that all tasks start on a big CPU"""


### PR DESCRIPTION
This tunable is required to use the "sched" cpufreq governor (schedfreq)

Note that this isn't required right now - the acceptance tests use the performance governor - but we should expect people to want to change that. 