### PR TITLE
Trace: Automatically populate the task/PID map when sched_switch enabled

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -295,17 +295,17 @@ class Trace(object):
         :param tasks: list of task names
         :type tasks: list(str)
         """
+        def load(tasks, event, name_key, pid_key):
+            df = self._dfg_trace_event(event)
+            self.getTasks(df, tasks, name_key=name_key, pid_key=pid_key)
+            self._scanTasks(df, name_key=name_key, pid_key=pid_key)
+
         if 'sched_switch' in self.available_events:
-            self.getTasks(self._dfg_trace_event('sched_switch'), tasks,
-                          name_key='next_comm', pid_key='next_pid')
-            self._scanTasks(self._dfg_trace_event('sched_switch'),
-                            name_key='next_comm', pid_key='next_pid')
-            return
-        if 'sched_load_avg_task' in self.available_events:
-            self.getTasks(self._dfg_trace_event('sched_load_avg_task'), tasks)
-            self._scanTasks(self._dfg_trace_event('sched_load_avg_task'))
-            return
-        logging.warning('Failed to load tasks names from trace events')
+            load(tasks, 'sched_switch', 'next_comm', 'next_pid')
+        elif 'sched_load_avg_task' in self.available_events:
+            load(tasks, 'sched_load_avg_task', 'comm', 'pid')
+        else:
+            logging.warning('Failed to load tasks names from trace events')
 
     def hasEvents(self, dataset):
         """

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -428,11 +428,11 @@ class Trace(object):
         :param pid_key: The name of the dataframe columns containing task PIDs
         :type pid_key: str
         """
-        if dataframe is None:
-            return self.tasks
-        df = dataframe
         if task_names is None:
             task_names = self.tasks.keys()
+        if dataframe is None:
+            return {k: v for k, v in  self.tasks.iteritems() if k in task_names}
+        df = dataframe
         logging.debug("Lookup dataset for tasks...")
         for tname in task_names:
             logging.debug("Lookup for task [%s]...", tname)

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -52,8 +52,9 @@ class Trace(object):
     :param events: events to be parsed (everything in the trace by default)
     :type events: list(str)
 
-    :param tasks: filter data for the specified tasks only
-    :type tasks: list(str)
+    :param tasks: filter data for the specified tasks only. If None (default),
+        use data for all tasks found in the trace.
+    :type tasks: list(str) or NoneType
 
     :param window: time window to consider when parsing the trace
     :type window: tuple(int, int)
@@ -292,11 +293,13 @@ class Trace(object):
         """
         Try to load tasks names using one of the supported events.
 
-        :param tasks: list of task names
-        :type tasks: list(str)
+        :param tasks: list of task names. If None, load all tasks found.
+        :type tasks: list(str) or NoneType
         """
         def load(tasks, event, name_key, pid_key):
             df = self._dfg_trace_event(event)
+            if tasks is None:
+                tasks = df[name_key].unique()
             self.getTasks(df, tasks, name_key=name_key, pid_key=pid_key)
             self._scanTasks(df, name_key=name_key, pid_key=pid_key)
 
@@ -410,13 +413,12 @@ class Trace(object):
         two columns reporting the task name and the task PID. The default
         values of this colums could be specified using the provided parameters.
 
-        :param dataframe: A Pandas datafram containing at least 'pid' and
-            'task name' columns. If None, the previously filtered PIDs are
-            returned.
+        :param dataframe: A Pandas dataframe containing at least 'name_key' and
+            'pid_key' columns. If None, the all PIDs are returned.
         :type dataframe: :mod:`pandas.DataFrame`
 
-        :param task_names: The list of tasks to get the PID of (by default the
-            workload defined tasks)
+        :param task_names: The list of tasks to get the PID of (default: all
+            tasks)
         :type task_names: list(str)
 
         :param name_key: The name of the dataframe columns containing task

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -404,14 +404,14 @@ class Trace(object):
         """
         Helper function to get PIDs of specified tasks.
 
-        This method requires a Pandas dataset in input to be used to fiter out
+        This method can take a Pandas dataset in input to be used to fiter out
         the PIDs of all the specified tasks. If a dataset is not provided,
         previously filtered PIDs are returned.
 
-        If a list of task names is not provided, the workload defined task
-        names is used instead. The specified dataframe must provide at least
-        two columns reporting the task name and the task PID. The default
-        values of this colums could be specified using the provided parameters.
+        If a list of task names is not provided, all tasks detected in the trace
+        will be used. The specified dataframe must provide at least two columns
+        reporting the task name and the task PID. The default values of this
+        colums could be specified using the provided parameters.
 
         :param dataframe: A Pandas dataframe containing at least 'name_key' and
             'pid_key' columns. If None, the all PIDs are returned.
@@ -448,8 +448,8 @@ class Trace(object):
                 self.tasks[tname] = {}
             pids = list(results[pid_key].unique())
             self.tasks[tname]['pid'] = pids
-            logging.info('  task %16s found, pid: %s',
-                         tname, self.tasks[tname]['pid'])
+            logging.debug('  task %16s found, pid: %s',
+                          tname, self.tasks[tname]['pid'])
         return self.tasks
 
 


### PR DESCRIPTION
I'm not really sure what the original intention for these methods in `Trace` were so I might be off the mark here, but this seems to basically be the behaviour I'd expect from trace. That is I would expect to be able to have a trace parsed and then simply call `getTasks` to see which tasks were found.

This should make it more convenient for tests to figure out PIDs of tasks run during workload experiments so that they can do analysis. 

For example: https://github.com/ARM-software/lisa/blob/2f1eef3bdbd539380684472eb2e02b58584551cd/tests/eas/load_tracking.py#L111

