### PR TITLE
lisa_shell: Reset terminal colours in PS1

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -307,7 +307,7 @@ echo
 ################################################################################
 
 # Setup Shell variables
-PS1="\[${LISASHELL_BLUE}\][LISAShell \[${LISASHELL_LCYAN}\]\W\[${LISASHELL_BLUE}\]] \> \[${LISASHELL_DEFAULT}\]"
+PS1="\[${LISASHELL_BLUE}\][LISAShell \[${LISASHELL_LCYAN}\]\W\[${LISASHELL_BLUE}\]] \> \[${LISASHELL_RESET}\]"
 
 # Dump out a nice LISA Shell logo
 clear


### PR DESCRIPTION
So we don't mess up the terminal too much for people with pale backgrounds.