### PR TITLE
Update trappy and fix cpu_idle

### DIFF
--- a/libs/utils/analysis/frequency_analysis.py
+++ b/libs/utils/analysis/frequency_analysis.py
@@ -26,7 +26,7 @@ from trappy.utils import listify
 from devlib.utils.misc import memoized
 
 from analysis_module import AnalysisModule
-from trace import NON_IDLE_STATE, ResidencyTime, ResidencyData
+from trace import ResidencyTime, ResidencyData
 
 
 class FrequencyAnalysis(AnalysisModule):

--- a/libs/utils/analysis/idle_analysis.py
+++ b/libs/utils/analysis/idle_analysis.py
@@ -69,7 +69,7 @@ class IdleAnalysis(AnalysisModule):
         #     idle_state[t] == 0 otherwise
         available_idles = sorted(idle_df.state.unique())
         # Remove non-idle state from availables
-        available_idles.pop()
+        available_idles = available_idles[1:]
         cpu_idle = cpu_idle.join(cpu_is_idle.to_frame(name='is_idle'),
                                  how='outer')
         cpu_idle.fillna(method='ffill', inplace=True)
@@ -142,7 +142,7 @@ class IdleAnalysis(AnalysisModule):
         #     idle_state[t] == 0 otherwise
         available_idles = sorted(idle_df.state.unique())
         # Remove non-idle state from availables
-        available_idles.pop()
+        available_idles = available_idles[1:]
         cl_idle = cl_idle.join(cl_is_idle.to_frame(name='is_idle'),
                                how='outer')
         cl_idle.fillna(method='ffill', inplace=True)

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -33,7 +33,7 @@ from devlib.utils.misc import memoized
 from trappy.utils import listify
 
 
-NON_IDLE_STATE = 4294967295
+NON_IDLE_STATE = -1
 ResidencyTime = namedtuple('ResidencyTime', ['total', 'active'])
 ResidencyData = namedtuple('ResidencyData', ['label', 'residency'])
 


### PR DESCRIPTION
Some people have been using a later trappy version than the one specified in the submodules. That version contains a commit by me that breaks LISA's idle analysis module, so here's a fix for it.