### PR TITLE
Fixes for Executor

### DIFF
--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -139,6 +139,7 @@ class Executor():
         self.experiments = []
 
         # Run all the configured experiments
+        exp_idx = 0
         for tc in self._tests_conf['confs']:
             # TARGET: configuration
             if not self._target_configure(tc):
@@ -155,10 +156,9 @@ class Executor():
                         out_dir=os.path.join(test_dir, str(itr_idx)))
                     self.experiments.append(exp)
 
-            # WORKLOAD: execution
-            for exp_idx, experiment in enumerate(self.experiments):
-                self._wload_run(exp_idx, experiment)
-
+                    # WORKLOAD: execution
+                    self._wload_run(exp_idx, exp)
+                    exp_idx += 1
             self._target_cleanup(tc)
 
         self._print_section('Executor', 'Experiments execution completed')


### PR DESCRIPTION
I looked [here](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security-Enhanced_Linux/sect-Security-Enhanced_Linux-Working_with_SELinux-Mounting_File_Systems.html) to try and figure out if there's a mount option that could let us fix this properly. It sounds like adding `context=u:object_r:shell_data_file:s0` to the mount options should fix the issue but it gives me:

```
'schedtest' is read-only
mount: 'schedtest'->'/data/local/tmp/devlib-target/run_dir': Permission denied
```

I decided to be pragmatic about it - rather than reading great dusty tomes of SELinux documentation to figure out incantations I suggest we just put it in permissive mode. 