### PR TITLE
libs/utils/android: reset airplane mode for Jankbench

### DIFF
--- a/libs/utils/android/workloads/jankbench.py
+++ b/libs/utils/android/workloads/jankbench.py
@@ -154,6 +154,8 @@ class Jankbench(Workload):
 
         # Switch back to screen auto rotation
         Screen.set_orientation(self.target, auto=True)
+        
+        System.set_airplane_mode(self.target, on=False)
 
         return db_file, nrg_report
 


### PR DESCRIPTION
Jankbench activates airplaine mode before executing.
Set airplane mode back to OFF after execution finishes.

Signed-off-by: Juri Lelli <juri.lelli@arm.com>