### PR TITLE
idle_analysis: Fix idle residency when idle events are sparse

### DIFF
--- a/libs/utils/analysis/idle_analysis.py
+++ b/libs/utils/analysis/idle_analysis.py
@@ -76,6 +76,12 @@ class IdleAnalysis(AnalysisModule):
         cpu_idle = cpu_idle.join(cpu_is_idle.to_frame(name='is_idle'),
                                  how='outer')
         cpu_idle.fillna(method='ffill', inplace=True)
+
+        # Extend the last cpu_idle event to the end of the time window under
+        # consideration
+        final_entry = pd.DataFrame([cpu_idle.iloc[-1]], index=[self._trace.x_max])
+        cpu_idle = cpu_idle.append(final_entry)
+
         idle_time = []
         for i in available_idles:
             idle_state = cpu_idle.state.apply(


### PR DESCRIPTION
Not too sure if this is the best approach.. maybe we should come up with a more generic solution (`Trace._sanitizeCpuIdle`?). I haven't investigated whether `_dfg_cluster_idle_state_residency` is affected by the same issue (in my brief tests it didn't seem to be but good chance that's coincidence).

This is kind of a similar issue to this: https://github.com/ARM-software/lisa/pull/220