### PR TITLE
executor/env: Install rt-app automatically if required

### DIFF
--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -130,6 +130,11 @@ class Executor():
         self._log.info('Results will be collected under:')
         self._log.info('      %s', self.te.res_dir)
 
+        if any(wl['type'] == 'rt-app'
+               for wl in self._experiments_conf['wloads'].values()):
+            self._log.info('rt-app workloads found, installing tool on target')
+            self.te.install_tools(['rt-app'])
+
     def run(self):
         self._print_section('Experiments execution')
 


### PR DESCRIPTION
With this commit, tests that use rt-app workloads need not explicitly
specify 'rt-app' in the 'tools' field of the TestEnv test configuration.

This adds an `install_tools` method to the TestEnv class.

---

This might be considered a bit of a hack? The generic solution would probably be to fix this in the workload class(es) by passing a TestEnv (rather than a Target) to their `__init__.py` that they can use to install the required binary.