### PR TITLE
Add frequency invariant load tracking test 

### DIFF
--- a/ipynb/tests/Frequency_Invariance_Test.ipynb
+++ b/ipynb/tests/Frequency_Invariance_Test.ipynb
@@ -1,0 +1,677 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Frequency Invariant Load Tracking Test\n",
+    "\n",
+    "FreqInvarianceTest is a LisaTest class for automated testing of frequency invariant load tracking. This notebook uses the methods it provides to perform the same analysis as the automated test and plot some results.\n",
+    "\n",
+    "The test class runs the same workload at a selection of frequencies, each entry in `t.experiments` represents a run at a different frequency."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import json\n",
+    "\n",
+    "from trace import Trace\n",
+    "from trappy.plotter import plot_trace\n",
+    "from trappy.stats.grammar import Parser\n",
+    "from trappy import ILinePlot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-02-13 18:36:59,553 INFO    : root         : Using LISA logging configuration:\n",
+      "2017-02-13 18:36:59,554 INFO    : root         :   /home/brendan/sources/lisa/logging.conf\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "from conf import LisaLogging\n",
+    "LisaLogging.setup()\n",
+    "logging.getLogger('Analysis').setLevel(logging.ERROR)\n",
+    "logging.getLogger('Trace').setLevel(logging.ERROR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run test workload\n",
+    "\n",
+    "There's currently no way to pass a `TestEnv` or configuration to automated test classes. Instead the target information comes from the `target.config` file (in the root of the LISA source tree), so you'll need to edit that to configure LISA to connect to your target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "    Goal\n",
+      "    ====\n",
+      "    Basic check for frequency invariant load tracking\n",
+      "\n",
+      "    Detailed Description\n",
+      "    ====================\n",
+      "    This test runs the same workload on the most capable CPU on the system at a\n",
+      "    cross section of available frequencies. The trace is then examined to find\n",
+      "    the average activation length of the workload, which is combined with the\n",
+      "    known period to estimate an expected mean value for util_avg for each\n",
+      "    frequency. The util_avg value is extracted from scheduler trace events and\n",
+      "    its mean is compared with the expected value (ignoring the first 300ms so\n",
+      "    that the signal can stabilize). The test fails if the observed mean is\n",
+      "    beyond a certain error margin from the expected one. load_avg is then\n",
+      "    similarly compared with the expected util_avg mean, under the assumption\n",
+      "    that load_avg should equal util_avg when system load is light.\n",
+      "\n",
+      "    Expected Behaviour\n",
+      "    ==================\n",
+      "    Load tracking signals are scaled so that the workload results in roughly the\n",
+      "    same util & load values regardless of frequency.\n",
+      "    \n"
+     ]
+    }
+   ],
+   "source": [
+    "from tests.eas.load_tracking import FreqInvarianceTest\n",
+    "\n",
+    "t = FreqInvarianceTest()\n",
+    "print t.__doc__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run automated tests from within a notebook we instantiate the test class and call `runExperiments` on it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-02-13 18:36:59,608 INFO    : LisaTest     : Setup tests execution engine...\n",
+      "2017-02-13 18:36:59,609 INFO    : TestEnv      : Using base path: /home/brejac01/sources/lisa\n",
+      "2017-02-13 18:36:59,610 INFO    : TestEnv      : Loading default (file) target configuration\n",
+      "2017-02-13 18:36:59,611 INFO    : TestEnv      : Loading target configuration [/home/brejac01/sources/lisa/target.config]...\n",
+      "2017-02-13 18:36:59,613 INFO    : TestEnv      : Loading custom (inline) test configuration\n",
+      "2017-02-13 18:36:59,614 INFO    : TestEnv      : Devlib modules to load: ['bl', u'cpuidle', 'cgroups', 'cpufreq']\n",
+      "2017-02-13 18:36:59,615 INFO    : TestEnv      : Connecting linux target:\n",
+      "2017-02-13 18:36:59,616 INFO    : TestEnv      :   username : brendan\n",
+      "2017-02-13 18:36:59,617 INFO    : TestEnv      :       host : 192.168.2.2\n",
+      "2017-02-13 18:36:59,618 INFO    : TestEnv      :   password : password\n",
+      "2017-02-13 18:36:59,618 INFO    : TestEnv      : Connection settings:\n",
+      "2017-02-13 18:36:59,619 INFO    : TestEnv      :    {'username': u'brendan', 'host': u'192.168.2.2', 'password': u'password'}\n",
+      "2017-02-13 18:37:07,367 INFO    : TestEnv      : Initializing target workdir:\n",
+      "2017-02-13 18:37:07,369 INFO    : TestEnv      :    /home/brendan/devlib-target\n",
+      "2017-02-13 18:37:11,034 INFO    : CGroups      : Available controllers:\n",
+      "2017-02-13 18:37:12,775 INFO    : CGroups      :   cpuset       : /home/brendan/devlib-target/cgroups/devlib_cgh2\n",
+      "2017-02-13 18:37:14,512 INFO    : CGroups      :   cpu          : /home/brendan/devlib-target/cgroups/devlib_cgh3\n",
+      "2017-02-13 18:37:16,249 INFO    : CGroups      :   cpuacct      : /home/brendan/devlib-target/cgroups/devlib_cgh3\n",
+      "2017-02-13 18:37:17,988 INFO    : CGroups      :   blkio        : /home/brendan/devlib-target/cgroups/devlib_cgh4\n",
+      "2017-02-13 18:37:19,726 INFO    : CGroups      :   memory       : /home/brendan/devlib-target/cgroups/devlib_cgh5\n",
+      "2017-02-13 18:37:21,465 INFO    : CGroups      :   devices      : /home/brendan/devlib-target/cgroups/devlib_cgh6\n",
+      "2017-02-13 18:37:23,205 INFO    : CGroups      :   perf_event   : /home/brendan/devlib-target/cgroups/devlib_cgh7\n",
+      "2017-02-13 18:37:24,944 INFO    : CGroups      :   hugetlb      : /home/brendan/devlib-target/cgroups/devlib_cgh8\n",
+      "2017-02-13 18:37:26,682 INFO    : CGroups      :   pids         : /home/brendan/devlib-target/cgroups/devlib_cgh9\n",
+      "2017-02-13 18:37:29,594 INFO    : TestEnv      : Topology:\n",
+      "2017-02-13 18:37:29,596 INFO    : TestEnv      :    [[0, 3, 4, 5], [1, 2]]\n",
+      "2017-02-13 18:37:32,227 INFO    : TestEnv      : Loading default EM:\n",
+      "2017-02-13 18:37:32,229 INFO    : TestEnv      :    /home/brejac01/sources/lisa/libs/utils/platforms/juno.json\n",
+      "2017-02-13 18:37:33,996 WARNING : LinuxTarget  : Event [sched_load_avg_task] not available for tracing\n",
+      "2017-02-13 18:37:33,999 WARNING : LinuxTarget  : Event [sched_load_avg_cpu] not available for tracing\n",
+      "2017-02-13 18:37:34,001 INFO    : TestEnv      : Enabled tracepoints:\n",
+      "2017-02-13 18:37:34,002 INFO    : TestEnv      :    sched_switch\n",
+      "2017-02-13 18:37:34,003 INFO    : TestEnv      :    sched_load_avg_task\n",
+      "2017-02-13 18:37:34,004 INFO    : TestEnv      :    sched_load_avg_cpu\n",
+      "2017-02-13 18:37:34,006 INFO    : TestEnv      :    sched_pelt_se\n",
+      "2017-02-13 18:37:34,007 WARNING : TestEnv      : Using configuration provided RTApp calibration\n",
+      "2017-02-13 18:37:34,008 INFO    : TestEnv      : Using RT-App calibration values:\n",
+      "2017-02-13 18:37:34,010 INFO    : TestEnv      :    {\"0\": 354, \"1\": 138, \"2\": 138, \"3\": 363, \"4\": 355, \"5\": 357}\n",
+      "2017-02-13 18:37:34,011 INFO    : EnergyMeter  : HWMON module not enabled\n",
+      "2017-02-13 18:37:34,012 WARNING : EnergyMeter  : Energy sampling disabled by configuration\n",
+      "2017-02-13 18:37:34,013 INFO    : TestEnv      : Set results folder to:\n",
+      "2017-02-13 18:37:34,015 INFO    : TestEnv      :    /home/brejac01/sources/lisa/results/20170213_183734\n",
+      "2017-02-13 18:37:34,016 INFO    : TestEnv      : Experiment results available also in:\n",
+      "2017-02-13 18:37:34,017 INFO    : TestEnv      :    /home/brejac01/sources/lisa/results_latest\n",
+      "2017-02-13 18:37:34,018 INFO    : Executor     : Loading custom (inline) test configuration\n",
+      "2017-02-13 18:37:34,019 INFO    : Executor     : \n",
+      "2017-02-13 18:37:34,020 INFO    : Executor     : ################################################################################\n",
+      "2017-02-13 18:37:34,022 INFO    : Executor     : Experiments configuration\n",
+      "2017-02-13 18:37:34,023 INFO    : Executor     : ################################################################################\n",
+      "2017-02-13 18:37:34,024 INFO    : Executor     : Configured to run:\n",
+      "2017-02-13 18:37:34,025 INFO    : Executor     :      1 target configurations:\n",
+      "2017-02-13 18:37:34,026 INFO    : Executor     :       freq_450000\n",
+      "2017-02-13 18:37:34,027 INFO    : Executor     :      1 workloads (1 iterations each)\n",
+      "2017-02-13 18:37:34,028 INFO    : Executor     :       fie_10pct\n",
+      "2017-02-13 18:37:34,029 INFO    : Executor     : Total: 1 experiments\n",
+      "2017-02-13 18:37:34,030 INFO    : Executor     : Results will be collected under:\n",
+      "2017-02-13 18:37:34,031 INFO    : Executor     :       /home/brejac01/sources/lisa/results/20170213_183734\n",
+      "2017-02-13 18:37:34,032 INFO    : Executor     : rt-app workloads found, installing tool on target\n",
+      "2017-02-13 18:37:34,033 INFO    : LisaTest     : Experiments execution...\n",
+      "2017-02-13 18:37:34,034 INFO    : Executor     : \n",
+      "2017-02-13 18:37:34,035 INFO    : Executor     : ################################################################################\n",
+      "2017-02-13 18:37:34,036 INFO    : Executor     : Experiments execution\n",
+      "2017-02-13 18:37:34,037 INFO    : Executor     : ################################################################################\n",
+      "2017-02-13 18:37:34,038 INFO    : Executor     : \n",
+      "2017-02-13 18:37:34,039 INFO    : Executor     : ================================================================================\n",
+      "2017-02-13 18:37:34,040 INFO    : Executor     : configuring target for [freq_450000] experiments\n",
+      "2017-02-13 18:37:35,760 INFO    : Executor     : Configuring all CPUs to use [userspace] cpufreq governor\n",
+      "2017-02-13 18:37:36,666 INFO    : Executor     :        CPUFreq - CPU frequencies: {1: 450000}\n",
+      "2017-02-13 18:37:38,683 INFO    : Workload     : Setup new workload fie_10pct\n",
+      "2017-02-13 18:37:38,685 INFO    : Workload     : Workload duration defined by longest task\n",
+      "2017-02-13 18:37:38,686 INFO    : Workload     : Default policy: SCHED_OTHER\n",
+      "2017-02-13 18:37:38,687 INFO    : Workload     : ------------------------\n",
+      "2017-02-13 18:37:38,688 INFO    : Workload     : task [fie_test0], sched: using default policy\n",
+      "2017-02-13 18:37:38,689 INFO    : Workload     :  | calibration CPU: 1\n",
+      "2017-02-13 18:37:38,691 INFO    : Workload     :  | loops count: 1\n",
+      "2017-02-13 18:37:38,692 INFO    : Workload     : + phase_000001: duration 1.000000 [s] (62 loops)\n",
+      "2017-02-13 18:37:38,693 INFO    : Workload     : |  period    16000 [us], duty_cycle  10 %\n",
+      "2017-02-13 18:37:38,694 INFO    : Workload     : |  run_time   1600 [us], sleep_time  14400 [us]\n",
+      "2017-02-13 18:37:39,836 INFO    : Executor     : ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+      "2017-02-13 18:37:39,838 INFO    : Executor     : Experiment 0/1, [freq_450000:fie_10pct] 1/1\n",
+      "2017-02-13 18:37:40,255 WARNING : Executor     : No freezer cgroup controller on target. Not freezing userspace\n",
+      "2017-02-13 18:37:40,257 WARNING : Executor     : FTrace events collection enabled\n",
+      "2017-02-13 18:37:46,898 INFO    : Workload     : Workload execution START:\n",
+      "2017-02-13 18:37:46,899 INFO    : Workload     :    /home/brendan/devlib-target/bin/taskset 0x2 /home/brendan/devlib-target/bin/rt-app /home/brendan/devlib-target/run_dir/fie_10pct_00.json 2>&1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-02-13 18:37:54,459 INFO    : Executor     : Collected FTrace binary trace:\n",
+      "2017-02-13 18:37:54,460 INFO    : Executor     :    <res_dir>/rtapp:freq_450000:fie_10pct/1/trace.dat\n",
+      "2017-02-13 18:37:54,461 INFO    : Executor     : Collected FTrace function profiling:\n",
+      "2017-02-13 18:37:54,463 INFO    : Executor     :    <res_dir>/rtapp:freq_450000:fie_10pct/1/trace_stat.json\n",
+      "2017-02-13 18:37:54,463 INFO    : Executor     : --------------------------------------------------------------------------------\n",
+      "2017-02-13 18:37:54,464 INFO    : Executor     : \n",
+      "2017-02-13 18:37:54,465 INFO    : Executor     : ################################################################################\n",
+      "2017-02-13 18:37:54,467 INFO    : Executor     : Experiments execution completed\n",
+      "2017-02-13 18:37:54,467 INFO    : Executor     : ################################################################################\n",
+      "2017-02-13 18:37:54,468 INFO    : Executor     : Results available in:\n",
+      "2017-02-13 18:37:54,469 INFO    : Executor     :       /home/brejac01/sources/lisa/results/20170213_183734\n"
+     ]
+    }
+   ],
+   "source": [
+    "t.runExperiments()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show variance in util_avg and load_avg\n",
+    "We want to see the same util_avg and load_avg values regardless of frequencies - the bar charts below should have bars all with roughly the same height."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Get the frequency an experiment was run at\n",
+    "def experiment_freq(exp):\n",
+    "    [cpu] = exp.wload.cpus\n",
+    "    freq = exp.conf['cpufreq']['freqs'][cpu]\n",
+    "    return freq\n",
+    "freqs = [experiment_freq(e) for e in t.experiments]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def plot_signal_against_freq(signal):\n",
+    "    means = [t.get_signal_mean(e, signal) for e in t.experiments]\n",
+    "    limits = (0 , max(means) * 1.15)\n",
+    "    pd.DataFrame(means, index=freqs, columns=['Mean ' + signal]).plot(kind='bar', ylim=limits)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot of variation of util_avg value with frequency:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['sched_switch', 'sched_pelt_se']"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t.get_trace(t.experiments[0]).available_events"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXIAAAEXCAYAAACwHc/gAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAEwVJREFUeJzt3X2QVeVhx/HvWRDYwi67WxpYAUFKSLLVUDH1LRJug6Im\nKpgORJQ3S80kjhNJx1YgE1zSaY1UrZmxYRpjAjSAQasROyFC0CtOmmgm0S26QYLBAdeCq7wLiMne\n/nEuy91dXnbvC3cf7vczc2bPec7LfRb2/ua5z3nOc0GSJEmSJEmSJEmSJEmSJCmvvg/sBDZmlP0r\n8FugAXgC6J+xbx7wO2ATMOE01VGSdBJjgQtoG+RXAmXp9W+lF4A64BXgLGA4sCXjuFbjxo1LAS4u\nLi4uXVuSnEDPE+1Ie4E4lDOty1h/Efib9PpEYCXwIfAmcZBfBPwy8+Tnn3+eVCp1ipeViqO+vp76\n+vpiV0PqIIqicSfa16HF3EV/C/wkvX428FbGvreAwTleX5J0CrkE+deBI8CKkxxj01uSCuxUXSsn\nMgv4HDA+o6wJGJqxPSRd1kHmR9dEIkEikciyGlJ++beo7iKZTJJMJjt1bNSJY4YDTwPnp7evBu4H\nxgHvZhxXR9w6v4i4S+VnwEg6tspT9pFLUtdEUQQnyOxTtchXEgf2AGA7cDfxEMNeHLvp+QvgNqAR\nWJX++Yd0mYktZammpobdu3cXuxo6zaqrq9m1a1eXzulMizzfbJFLnRBFkSO8StCJ/t9P1iLPddSK\nJKnIDHJJCpxBLkmBM8gllazzzjuPDRs2APGw6OnTpxe5RtkxyKWAVFbWEEVRwZbKyppO12X48OH0\n7t2b9957r035BRdcQFlZGdu2bcv3r5+TWbNm8Y1vfKNN2auvvspnPvMZoPVmYpAMcikg+/fvppDz\nMsXX75woihgxYgQrV65sLdu4cSOHDh0KMhRDHiFkkEvK2rRp01i2bFnr9tKlS5kxY0abUPzggw+4\n8847GTZsGIMGDeIrX/kKhw8fBmDPnj1ce+21fOQjH6GmpobrrruOpqZjD4QnEgkWLFjA5ZdfTmVl\nJVdddVWHTwBHLVmyhLFjx7YpKysr44033uC73/0uK1asYNGiRVRUVDBx4kQg/lTx7LPPdul3njx5\nMrW1tVRVVTFu3DgaGxsBePHFF6mtrW3zuz/55JOMHj0agEOHDjFz5kxqamqoq6tj0aJFDB069Liv\n0VUGuaSsXXLJJezbt49Nmzbxxz/+kR/96EdMmzatzTFz585ly5YtNDQ0sGXLFpqamvjmN78JQEtL\nC7Nnz2bbtm1s27aN8vJybr/99jbnr1y5kiVLlvDOO+9w5MgR7rvvvi7VMYoivvSlL3HzzTdz1113\nsX//fp566qnWfV31+c9/ni1bttDc3MyYMWO4+eabAbj44ovp27cv69evbz12xYoVrfsXLlzItm3b\n2Lp1K+vWreOHP/xh3j65GOSScjJ9+nSWLVvGunXrqKurY/DgY5OeplIpHn74YR544AGqqqro168f\n8+bN49FHHwXip1dvuOEG+vTpQ79+/Zg/fz7PP/986/lRFHHLLbcwcuRI+vTpw5QpU3jllVeyrms+\nuk9mzZpF3759Oeuss7j77rtpaGhg//79AEydOrW1q2n//v2sWbOGqVOnAvDYY48xf/58+vfvz+DB\ng7njjjvy1p2T7aRZkkQURUyfPp2xY8eydevWDt0qzc3NHDx4kAsvvLC1LJVK0dLSAsDBgwf52te+\nxjPPPNM6HcGBAwdIpVKtrdVBgwa1nlteXs6BAwdOx692XC0tLcyfP5/HH3+c5uZmysrKiKKId999\nl4qKCqZOncqnP/1pFi9ezBNPPMGFF17Y2n3y9ttvt+lKGTJkSN7qZYtcUk7OOeccRowYwZo1a/jC\nF77QZt+AAQMoLy+nsbGR3bt3s3v3bvbs2cO+ffsAuP/++9m8eTMvvfQSe/fubf3imWxaqn379uXg\nwYOt2zt27GizPx/dGMuXL2f16tWsX7+evXv3snXr1jb1raurY9iwYaxZs4YVK1Zw0003tZ5bW1vL\n9u3bW7cz13NlkEvK2SOPPMKzzz5LeXl5m/KysjJuvfVW5syZQ3NzMwBNTU2sXbsWiFvf5eXl9O/f\nn127drFw4cIO1+5sqI8ePZrXXnuNhoYGDh8+3OGbngYOHMjvf//7LH67Yw4cOEDv3r2pqanh/fff\nZ/78+R2Ouemmm3jwwQd54YUXmDx5cmv5lClTuOeee9izZw9NTU089NBD9pFLpaiiopp43qTCLPH1\nu27EiBGMGTOmdTszoO69915GjhzJJZdcQv/+/bnyyivZvHkzAHPmzOHQoUMMGDCAyy67jGuuuaZD\nuGVuHx3vfjyjRo1iwYIFXHHFFXzsYx9j7NixbY6dPXs2jY2NVFdXd/jkcKprHzVjxgyGDRvG4MGD\nOe+887j00ks7nDN16lQ2bNjA+PHjqak5Ni5/wYIFDBkyhHPPPZcJEyYwefJkevXqddLX6yxnP5S6\nKWc/PLMtXryYVatW8dxzz7Upd/ZDSeqmduzYwc9//nNaWlp4/fXXeeCBB7jhhhvycm2DXJIyLF++\nnIqKig7L+eeff+qTT+LIkSN8+ctfprKykvHjxzNp0iRuu+22vNTZrhWpm7JrpTTZtSJJJcggl6TA\nGeSSFDgf0Ze6qerq6iCng1Vuqqu7PpbfIA9cZWVNl+aQlk6niopq9u3bVexqnPEctRK4uMXmv6e6\nK0fe5IujViTpDGaQS1LgDHJJCpxBLkmBM8glKXCnCvLvAzuBjRllNcA6YDOwFqjK2DcP+B2wCZiQ\nv2pKkk7kVEH+A+DqdmVziYN8FLA+vQ1QB3wx/fNq4DuduL4kKUenCtoXgPZPm1wPLE2vLwUmpdcn\nAiuBD4E3gS3ARXmppSTphLJpMQ8k7m4h/XNgev1s4K2M494CBmdfNUlSZ+T6iH6Kkz9WeNx9mV+K\nmkgkSCQSOVZDks4syWSSZDLZqWM784j+cOBp4OjXY2wCEsAOoBZ4Dvg4x/rKv5X++VPgbuDFdtfz\nEf088hF9dW8+op8v+X5EfzUwM70+E/hxRvmNQC/gXOCjwEtZXF+S1AWn6lpZCYwDBgDbgQXELe5V\nwGzim5pT0sc2pssbgT8At2FTUZIKztkPA2fXiro3u1byxdkPJekMZpBLUuAMckkKnEEuSYEzyCUp\ncAa5JAXOIJekwBnkkhQ4g1ySAmeQS1LgDHJJCpxBLkmBM8glKXAGuSQFziCXpMAZ5JIUOINckgJn\nkEtS4AxySQqcQS5JgTPIJSlwBrkkBc4gl6TAGeSSFDiDXJICZ5BLUuAMckkKXC5BPg94DdgIrAB6\nAzXAOmAzsBaoyrWCkqSTyzbIhwO3AmOA84EewI3AXOIgHwWsT29Lkgoo2yDfB3wI/AnQM/3zbeB6\nYGn6mKXApFwrKEk6uWyDfBdwP7CNOMD3ELfEBwI708fsTG9Lkgoo2yD/c2AOcRfL2UA/YFq7Y1Lp\nRZJUQD2zPO9TwP8A76W3nwAuBXYAg9I/a4F3jndyfX1963oikSCRSGRZDUk6MyWTSZLJZKeOjbJ8\njdHAcuCvgMPAEuAlYBhxuN9LfKOzio43PFOplA31fImiCD/4qPuK8P2eH/F7/fiZnW2QA/wjMBNo\nAX4D/B1QAawCzgHeBKYQ959nMsjzyCBX92aQ50uhgjxbBnkeGeTq3gzyfDlZkPtkpyQFziCXpMAZ\n5JIUOINckgJnkEtS4AxySQqcQS5JgTPIJSlwBrkkBc4gl6TAGeSSFDiDXJICZ5BLUuAMckkKnEEu\nSYEzyCUpcAa5JAXOIJekwBnkkhQ4g1ySAmeQS1LgDHJJCpxBLkmBM8glKXAGuSQFziCXpMAZ5JIU\nOINckgKXS5BXAY8DvwUagYuBGmAdsBlYmz5GklRAuQT5t4GfAJ8APglsAuYSB/koYH16W5JUQFGW\n5/UHXgZGtCvfBIwDdgKDgCTw8XbHpFKpVJYvq/aiKAL891R3FeH7PT/i9/rxMzvbFvm5QDPwA+A3\nwMNAX2AgcYiT/jkwy+tLkjqpZw7njQFuB34FPEjHbpQUJ2gq1tfXt64nEgkSiUSW1ZCkM1MymSSZ\nTHbq2Gy7VgYBvyBumQNcDswj7mr5a2AHUAs8h10rBWXXiro3u1bypRBdKzuA7cQ3NQGuAF4DngZm\npstmAj/O8vqSpE7KtkUOMBr4HtALeAO4BegBrALOAd4EpgB72p1nizyPbJGre7NFni8na5HnEuTZ\nMsjzyCBX92aQ50shulYkSd2EQS5JgTPIJSlwBrkkBc4gl6TAGeSSFDiDXJICZ5BLUuAMckkKnEEu\nSYEzyCUpcAa5JAXOIJekwBnkkhQ4g1ySAmeQS1LgDHJJCpxBLkmBM8glKXAGuSQFziCXpMAZ5JIU\nOINckgJnkEtS4AxySQqcQS5JgTPIJSlwuQZ5D+Bl4On0dg2wDtgMrAWqcry+JOkUcg3yO4BGIJXe\nnksc5KOA9eltSVIB5RLkQ4DPAd8DonTZ9cDS9PpSYFIO15ckdUIuQf5vwD8ALRllA4Gd6fWd6W1J\nUgFlG+TXAu8Q949HJzgmxbEuF0lSgfTM8rzLiLtRPgf0ASqB/yRuhQ8CdgC1xGHfQX19fet6IpEg\nkUhkWQ1JOjMlk0mSyWSnjj1Ra7orxgF3AtcBi4D3gHuJb3RW0fGGZyqVsqGeL1EU4QcfdV8Rvt/z\nI36vHz+z8zWO/Oj/1LeAK4mHH342vS1JKqB8tMi7yhZ5HtkiV/dmizxfTkeLXJJUJAa5JAXOIJek\nwBnkkhQ4g1ySAmeQS1LgDHJJCpxBLkmBM8glKXAGuSQFziCXpMAZ5JIUOINckgJnkEtS4AxySQqc\nQS5JgTPIJSlwBrkkBc4gl6TAGeSSFDiDXJICZ5BLUuAMckkKnEEuSYEzyCUpcAa5JAXOIJekwBnk\nkhS4bIN8KPAc8BrwKvDVdHkNsA7YDKwFqnKtoCTp5KIszxuUXl4B+gG/BiYBtwDvAouAu4BqYG67\nc1OpVCrLl1V7URQB/nuqu4rw/Z4f8Xv9+JmdbYt8B3GIAxwAfgsMBq4HlqbLlxKHuySpgPLRRz4c\nuAB4ERgI7EyX70xvS5IKqGeO5/cD/gu4A9jfbl+KE3zmr6+vb11PJBIkEokcqyFJZ5ZkMkkymezU\nsdn2kQOcBfw3sAZ4MF22CUgQd73UEt8Q/Xi78+wjzyP7yNW92UeeL4XoI4+AR4BGjoU4wGpgZnp9\nJvDjLK8vSeqkbFvklwMbgP/lWHNwHvASsAo4B3gTmALsaXeuLfI8skWu7s0Web6crEWeS9dKtgzy\nPDLI1b0Z5PlSiK4VSVI3YZBLUuAMckkKnEEuSYEzyCUpcAa5JAXOIJekwBnkkhQ4g1ySAmeQS1Lg\nDHJJCpxBLkmBM8glKXAGuSQFziCXpMAZ5JIUOINckgJnkEtS4AxySQqcQS5JgTPIJSlwBrkkBc4g\nl6TAGeSSFDiDXJICZ5BLUuAMckkKXCGC/GpgE/A74K4CXF+SlCHfQd4DeIg4zOuAqcAn8vwaUgEl\ni10BqcvyHeQXAVuAN4EPgUeBiXl+DamAksWugNRl+Q7ywcD2jO230mWSpALJd5Cn8nw9SdIp9Mzz\n9ZqAoRnbQ4lb5ZkaoiganefXLXFRsStwhllY7AqcUaLIv888aThdL9QTeAMYDvQCXsGbnZIUnGuA\n14lves4rcl0kSZIkSZIKyLsQKmVVxA+vHR0i+xbwDLCnaDWSstCj2BWQimQGsAJoAQ4BZwF/CSwi\nDvLTNkJAkpSdzcQt8vaqiecJkoLh7IdSWz7UpuDk+4EgKRT/DPwaWMuxh9aGAhOAfypWpaRseLNT\npawGuAo4O73dRBzsu4pWI0lSVv40vUiSAjKMeJrlZuKnkLek1x8lnmJCktTN/RL4Im3vE/UEbkzv\nkyR1cycbYujwQwXFB4JUqi4HPgu8SzzksAL4C+DrwF7gseJVTeoaR62oVPUGZgPXc+wR/SZgNfAI\n8EGR6iVJkkqNLXKVsquBSbSdNOsp4KdFq5GUBYNcperbwEeBZcRdKgBDgOnEQxG/WqR6SZI66UQj\nUyLiIJeC4aRZKlWHgYuOU34R8bS2UjCcNEulahawmHjY4dFJs4YA+9L7pGDYR65SV0vbSbN2FLEu\nUlZskauURcRzrhwdtdIT2IlzkiswtshVqiYA3yG+sZnZtfJR4Dbi7+6UJHVjmzj+LIfnpvdJwXDU\nikpVD46NH8/UhF2OCox/sCpV3wd+Bayk7Ve93ZjeJwXDPnKVsjpgIm1HrawGGotWI0mSJKlUXJOx\nXkU8de1GYAUwsCg1krLkzU6Vqn/JWL8f+D/gOuJ+8/8oSo0kSV3ycsZ6A23vFzWc5rpIOXHUikrV\nnwF/Txzg/dvtcxCAguJ3dqpUVQK9iL/y7WXikSrvE8+98kngyeJVTZKUrWXFroCUDbtWVKqeJp4c\nK7Mb5bNAdbr8+mJUSsqGQa5SNYS4O+V7QAtxoH8KuA/7yCUpCD2Ib3b+DLggXba1eNWRJGVrCPAY\n8O/A9iLXRcqKo1ZU6vYRB3kZsBtYX9zqSJIkSZIkSZIkSZIkSVII/h9v8aJGNkqW3gAAAABJRU5E\nrkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fd3f57dba10>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_signal_against_freq('util_avg')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### And the same thing for load_avg:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXIAAAEWCAYAAAB7QRxFAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAFHVJREFUeJzt3XuQVNWBx/FvA44LysCMGF7DQzQmYh5iXDUWFh2NCrso\nJFZ4lUoemgqWiWjFDeyW7FhGo64uJqVYm41JoRVIGZdVMSGiYIOVZMFC44OHo5YgoCCB4SUIjJz9\n4zbNzDAwQ08304f5fqq6+t5zX8dx+jeHc889DZIkSZIkSZIkSZIkSZIkSUcldawvOGzYsLBo0aJj\nfVlJit0iIN3UhuaC/NfAPwMfAV/Mlv0HMBLYC7wLfAfYlt02Ffgu8CnwI2B+E+cMIYSWV106hqqr\nq6murm7rakiHSKVScJjM7tDMsb8Bhjcqmw+cDXwZqCEJb4DBwNjs+3BgRgvOL0lqpeaC9iWgtlHZ\n88D+7PISoCq7PAqYDewDVgPvAOcXpJaSpMNqbYv5u8Afs8t9gHX1tq0D+rby/NIxlU6n27oK0lHr\n1Ipj/42kn3zWEfZpsjO8fh9kOp32w6OS4e+iSkUmkyGTybRo35aMWhkIzOXgzU6AbwM3AJcCn2TL\npmTf78m+/wn4d5Lul/q82SnVU1lZSW1t4x5MtVcVFRVs2bLlkPIj3ezMp0U+HLgNGMbBEAd4hqR1\n/p8kXSqfBZbmcX6pXamtrcXGjQ7IBvZRaS7IZ5MEdg9gLUkLeypQRnLTE+CvwI3ACuCJ7Htdtszf\nTkkqsmP+QBB2rUgNpFIpW+TKOdzvQ2vGkUuSSpxBLikamUyGfv36FeXcAwcOZMGCBUU5d7EZ5FKJ\nKS+vJJVKFe1VXl7Z4roMHDiQE088kc2bNzcoHzJkCB06dOD9998v9H9+mznw84mRQS6VmB07aknG\nCRTnlZy/ZVKpFIMGDWL27Nm5sjfeeIPdu3dHG3rHI4Nc0hFdc801PPbYY7n1mTNnct111zW4Ibdn\nzx5+/OMfM2DAAHr16sWkSZP45JNkdPLWrVsZOXIkn/nMZ6isrOTKK69k/fr1uWPT6TTTpk1j6NCh\nlJeXc8UVVxzyL4DDWblyJel0moqKCr7whS8wd+7c3LY//OEPDBkyhG7dutG/f3/uuOOOBsc+/vjj\nDBgwgB49enD33Xe36HpLly7lq1/9KhUVFfTp04cf/vCH7Nu3D4BJkyZx2223Ndh/1KhRTJ8+HYBX\nXnmFIUOGUF5ezpgxYxg7diy33357i65bioKkgxp/JoAAoYivln8GBw4cGF544YXwuc99LqxcuTLU\n1dWFqqqqsGbNmpBKpcKaNWtCCCFMnjw5jBo1KtTW1oYdO3aEK6+8MkydOjWEEMLmzZvDnDlzwu7d\nu8OOHTvCt771rTB69OjcNYYNGxbOOOOM8Pbbb4fdu3eHdDodpkyZ0mR9XnzxxVBVVRVCCGHv3r3h\n9NNPDz/72c/Cvn37wsKFC0PXrl3DW2+9FUIIIZPJhDfffDOEEMLrr78eevbsGZ566qkQQgjLly8P\nJ598cnjppZfCnj17wq233ho6deoUFixYcMSfx7Jly8KSJUvCp59+GlavXh3OOuus8OCDD4YQQli8\neHHo169fbt8tW7aEzp07hw8//DDs2bMn9O/fP/ziF78IdXV1Yc6cOaGsrCzcfvvth1zjcP9/KLHh\n3Ef8QUntTePPBCUY5D/96U/D1KlTw7x588Lll18e6urqckG+f//+cNJJJ4V33303d9xf/vKXcNpp\npzV5zldffTVUVFTk1tPpdLjrrrty6zNmzAjDhw9v8tj6Qb548eLQq1evBtvHjx8fqqurmzz25ptv\nDrfccksIIYQ77rgjjB8/Prft448/DmVlZc0GeWPTp08P3/jGN0IIIezfvz/0798/LF68OIQQwi9/\n+ctw6aWXhhBCWLRoUejbt2+DY4cOHVqwIG/NXCuS2oFUKsW1117LxRdfzHvvvXdIt8qmTZvYtWsX\nX/nKV3JlIQT2708mSd21axe33HILzz33XG4qgp07dxJCyPWz9+rVK3ds586d2blzZ7P1+uCDDw4Z\nwTJgwIBct82SJUuYMmUKy5cvZ+/evezZs4cxY8bkjq2qqsod16VLF0455ZRmr1lTU8Ott97KsmXL\n2LVrF3V1dZx33nm5n9O4ceOYPXs2F198MbNmzeK6667LXa9v34ZzCPbr169gzw/YRy6pWf3792fQ\noEHMmzePb37zmw229ejRg86dO7NixQpqa2upra1l69atbN++HYAHHniAmpoali5dyrZt21i0aBEh\nhFaHWJ8+fVi7dm2D86xZsyYX0BMmTGD06NGsW7eOrVu38oMf/CC374FjD9i1a1eL+uUnTZrE4MGD\neeedd9i2bRt33XVX7g8WwPjx43nyySdZs2YNS5cu5eqrrwagd+/eDe4LALz//vsFu2FskEtqkUcf\nfZSFCxfSuXPnBuUdOnTghhtuYPLkyWzatAmA9evXM39+8gVhO3fupHPnznTr1o0tW7YcctMRyCvU\nL7jgArp06cJ9993Hvn37yGQyPPvss4wbNy533YqKCsrKyli6dCmzZh2cqPXqq6/m2Wef5c9//jN7\n9+5l2rRpDQL5cHbu3EnXrl3p0qULq1at4pFHHmmw/ZxzzqFHjx5cf/31DB8+nPLycgAuuugiOnbs\nyEMPPURdXR1PP/00L7/88lH/Nx+OQS6VmK5dK0iexC7OKzn/0Rs0aBDnnntubr1+a/Lee+/ljDPO\n4MILL6Rbt25cdtll1NTUADB58mR2795Njx49uOiiixgxYsQhLdH6682N5z6wraysjLlz5zJv3jxO\nPfVUbrrpJh5//HHOPPNMAGbMmMG0adMoLy/nzjvvZOzYsblznH322Tz88MNMmDCBPn36UFlZ2aIH\nje6//35mzZpFeXk53//+9xk3btwhdZ0wYQILFy5kwoQJubITTjiBOXPm8Oijj1JRUcFvf/tbRo4c\nSVlZWbPXbAnnWpHamHOttE8XXHABN954IxMnTmxQ7lwrklSiFi9ezIYNG6irq2PmzJm8+eabDB/e\n+CuR82OQS1I9I0aMoGvXroe87rnnnuYPPoK33nqLc845h4qKCqZPn86TTz5Jz549C1Jnu1akNmbX\niuqza0WS2iGDXJIiZ5BLUuR8RF9qYxUVFU4Jq5yKiqMf52+QR668vPKo5peWjqWuXSvYvn1LW1fj\nuOeolcglLTl/nipVjsgpFEetSNJxzCCXpMgZ5JIUOYNckiJnkEtS5AxySYpcc0H+a2Aj8Ea9skrg\neaAGmA90r7dtKvA2sAq4vHDVlCQdTnNB/hug8YS5U0iC/ExgQXYdYDAwNvs+HJjRgvNLklqpuaB9\nCWj82OBVwMzs8kxgdHZ5FDAb2AesBt4Bzi9ILSVJh5VPi7knSXcL2fcDM6P3AdbV228d0Df/qkmS\nWqK1XR+BIz8f7rO5klRk+UyatRHoBWwAegMfZcvXA/W/hroqW3aI6urq3HI6nSadTudRDUk6fmUy\nGTKZTIv2bcmkWQOBucAXs+v3AZuBe0ludHbPvg8GZpH0i/cFXgDO4NBWuZNmFZCTZqm0OWlWoRxp\n0qzmWuSzgWFAD2AtMA24B3gC+B7JTc0x2X1XZMtXAHXAjZgwklR0TmMbOVvkKm22yAvFaWwl6Thm\nkEtS5AxySYqcQS5JkTPIJSlyBrkkRc4gl6TIGeSSFDmDXJIiZ5BLUuQMckmKnEEuSZEzyCUpcga5\nJEXOIJekyBnkkhQ5g1ySImeQS1LkDHJJipxBLkmRM8glKXIGuSRFziCXpMgZ5JIUOYNckiJnkEtS\n5AxySYqcQS5JkWtNkE8FlgNvALOAE4FK4HmgBpgPdG9tBSVJR5ZvkA8EbgDOBb4IdATGAVNIgvxM\nYEF2XZJURPkG+XZgH9AF6JR9/wC4CpiZ3WcmMLq1FZQkHVm+Qb4FeAB4nyTAt5K0xHsCG7P7bMyu\nS5KKqFOex50OTCbpYtkG/B64ptE+Ifs6RHV1dW45nU6TTqfzrIYkHZ8ymQyZTKZF+6byvMZY4DLg\n+uz6tcCFwCXA14ANQG/gReDzjY4NITSZ78pDKpXiMH8vpRKQws97YSSf9aYzO9+ulVUkwd05e+Kv\nAyuAucDE7D4TgafyPL8kqYXybZED/AtJWO8HXiFpnXcFngD6A6uBMST95/XZIi8gW+QqbbbIC+VI\nLfLWBHm+DPICMshV2gzyQilG14okqUQY5JIUOYNckiJnkEtS5AxySYqcQS5JkTPIJSlyBrkkRc4g\nl6TIGeSSFDmDXJIiZ5BLUuQMckmKnEEuSZEzyCUpcga5JEXOIJekyBnkkhQ5g1ySImeQS1LkDHJJ\nipxBLkmRM8glKXIGuSRFziCXpMgZ5JIUOYNckiLXmiDvDjwJrARWABcAlcDzQA0wP7uPJKmIWhPk\nPwf+CJwFfAlYBUwhCfIzgQXZdUlSEaXyPK4b8CowqFH5KmAYsBHoBWSAzzfaJ4QQ8rysGkulUoA/\nT5WqFH7eCyP5rDed2fm2yE8DNgG/AV4B/hs4CehJEuJk33vmeX5JUgt1asVx5wI3AS8DD3JoN0rg\nME3F6urq3HI6nSadTudZDUk6PmUyGTKZTIv2zbdrpRfwV5KWOcBQYCpJV8vXgA1Ab+BF7FopKrtW\nVNrsWimUYnStbADWktzUBPg6sByYC0zMlk0Ensrz/JKkFsq3RQ7wZeBXQBnwLvAdoCPwBNAfWA2M\nAbY2Os4WeQHZIldps0VeKEdqkbcmyPNlkBeQQa7SZpAXSjG6ViRJJcIgl6TIGeSSFDmDXJIiZ5BL\nUuQMckmKnEEuSZEzyCUpcga5JEXOIJekyBnkkhQ5g1ySImeQS1LkDHJJipxBLkmRM8glKXIGuSRF\nziCXpMgZ5JIUOYNckiJnkEtS5AxySYqcQS5JkTPIJSlyBrkkRc4gl6TIGeSSFLnWBnlH4FVgbna9\nEngeqAHmA91beX5JUjNaG+Q3AyuAkF2fQhLkZwILsuuSpCJqTZBXAf8E/ApIZcuuAmZml2cCo1tx\nfklSC7QmyKcDtwH765X1BDZmlzdm1yVJRdQpz+NGAh+R9I+nD7NP4GCXSwPV1dW55XQ6TTp9uFNI\nUvuUyWTIZDIt2jfV/C5Nuhu4FqgD/gEoB+YA/0gS7BuA3sCLwOcbHRtCaDLflYdUKsVh/l5KJSCF\nn/fCSD7rTWd2vl0r/wr0A04DxgELSYL9GWBidp+JwFN5nl+S1EKFGkd+4E/uPcBlJMMPL8muS5KK\nKN+uldawa6WA7FpRabNrpVCK0bUiSSoRBrkkRc4gl6TIGeSSFDmDXJIiZ5BLUuQMckmKnEEuSZEz\nyCUpcga5JEXOIJekyBnkkhQ5g1ySImeQS1LkDHJJipxBLkmRM8glKXIGuSRFziCXpMgZ5JIUOYNc\nkiJnkEtS5AxySYqcQS5JkTPIJSlyBrkkRc4gl6TI5Rvk/YAXgeXAm8CPsuWVwPNADTAf6N7aCkqS\njiyV53G9sq+/AScDy4DRwHeAvwP3AT8BKoApjY4NIYQ8L6vGUqkU4M9TpSqFn/fCSD7rTWd2vi3y\nDSQhDrATWAn0Ba4CZmbLZ5KEuySpiArRRz4QGAIsAXoCG7PlG7PrkqQiam2Qnwz8D3AzsKPRtoD/\n5pekouvUimNPIAnxx4GnsmUbSfrONwC9gY+aOrC6ujq3nE6nSafTraiGJB1/MpkMmUymRfvme7Mz\nRdIHvhm4pV75fdmye0lucnbHm51F5c1OlTZvdhbKkW525hvkQ4HFwOscTJGpwFLgCaA/sBoYA2xt\ndKxBXkAGuUqbQV4oxQjy1jDIC8ggV2kzyAulGMMPJUklwiCXpMgZ5JIUOYNckiJnkEtS5AxySYqc\nQS5JkTPIJSlyBrkkRc4gl6TIGeSSFDmDXJIiZ5BLUuQMckmKnEEuSZEzyCUpcga5JEXOIJekyBnk\nkhQ5g1ySImeQS1LkDHJJipxBLkmRM8glKXIGuSRFziCXpMgZ5JIUuWIE+XBgFfA28JMinF+SVE+h\ng7wj8BBJmA8GxgNnFfgaUhFl2roC0lErdJCfD7wDrAb2Ab8DRhX4GlIRZdq6AtJRK3SQ9wXW1ltf\nly2TJBVJoYM8FPh8kqRmdCrw+dYD/eqt9yNpldf3WiqV+nKBr9vOpdq6AseZO9q6AseVVMrfzwJ5\n7VhdqBPwLjAQKAP+hjc7JSk6I4C3SG56Tm3jukiSJEmSJBWRdyHUnnUneXjtwBDZdcBzwNY2q5GU\nh45tXQGpjVwHzAL2A7uBE4BzgPtIgvyYjRCQJOWnhqRF3lgFyTxBUjSc/VBqyIfaFJ1CPxAkxeIu\nYBkwn4MPrfUDLgfubKtKSfnwZqfas0rgCqBPdn09SbBvabMaSZLyckr2JUmKyACSaZY3kTyF/E52\n+XckU0xIkkrc/wFjaXifqBMwLrtNklTijjTE0OGHiooPBKm9GgpcAvydZMhhV+Bs4N+AbcDv265q\n0tFx1IraqxOB7wFXcfAR/fXAM8CjwJ42qpckSWpvbJGrPRsOjKbhpFlPA39qsxpJeTDI1V79HPgs\n8BhJlwpAFXAtyVDEH7VRvSRJLXS4kSkpkiCXouGkWWqvPgHOb6L8fJJpbaVoOGmW2qtvA4+QDDs8\nMGlWFbA9u02Khn3kau9603DSrA1tWBcpL7bI1Z6lSOZcOTBqpROwEeckV2Rskau9uhyYQXJjs37X\nymeBG0m+u1OSVMJW0fQsh6dlt0nRcNSK2quOHBw/Xt967HJUZPyFVXv1a+BlYDYNv+ptXHabFA37\nyNWeDQZG0XDUyjPAijarkSRJktRejKi33J1k6to3gFlAzzapkZQnb3aqvbq73vIDwIfAlST95v/V\nJjWSJB2VV+stv0bD+0WvHeO6SK3iqBW1V6cCt5IEeLdG2xwEoKj4nZ1qr8qBMpKvfHuVZKTKxyRz\nr3wJ+N+2q5okKV+PtXUFpHzYtaL2ai7J5Fj1u1EuASqy5Ve1RaWkfBjkaq+qSLpTfgXsJwn084D7\nsY9ckqLQkeRm5wvAkGzZe21XHUlSvqqA3wMPA2vbuC5SXhy1ovZuO0mQdwBqgQVtWx1JkiRJkiRJ\nkiRJkiRJisH/A/v5fIbikDV+AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fd3f52c9150>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_signal_against_freq('load_avg')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Examine trace from workload execution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot task residency and `sched_util` and `sched_load` for the workload task, along with the expected mean value for util_avg. Note that assuming the system was under little load, so that the task was RUNNING whenever it was RUNNABLE, `load_avg` and `util_avg` should be the same. \n",
+    "\n",
+    "Call `examine_experiment` with different experiment indexes to get plots for runs at different frequencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "signals = ['util_avg', 'load_avg']\n",
+    "def examine_experiment(idx):\n",
+    "    experiment = t.experiments[idx]\n",
+    "    \n",
+    "    [freq] = experiment.conf['cpufreq']['freqs'].values()\n",
+    "    print \"Experiment ran at frequency {}\".format(freq)\n",
+    "    events = t.te.test_conf[\"ftrace\"][\"events\"]\n",
+    "    \n",
+    "    # todo add get_trace method\n",
+    "    tasks = experiment.wload.tasks.keys()\n",
+    "    #trace = Trace(t.te.platform, experiment.out_dir, events, tasks)\n",
+    "    print 'Trace plot:'\n",
+    "    plot_trace(t.get_trace(experiment).ftrace)\n",
+    "    \n",
+    "    # Get observed signal\n",
+    "    signal_df = t.get_sched_task_signals(experiment, signals)\n",
+    "    # Get expected average value for util_avg signal\n",
+    "    expected_util_avg_mean = t.get_expected_util_avg(experiment)\n",
+    "    \n",
+    "    # Plot task util_avg signal with expected mean value\n",
+    "    util_avg_mean = pd.Series([expected_util_avg_mean], name='expected_util_avg', index=[signal_df.index[0]])\n",
+    "    df = pd.concat([signal_df, util_avg_mean], axis=1).ffill()\n",
+    "    ILinePlot(df, column=signals + ['expected_util_avg'], drawstyle='steps-post',\n",
+    "             title='Scheduler task signals').view()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experiment 0:    450000Hz\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i , f in enumerate(freqs):\n",
+    "    print \"Experiment {}:{:10d}Hz\".format(i, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experiment ran at frequency 450000\n",
+      "Trace plot:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "/*\n",
+       " *    Copyright 2015-2016 ARM Limited\n",
+       " *\n",
+       " * Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+       " * you may not use this file except in compliance with the License.\n",
+       " * You may obtain a copy of the License at\n",
+       " *\n",
+       " *     http://www.apache.org/licenses/LICENSE-2.0\n",
+       " *\n",
+       " * Unless required by applicable law or agreed to in writing, software\n",
+       " * distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+       " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+       " * See the License for the specific language governing permissions and\n",
+       " * limitations under the License.\n",
+       " */\n",
+       "\n",
+       ".d3-tip {\n",
+       "  line-height: 1;\n",
+       "  padding: 12px;\n",
+       "  background: rgba(0, 0, 0, 0.6);\n",
+       "  color: #fff;\n",
+       "  border-radius: 2px;\n",
+       "  position: absolute !important;\n",
+       "  z-index: 99999;\n",
+       "}\n",
+       "\n",
+       ".d3-tip:after {\n",
+       "  box-sizing: border-box;\n",
+       "  pointer-events: none;\n",
+       "  display: inline;\n",
+       "  font-size: 10px;\n",
+       "  width: 100%;\n",
+       "  line-height: 1;\n",
+       "  color: rgba(0, 0, 0, 0.6);\n",
+       "  content: \"\\25BC\";\n",
+       "  position: absolute !important;\n",
+       "  z-index: 99999;\n",
+       "  text-align: center;\n",
+       "}\n",
+       "\n",
+       ".d3-tip.n:after {\n",
+       "  margin: -1px 0 0 0;\n",
+       "  top: 100%;\n",
+       "  left: 0;\n",
+       "}\n",
+       "\n",
+       ".contextRect {\n",
+       "  fill: lightgray;\n",
+       "  fill-opacity: 0.5;\n",
+       "  stroke: black;\n",
+       "  stroke-width: 1;\n",
+       "  stroke-opacity: 1;\n",
+       "  pointer-events: none;\n",
+       "  shape-rendering: crispEdges;\n",
+       "}\n",
+       "\n",
+       ".chart {\n",
+       "  shape-rendering: crispEdges;\n",
+       "}\n",
+       "\n",
+       ".mini text {\n",
+       "  font: 9px sans-serif;\n",
+       "}\n",
+       "\n",
+       ".main text {\n",
+       "  font: 12px sans-serif;\n",
+       "}\n",
+       "\n",
+       ".axis line, .axis path {\n",
+       "  stroke: black;\n",
+       "}\n",
+       "\n",
+       ".miniItem {\n",
+       "  stroke-width: 8;\n",
+       "}\n",
+       "\n",
+       ".brush .extent {\n",
+       "\n",
+       "  stroke: #000;\n",
+       "  fill-opacity: .125;\n",
+       "  shape-rendering: crispEdges;\n",
+       "}\n",
+       "</style>\n",
+       "<div id=\"fig_de98d94c094f48cc85343707f81b5c45\" class=\"eventplot\">\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js\" -->\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"http://labratrevenge.com/d3-tip/javascripts/d3.tip.v0.6.3.js\" -->\n",
+       "\n",
+       "        <script>\n",
+       "            /* TRAPPY_PUBLISH_IMPORT = \"plotter/js/EventPlot.js\" */\n",
+       "            /* TRAPPY_PUBLISH_REMOVE_START */\n",
+       "            var req = require.config( {\n",
+       "\n",
+       "                paths: {\n",
+       "\n",
+       "                    \"EventPlot\": '/nbextensions/plotter_scripts/EventPlot/EventPlot',\n",
+       "                    \"d3-tip\": '/nbextensions/plotter_scripts/EventPlot/d3.tip.v0.6.3',\n",
+       "                    \"d3-plotter\": '/nbextensions/plotter_scripts/EventPlot/d3.min'\n",
+       "                },\n",
+       "                waitSeconds: 15,\n",
+       "                shim: {\n",
+       "                    \"d3-plotter\" : {\n",
+       "                        \"exports\" : \"d3\"\n",
+       "                    },\n",
+       "                    \"d3-tip\": [\"d3-plotter\"],\n",
+       "                    \"EventPlot\": {\n",
+       "\n",
+       "                        \"deps\": [\"d3-tip\", \"d3-plotter\" ],\n",
+       "                        \"exports\":  \"EventPlot\"\n",
+       "                    }\n",
+       "                }\n",
+       "            });\n",
+       "            /* TRAPPY_PUBLISH_REMOVE_STOP */\n",
+       "            \n",
+       "        req([\"require\", \"EventPlot\"], function() { /* TRAPPY_PUBLISH_REMOVE_LINE */\n",
+       "            EventPlot.generate('fig_de98d94c094f48cc85343707f81b5c45', '/nbextensions/', {\"lanes\": [{\"id\": 0, \"label\": \"CPU :0\"}, {\"id\": 1, \"label\": \"CPU :1\"}, {\"id\": 2, \"label\": \"CPU :2\"}, {\"id\": 3, \"label\": \"CPU :3\"}, {\"id\": 4, \"label\": \"CPU :4\"}, {\"id\": 5, \"label\": \"CPU :5\"}], \"colorMap\": null, \"keys\": [\"sshd-3943\", \"sshd-3946\", \"sshd-3948\", \"sshd-3945\", \"bash-3919\", \"bash-3957\", \"bash-3922\", \"bash-3949\", \"fie_test0-3941\", \"bash-3954\", \"bash-3927\", \"sh-3925\", \"sh-3952\", \"sudo-3954\", \"sudo-3921\", \"sudo-3957\", \"sudo-3956\", \"sudo-3959\", \"sudo-3951\", \"sudo-3922\", \"bash-3940\", \"sudo-3919\", \"sudo-3949\", \"shutils-3932\", \"kworker/u12:2-3923\", \"kworker/u12:1-3950\", \"kworker/u12:1-3947\", \"kworker/u12:1-3944\", \"kworker/u12:1-3955\", \"kworker/u12:1-3958\", \"kworker/u12:2-3920\", \"shutils-3953\", \"shutils-3926\", \"sudo-3924\", \"shutils-3937\", \"shutils-3929\", \"shutils-3931\", \"busybox-3928\", \"shutils-3939\", \"shutils-3933\", \"shutils-3935\", \"busybox-3930\", \"systemd-journal-1675\", \"sudo-3915\", \"busybox-3934\", \"shutils-3930\", \"busybox-3936\", \"shutils-3936\", \"busybox-3938\", \"shutils-3928\", \"shutils-3938\", \"shutils-3934\", \"sh-3960\", \"sh-3917\", \"sshd-1747\", \"shutils-3927\", \"sh-3924\", \"systemd-1\", \"scp-3945\", \"scp-3948\", \"shutils-3952\", \"sh-3951\", \"sshd-3752\", \"shutils-3925\", \"ksoftirqd/0-3\", \"bash-3754\", \"in:imuxsock-1761\", \"rs:main Q:Reg-1763\", \"rt-app-3940\", \"jbd2/sda1-8-990\", \"kworker/1:0-3513\", \"true-3938\", \"ksoftirqd/2-23\", \"rt-app-3941\", \"kworker/u12:1-3942\", \"kworker/2:1-2987\", \"kworker/u12:2-3314\", \"kthreadd-2\", \"ksoftirqd/1-17\", \"kworker/u12:0-3216\", \"usb-storage-975\", \"kworker/3:2-1646\", \"rcu_preempt-7\", \"kworker/0:2-1645\", \"rcu_sched-8\", \"khungtaskd-320\", \"kworker/4:1-969\", \"kworker/5:2-1697\", \"kworker/1:1H-989\", \"kthreadd-3942\", \"watchdog/2-21\", \"watchdog/1-15\", \"watchdog/0-12\", \"watchdog/4-33\", \"watchdog/5-39\", \"watchdog/3-27\"], \"stride\": false, \"showSummary\": true, \"xDomain\": [6.6000000060739694e-05, 5.9025510000001304], \"data\": {\"watchdog/4-33\": {\"4\": [[2.6286530000002131, 2.6286620000000767]]}, \"kworker/1:0-3513\": {\"1\": [[0.36080000000038126, 0.36083300000018426], [0.95277600000008533, 0.95296000000007552], [1.1768650000003618, 1.1769090000002507], [1.4647730000001502, 1.4648310000002311], [1.4657990000000609, 1.4658850000000712], [1.9768579999999929, 1.9770490000000791], [2.4166840000002594, 2.4167290000000321], [3.0006780000003346, 3.0008670000001985], [3.4808760000000802, 3.4809390000000349], [3.4813740000004145, 3.4814530000003288], [4.0246540000002824, 4.0248430000001463], [4.260827000000063, 4.2608750000003965], [5.0488240000004225, 5.0490110000000641], [5.1767060000001948, 5.1767400000003363], [5.4967710000000807, 5.4968310000003839], [5.4976760000004106, 5.4977630000003046]]}, \"true-3938\": {\"5\": [[2.052654000000075, 2.0527950000000601]]}, \"rcu_preempt-7\": {\"0\": [[0.42894599999999627, 0.428972000000158], [0.4366280000003826, 0.4366400000003523], [0.43682400000034249, 0.43683700000019599], [0.44461700000010751, 0.44463400000040565], [0.45280400000001464, 0.45282800000040879], [0.4532880000001569, 0.45331500000020242], [0.46080200000005789, 0.46082700000033583], [3.8526930000002721, 3.8527130000002217], [3.8565600000001723, 3.856572000000142], [3.8646850000000086, 3.8647000000000844], [3.8766340000001946, 3.8766470000000481], [3.8808070000000043, 3.8808200000003126], [3.888618000000406, 3.8886710000001585], [3.8887050000003001, 3.888716000000386], [3.8966910000003736, 3.8967030000003433], [3.9046849999999722, 3.9046980000002804], [3.9126880000003439, 3.9127010000001974], [3.9206910000002608, 3.9207040000001143], [3.9286220000003595, 3.9286329999999907]], \"1\": [[1.1246610000002875, 1.1246820000001208], [1.1249290000000656, 1.124953000000005], [1.1326560000002246, 1.1326820000003863], [2.0286450000003242, 2.0286710000000312], [2.036645000000135, 2.0366680000001907], [2.0366950000002362, 2.036717000000408], [2.4768670000003112, 2.476886000000377], [3.7367480000002615, 3.7367670000003272], [3.7447580000002745, 3.7447810000003301], [3.7527610000001914, 3.752784000000247], [3.7607570000000123, 3.7607760000000781], [3.7967860000003384, 3.7968050000004041], [3.8047760000004018, 3.8047990000000027], [3.8127560000002632, 3.8127790000003188], [3.8207660000002761, 3.8207840000000033], [3.8248020000000906, 3.8248220000000401], [3.9286610000003748, 3.9286830000000919], [4.0606420000003709, 4.0606660000003103], [4.0686660000001211, 4.068688000000293], [4.0766260000000329, 4.0766499999999724], [4.0847600000001876, 4.0847820000003594], [4.0927580000002308, 4.0927770000002965], [4.0930140000000392, 4.0930360000002111], [4.1007540000000517, 4.1007740000000013], [4.1010110000001987, 4.101032000000032], [4.1087580000003072, 4.1087760000000344], [4.1090290000001914, 4.1090500000000247], [4.1167620000001079, 4.116783000000396], [4.2767140000000836, 4.2767340000000331], [5.1926440000002003, 5.1926670000002559], [5.8807930000002671, 5.880877000000055], [5.8887859999999819, 5.888810000000376], [5.8965950000001612, 5.8966199999999844]], \"2\": [[0.0046420000003308814, 0.0046660000002702873], [0.016622000000097614, 0.016640000000279542], [0.024623000000246975, 0.024642000000312692], [0.032748000000083266, 0.032771000000138883], [0.040758999999980006, 0.040782000000035623], [0.048760000000129367, 0.048779000000195083], [0.41266700000005585, 0.4127440000002025], [0.42065600000023551, 0.42067800000040734], [0.42859800000042014, 0.42862400000012713], [0.46090200000026016, 0.46092500000031578], [0.46889499999997497, 0.46891900000036912], [0.47675300000037169, 0.47677199999998265], [1.1167150000001129, 1.1167370000002848], [1.1407269999999698, 1.1408110000002125], [1.1486380000001191, 1.1486620000000585], [1.1606200000001081, 1.1606400000000576], [1.1687510000001566, 1.168775000000096], [1.1806420000002618, 1.1806620000002113], [1.1887520000000222, 1.1887750000000779], [1.1967620000000352, 1.1967800000002171], [2.0207170000003316, 2.0208070000003318], [2.0446380000003046, 2.0446540000002642], [2.0447000000003754, 2.044716000000335], [2.0526360000003478, 2.0527210000000196], [2.0566290000001572, 2.056648000000223], [2.0687660000003234, 2.068789000000379], [2.0768880000000536, 2.0769110000001092], [2.0848820000001069, 2.0849050000001625], [2.092855000000327, 2.0928780000003826], [2.100760000000264, 2.1007779999999912], [2.4685990000002676, 2.4687560000002122], [2.4767679999999928, 2.4767870000000585], [2.4847480000003088, 2.484766000000036], [2.4927640000000792, 2.4927820000002612], [2.4968790000002627, 2.4968969999999899], [2.5048320000000786, 2.5048540000002504], [2.5127630000001773, 2.5127810000003592], [3.46478100000013, 3.4648010000000795], [3.4727700000003097, 3.4727880000000368], [3.4730380000000878, 3.4730590000003758], [3.4807650000002468, 3.480782999999974], [3.4810300000003735, 3.4810510000002068], [3.4888180000002649, 3.4888420000002043], [3.4890970000001289, 3.4891180000004169], [3.496813000000202, 3.4968380000000252], [3.6887190000002192, 3.6888160000003154], [3.6967890000000807, 3.6968150000002424], [3.7087530000003426, 3.7087800000003881], [3.7167470000003959, 3.7167710000003353], [3.7247550000001866, 3.7247800000000097], [3.8367440000001807, 3.8367630000002464], [3.8447530000003098, 3.8447750000000269], [3.9407430000001114, 3.9407620000001771], [3.9487540000000081, 3.9487760000001799], [3.9567530000003899, 3.9567720000000008], [4.0007160000000113, 4.0007340000001932], [4.0087690000000293, 4.008792000000085], [4.0167570000003252, 4.0167750000000524], [4.0287700000003497, 4.0287880000000769], [4.036830000000009, 4.0368530000000646], [4.0447590000003402, 4.0447820000003958], [4.0540869999999813, 4.0541840000000775], [4.2846480000002884, 4.2847289999999703], [4.2847460000002684, 4.2847639999999956], [4.2926760000000286, 4.2927000000004227], [4.3006480000003648, 4.3006720000003043], [4.3086580000003778, 4.3086800000000949], [4.3166330000003654, 4.3166519999999764], [4.3248660000003838, 4.3248900000003232], [4.3328620000002047, 4.3328850000002603], [4.3407530000004044, 4.3407720000000154], [5.1768090000000484, 5.1769010000002709], [5.1848130000003039, 5.1848950000003242], [5.2006430000001274, 5.2006670000000668], [5.2127550000000156, 5.2127810000001773], [5.2208580000001348, 5.2208820000000742], [5.2288580000004004, 5.2288820000003398], [5.2368550000001051, 5.2368780000001607], [5.2447530000004008, 5.2447720000000118], [5.8966770000001816, 5.896701000000121]]}, \"kworker/1:1H-989\": {\"1\": [[3.3846800000001167, 3.3847000000000662], [4.0567680000003747, 4.0567840000003343], [4.0590480000000753, 4.0590610000003835]]}, \"watchdog/0-12\": {\"0\": [[2.4445720000003348, 2.4445840000003045]]}, \"kworker/u12:2-3314\": {\"0\": [[0.20749700000033044, 0.20751200000040626], [0.35927000000037879, 0.35931200000004537]], \"1\": [[0.42381999999997788, 0.42387600000029124], [0.43827900000042064, 0.43831600000021353], [1.0608799999999974, 1.0609810000000834], [1.0612420000002203, 1.0612840000003416], [1.0645410000001903, 1.0646460000002662], [1.1263930000000073, 1.1264500000002045], [1.1475100000002385, 1.1475460000001476], [1.7622210000004088, 1.762358000000404], [1.7626210000003084, 1.7626589999999851], [1.8123390000000654, 1.8124680000000808], [1.8127420000000711, 1.8127830000003087], [3.6700510000000577, 3.6700920000002952], [5.1252730000001065, 5.1252890000000662], [5.1253320000000713, 5.1253490000003694], [5.125391000000036, 5.1254060000001118], [5.1254480000002332, 5.1254619999999704], [5.1255049999999756, 5.1255200000000514], [5.1255620000001727, 5.1255780000001323], [5.1256190000003699, 5.1256360000002132], [5.1256760000001123, 5.1256920000000719], [5.125735000000077, 5.1257920000002741], [5.1258340000003955, 5.1258490000000165], [5.1258910000001379, 5.1259070000000975], [5.125948000000335, 5.1259630000004108], [5.1260050000000774, 5.1260200000001532], [5.1260600000000522, 5.1260760000000118], [5.1261180000001332, 5.126133000000209], [5.1261760000002141, 5.1261900000004061], [5.1262310000001889, 5.1262490000003709], [5.1262910000000375, 5.1263060000001133], [5.1263490000001184, 5.1263630000003104], [5.1264060000003155, 5.1264200000000528], [5.1264610000002904, 5.12647700000025], [5.1265180000000328, 5.1265330000001086], [5.126578000000336, 5.1265930000004118], [5.1266340000001946, 5.1266500000001543], [5.1266930000001594, 5.1267070000003514], [5.1267510000002403, 5.1267660000003161], [5.126810000000205, 5.1268240000003971], [5.1268660000000637, 5.1268850000001294], [5.1269280000001345, 5.1269430000002103], [5.1269860000002154, 5.1270030000000588], [5.1270480000002863, 5.1271520000000237], [5.1271990000000187, 5.1272140000000945], [5.1272570000000997, 5.1272720000001755], [5.1273170000004029, 5.127332000000024], [5.1273760000003676, 5.1273900000001049], [5.1274350000003324, 5.1274490000000696], [5.1274940000002971, 5.1275080000000344], [5.1275510000000395, 5.1275660000001153], [5.1276100000000042, 5.1276260000004186], [5.1276700000003075, 5.1276850000003833], [5.1277310000000398, 5.1277460000001156], [5.127791000000343, 5.1278060000004189], [5.127849000000424, 5.1278650000003836], [5.1279090000002725, 5.1279250000002321], [5.1279710000003433, 5.1279860000004192], [5.1280320000000756, 5.1280470000001515], [5.1280940000001465, 5.1281080000003385], [5.1281550000003335, 5.1281850000000304], [5.8276620000001458, 5.8277030000003833], [5.8280690000001414, 5.8281400000000758], [5.8284530000000814, 5.8284940000003189], [5.8289570000001731, 5.8290310000002137], [5.8292810000002646, 5.8293220000000474]], \"2\": [[0.36000300000023344, 0.36015100000031453], [0.36058500000035565, 0.3606950000003053], [0.36103700000012395, 0.3610780000003615], [0.36144700000022567, 0.36151900000004389], [0.36177200000020093, 0.36181299999998373], [0.36217500000020664, 0.36224800000036339], [0.36249700000007579, 0.36253800000031333], [0.36275000000023283, 0.36281400000007125], [0.36293000000023312, 0.36295200000040495], [0.36312100000031933, 0.36314100000026883], [0.36330399999997098, 0.3633270000000266], [0.36348300000008749, 0.36350300000003699], [0.36366300000008778, 0.36368300000003728], [0.36398600000029546, 0.36402100000032078], [0.36429200000020501, 0.36433299999998781], [0.364676000000145, 0.3646840000001248], [0.409179000000222, 0.40927200000032826], [0.40929600000026767, 0.40938400000004549], [0.42111300000033225, 0.42119900000034249], [1.0647180000000844, 1.064734000000044], [1.0647840000001452, 1.0647980000003372], [1.0648470000000998, 1.0648610000002918], [1.0649090000001706, 1.0649230000003627], [1.0649720000001253, 1.0649880000000849], [1.0650350000000799, 1.0650500000001557], [1.0650990000003731, 1.0651139999999941], [1.0651620000003277, 1.065176000000065], [1.0652260000001661, 1.0653360000001157], [1.0653870000001007, 1.0654030000000603], [1.0654500000000553, 1.0654660000000149], [1.0655130000000099, 1.0655290000004243], [1.0655770000003031, 1.0655910000000404], [1.0656410000001415, 1.0656560000002173], [1.0657049999999799, 1.0657210000003943], [1.0657740000001468, 1.0657890000002226], [1.0658370000001014, 1.0658520000001772], [1.0659020000002783, 1.0659170000003542], [1.0659670000000006, 1.0659820000000764], [1.0660320000001775, 1.0660460000003695], [1.1109000000001288, 1.1109430000001339], [1.1116100000003826, 1.1117600000002312], [1.1234309999999823, 1.1235160000001088], [1.8129550000003292, 1.8130519999999706], [1.8132230000001073, 1.8132709999999861], [1.9651080000003276, 1.9651530000001003], [1.9658390000004147, 1.965994000000137], [1.9663460000001578, 1.9664200000001983], [1.9667480000002797, 1.9667900000004011], [1.967160000000149, 1.9672300000001997], [1.9674800000002506, 1.9675210000000334], [2.2590760000002774, 2.2591489999999794], [2.4135100000003149, 2.4135559999999714], [2.4142260000003262, 2.4143770000000586], [2.4147550000002411, 2.4148280000003979], [2.4150770000001103, 2.4151170000000093], [2.4158520000000863, 2.415925000000243], [2.4161760000001777, 2.4162170000004153], [3.4610139999999774, 3.4610250000000633], [3.6651180000003478, 3.6651620000002367], [3.6653989999999794, 3.6654190000003837], [5.8272680000000037, 5.827284000000418]]}, \"kworker/2:1-2987\": {\"2\": [[0.3606950000003053, 0.36077300000033574], [1.1770040000001245, 1.1770300000002862], [2.4166830000003756, 2.4167630000001736], [4.2613330000003771, 4.261363000000074], [5.1847880000000259, 5.1848130000003039]]}, \"kworker/4:1-969\": {\"4\": [[2.4168220000001384, 2.4168650000001435]]}, \"kworker/u12:2-3920\": {\"2\": [[0.42119900000034249, 0.42378500000040731]]}, \"kworker/u12:2-3923\": {\"2\": [[1.1235160000001088, 1.1262820000001739]]}, \"shutils-3952\": {\"2\": [[4.3017620000000534, 4.3017970000000787], [4.3018220000003566, 4.3018369999999777], [4.3018830000000889, 4.301897000000281], [4.3019420000000537, 4.3019560000002457], [4.3022310000001198, 4.3033110000001216]]}, \"shutils-3953\": {\"1\": [[4.2997730000001866, 4.3022800000003372]]}, \"watchdog/1-15\": {\"1\": [[2.4967610000003333, 2.4967740000001868]]}, \"kthreadd-2\": {\"2\": [[3.6651620000002367, 3.6652320000002874]]}, \"sshd-3945\": {\"2\": [[3.8531970000003639, 3.8640950000003613]]}, \"systemd-journal-1675\": {\"1\": [[0.42819500000041444, 0.42980100000022503], [0.42983600000025035, 0.43023400000038237], [0.43045300000039788, 0.43140000000039436], [0.4348720000002686, 0.43612300000040705], [1.130844000000252, 1.132361000000401], [1.1329279999999926, 1.1342190000000301], [1.1454770000000281, 1.1467590000002019], [4.3043440000001283, 4.3049750000000131], [4.3050120000002607, 4.3050480000001698], [4.3051080000000184, 4.3059090000001561], [5.19413300000042, 5.1956480000003467], [5.1959260000003269, 5.1963190000001305], [5.1965190000000803, 5.1975560000000769]], \"2\": [[0.0013650000000779983, 0.0014940000000933651], [0.0016080000000329164, 0.0020890000000690634], [0.0021200000001044828, 0.0029750000003332389], [3.8515990000000784, 3.8531970000003639], [3.8688879999999699, 3.8700420000000122], [4.0525489999999991, 4.0540869999999813], [4.0684049999999843, 4.0696760000000722], [4.2905640000003586, 4.2919700000002194], [4.2921530000003258, 4.2925520000003416], [4.2927300000001196, 4.2935780000002524], [5.2008140000002641, 5.2012940000004164], [5.2014970000000176, 5.2024000000001251], [5.8959200000003875, 5.8960420000003069], [5.8962580000002163, 5.8966770000001816], [5.896701000000121, 5.8977660000000469], [5.8979450000001634, 5.8981080000003203], [5.9013500000000931, 5.9025510000001304]]}, \"kworker/0:2-1645\": {\"0\": [[2.4167449999999917, 2.4168140000001586], [3.6566190000003189, 3.6566300000004048]]}, \"sudo-3919\": {\"1\": [[0.43209999999999127, 0.43213500000001659], [0.43422400000008565, 0.4348720000002686], [0.43612300000040705, 0.43777100000033897]], \"2\": [[0.42387700000017503, 0.42859800000042014], [0.42862400000012713, 0.43065300000034767]]}, \"sh-3960\": {\"1\": [[5.9013740000000325, 5.9025510000001304]]}, \"khungtaskd-320\": {\"1\": [[0.82477400000016132, 0.82482100000015635]]}, \"bash-3919\": {\"1\": [[0.41042700000025434, 0.42099800000005416]]}, \"sudo-3915\": {\"1\": [[0.0006710000002385641, 0.0016010000003916502], [0.00174200000037672, 0.0031870000002527377]]}, \"busybox-3930\": {\"1\": [[2.029461000000083, 2.0312430000003587]]}, \"kworker/5:2-1697\": {\"5\": [[2.0526260000001457, 2.052654000000075]]}, \"busybox-3936\": {\"4\": [[2.0458730000000287, 2.0472590000003947]]}, \"busybox-3934\": {\"3\": [[2.040447000000313, 2.0419510000001537]]}, \"busybox-3938\": {\"5\": [[2.0512760000001435, 2.0526260000001457]]}, \"ksoftirqd/0-3\": {\"0\": [[1.0646410000003925, 1.064944000000196], [3.8528610000003027, 3.8530400000004192], [3.8647000000000844, 3.8647860000000946]]}, \"sh-3917\": {\"2\": [[7.6000000262865797e-05, 0.000709000000369997]]}, \"watchdog/5-39\": {\"5\": [[2.6726280000002589, 2.6726370000001225]]}, \"shutils-3927\": {\"1\": [[2.0274030000000494, 2.0275220000003173], [2.0276000000003478, 2.0279980000000251], [2.0332350000003316, 2.0333300000002055], [2.0334250000000793, 2.0338040000001456], [2.0366680000001907, 2.0366950000002362], [2.036717000000408, 2.0370280000001912], [2.0419710000001032, 2.0423130000003766], [2.0472780000000057, 2.0476210000001629]], \"2\": [[2.0252610000002278, 2.0257160000001022], [2.0312480000002324, 2.0315870000003997], [2.0385100000003149, 2.0385949999999866], [2.0388070000003609, 2.0391859999999724], [2.0438950000002478, 2.0439880000003541], [2.0440889999999854, 2.0444820000002437], [2.0493620000002011, 2.0493930000002365], [2.0495540000001711, 2.0499320000003536], [2.0528070000000298, 2.0531510000000708], [2.0546880000001693, 2.0547090000000026], [2.0549810000002253, 2.0554670000001352]]}, \"sudo-3924\": {\"2\": [[1.1335240000003068, 1.1343260000003283], [1.1344390000003841, 1.1369230000000243]]}, \"sudo-3922\": {\"1\": [[1.1350830000001224, 1.1351790000003348]], \"2\": [[1.1264510000000882, 1.1309850000002371], [1.1312340000004042, 1.1335240000003068], [1.1447110000003704, 1.1468620000000556], [1.1469990000000507, 1.1471590000001015]]}, \"sudo-3921\": {\"2\": [[0.43065300000034767, 0.4341100000001461]]}, \"watchdog/3-27\": {\"3\": [[2.5846290000004046, 2.5846380000002682]]}, \"busybox-3928\": {\"0\": [[2.0232330000003458, 2.0251070000003892]]}, \"jbd2/sda1-8-990\": {\"1\": [[4.0534190000003036, 4.0536300000003394], [4.0567840000003343, 4.0568930000004002], [4.0590680000000248, 4.0591730000001007]]}, \"shutils-3935\": {\"1\": [[2.0423130000003766, 2.0441340000002128]]}, \"shutils-3936\": {\"1\": [[2.0443960000002335, 2.0457540000002155]]}, \"shutils-3937\": {\"1\": [[2.0476210000001629, 2.0495970000001762]]}, \"shutils-3930\": {\"2\": [[2.0279210000003332, 2.0293150000002242]]}, \"shutils-3931\": {\"2\": [[2.0315870000003997, 2.0334670000002006]]}, \"shutils-3932\": {\"2\": [[2.0337290000002213, 2.0367270000001554]]}, \"bash-3754\": {\"1\": [[0.15582400000039343, 0.15598799999997937], [0.20640100000036909, 0.2066530000001876], [0.2068730000000869, 0.20716700000002675], [0.20730200000025434, 0.2074070000003303], [0.35978700000032404, 0.36005999999997584], [0.36028800000030969, 0.36051500000030501], [0.36083300000018426, 0.36107600000013917], [0.36122300000033647, 0.36144500000000335], [0.36159700000007433, 0.36180899999999383], [0.3619380000000092, 0.36217600000009043], [0.36230599999998958, 0.36253600000009101], [0.36266100000011647, 0.36275200000000041], [0.36287300000003597, 0.36295800000016243], [0.3630950000001576, 0.36315000000013242], [0.36326700000017809, 0.36333200000035504], [0.36344800000006217, 0.363510000000133], [0.36362800000006246, 0.3636900000001333], [0.36383400000022448, 0.36402300000008836], [0.36414800000011383, 0.3643289999999979], [0.36446500000010928, 0.364676000000145], [0.36480200000005425, 0.36488900000040303], [0.40921400000024732, 0.40933300000006057], [0.40946500000018204, 0.41042700000025434], [1.1114130000000841, 1.1116630000001351], [1.1118830000000344, 1.1128539999999703], [1.1470950000002631, 1.1475100000002385], [1.1477520000003096, 1.1478440000000774], [1.9656240000003891, 1.9658880000001773], [1.9661200000000463, 1.9663480000003801], [1.9664800000000469, 1.9667890000000625], [1.966914000000088, 1.9671560000001591], [1.9672880000002806, 1.9675220000003719], [1.9676550000003772, 1.9679160000000593], [2.0157130000002326, 2.0159630000002835], [2.0161790000001929, 2.0170530000000326], [2.0554700000002413, 2.0558130000003985], [2.2078330000003916, 2.2079929999999877], [2.2583160000003772, 2.2585659999999734], [2.2587840000001052, 2.2590770000001612], [2.2592140000001564, 2.2593160000001262], [2.4140160000001742, 2.4142840000004071], [2.4145040000003064, 2.4147550000002411], [2.4148830000003727, 2.4151180000003478], [2.4152450000001409, 2.415494000000308], [2.4156380000003992, 2.4158500000003187], [2.4159740000000056, 2.4162129999999706], [2.4163400000002184, 2.4166840000002594], [2.4168600000002698, 2.4169329999999718], [2.4170690000000832, 2.417124000000058], [2.4172450000000936, 2.4173110000001543], [2.4174300000004223, 2.4174920000000384], [2.4176090000000841, 2.4176720000000387], [2.4177880000002006, 2.417852000000039], [2.417971000000307, 2.4180320000000393], [2.4181530000000748, 2.4182150000001457], [2.4183970000003683, 2.4184600000003229], [2.41857600000003, 2.4186389999999847], [2.4187590000001364, 2.4188220000000911], [2.4189400000000205, 2.4190080000003036], [2.4191270000001168, 2.4191900000000714], [2.4193070000001171, 2.4193700000000717], [2.4194880000000012, 2.4195530000001781], [2.4196719999999914, 2.4197360000002845], [2.4198570000003201, 2.4199200000002747], [2.420039000000088, 2.4201040000002649], [2.4202230000000782, 2.4202880000002551], [2.4204060000001846, 2.4204710000003615], [2.4206240000003163, 2.4206940000003669], [2.4208150000004025, 2.4208780000003571], [2.4209960000002866, 2.4210630000002311], [2.4211950000003526, 2.421259000000191], [2.4213780000000042, 2.4214450000004035], [2.4215650000001006, 2.4216320000000451], [2.4217490000000907, 2.4218150000001515], [2.4219440000001669, 2.4220100000002276], [2.422128000000157, 2.4221950000001016], [2.4223140000003696, 2.4223820000001979], [2.4225129999999808, 2.4225790000000416], [2.4226980000003095, 2.4227680000003602], [2.4228870000001734, 2.4229520000003504], [2.4230710000001636, 2.4231389999999919], [2.4232600000000275, 2.4233260000000882], [2.4234470000001238, 2.4235160000002907], [2.4236490000002959, 2.4237160000002405], [2.4238330000002861, 2.4239010000001144], [2.4240200000003824, 2.4240890000000945], [2.4242730000000847, 2.4243430000001354], [2.4244590000002972, 2.424525000000358], [2.4246760000000904, 2.4247460000001411], [2.4248660000002928, 2.4249350000000049], [2.4250550000001567, 2.425122999999985], [2.425242000000253, 2.4253100000000813], [2.4254450000003089, 2.425514000000021], [2.4256320000004052, 2.4257020000000011], [2.4258210000002691, 2.4258920000002036], [2.4260110000000168, 2.426082000000406], [2.4262000000003354, 2.4262680000001637], [2.4263860000000932, 2.42645500000026], [2.4265850000001592, 2.4266560000000936], [2.4267750000003616, 2.4268450000004123], [2.4269630000003417, 2.4270330000003923], [2.4271499999999833, 2.4272180000002663], [2.4273339999999735, 2.4274060000002464], [2.4275230000002921, 2.4275980000002164], [2.4277170000000297, 2.4277860000001965], [2.4279020000003584, 2.427972000000409], [2.4280889999999999, 2.4281600000003891], [2.4283000000000357, 2.4283709999999701], [2.4284920000000056, 2.4286440000000766], [2.4287699999999859, 2.4288310000001729], [2.4289499999999862, 2.4290220000002591], [2.4291400000001886, 2.4292120000000068], [2.4293290000000525, 2.4294020000002092], [2.4295310000002246, 2.4296040000003813], [2.4297230000001946, 2.4297970000002351], [2.4299150000001646, 2.4299869999999828], [2.4301040000000285, 2.4301770000001852], [2.4303610000001754, 2.4304910000000746], [2.4633650000000671, 2.4634770000002391], [2.4636100000002443, 2.4646860000002562], [3.4611950000003162, 3.4615420000000086], [3.6141139999999723, 3.6143120000001545], [3.6642400000000634, 3.6644840000003569], [3.6648210000003019, 3.6651220000003377], [3.6652090000002318, 3.6653110000002016], [4.2209150000003319, 4.222599000000173], [4.3062800000002426, 4.3067009999999755], [4.9224610000001121, 4.9226380000000063], [4.9725900000003094, 4.9731770000003053], [5.1250300000001516, 5.1252730000001065], [5.1252890000000662, 5.1253320000000713], [5.1253490000003694, 5.125391000000036], [5.1254060000001118, 5.1254480000002332], [5.1254619999999704, 5.1255049999999756], [5.1255200000000514, 5.1255620000001727], [5.1255780000001323, 5.1256190000003699], [5.1256360000002132, 5.1256760000001123], [5.1256920000000719, 5.125735000000077], [5.1257920000002741, 5.1258340000003955], [5.1258490000000165, 5.1258910000001379], [5.1259070000000975, 5.125948000000335], [5.1259630000004108, 5.1260050000000774], [5.1260200000001532, 5.1260600000000522], [5.1260760000000118, 5.1261180000001332], [5.126133000000209, 5.1261760000002141], [5.1261900000004061, 5.1262310000001889], [5.1262490000003709, 5.1262910000000375], [5.1263060000001133, 5.1263490000001184], [5.1263630000003104, 5.1264060000003155], [5.1264200000000528, 5.1264610000002904], [5.12647700000025, 5.1265180000000328], [5.1265330000001086, 5.126578000000336], [5.1265930000004118, 5.1266340000001946], [5.1266500000001543, 5.1266930000001594], [5.1267070000003514, 5.1267510000002403], [5.1267660000003161, 5.126810000000205], [5.1268240000003971, 5.1268660000000637], [5.1268850000001294, 5.1269280000001345], [5.1269430000002103, 5.1269860000002154], [5.1270030000000588, 5.1270480000002863], [5.1271520000000237, 5.1271990000000187], [5.1272140000000945, 5.1272570000000997], [5.1272720000001755, 5.1273170000004029], [5.127332000000024, 5.1273760000003676], [5.1273900000001049, 5.1274350000003324], [5.1274490000000696, 5.1274940000002971], [5.1275080000000344, 5.1275510000000395], [5.1275660000001153, 5.1276100000000042], [5.1276260000004186, 5.1276700000003075], [5.1276850000003833, 5.1277310000000398], [5.1277460000001156, 5.127791000000343], [5.1278060000004189, 5.127849000000424], [5.1278650000003836, 5.1279090000002725], [5.1279250000002321, 5.1279710000003433], [5.1279860000004192, 5.1280320000000756], [5.1280470000001515, 5.1280940000001465], [5.1281080000003385, 5.1281550000003335], [5.1281850000000304, 5.1294440000001487], [5.1751070000000254, 5.1761570000003303]], \"2\": [[0.0031910000002426386, 0.0036020000002281449], [0.0036460000001170556, 0.0037420000003294263], [0.43788500000027852, 0.43829900000037014], [1.0610490000003665, 1.0612790000000132], [1.061294000000089, 1.0613350000003265], [1.0613530000000537, 1.0613950000001751], [1.0614110000001347, 1.0614520000003722], [1.0614660000001095, 1.0615080000002308], [1.0615220000004228, 1.0615640000000894], [1.0615780000002815, 1.0616180000001805], [1.0616350000000239, 1.0616750000003776], [1.0616910000003372, 1.0617350000002261], [1.0617490000004182, 1.0617890000003172], [1.061804000000393, 1.0618460000000596], [1.0618600000002516, 1.0619030000002567], [1.0619180000003325, 1.0619599999999991], [1.0619740000001912, 1.0620160000003125], [1.0620320000002721, 1.0620730000000549], [1.0620880000001307, 1.0621290000003683], [1.0621439999999893, 1.0621869999999944], [1.0622010000001865, 1.0622440000001916], [1.0622580000003836, 1.0622980000002826], [1.062315000000126, 1.0623580000001311], [1.0623740000000907, 1.0624150000003283], [1.0624300000004041, 1.0624730000004092], [1.0624870000001465, 1.0625310000000354], [1.0625460000001112, 1.0625870000003488], [1.0626019999999698, 1.0626460000003135], [1.0626620000002731, 1.062706000000162], [1.062720000000354, 1.0627620000000206], [1.0627779999999802, 1.0628190000002178], [1.0628350000001774, 1.0628770000002987], [1.0628930000002583, 1.0629370000001472], [1.0629520000002231, 1.0629950000002282], [1.0630110000001878, 1.0630550000000767], [1.0630700000001525, 1.0631120000002738], [1.0631260000000111, 1.0631720000001224], [1.0631860000003144, 1.0632300000002033], [1.0632450000002791, 1.0632880000002842], [1.0633060000000114, 1.0633490000000165], [1.0633660000003147, 1.0634090000003198], [1.0634230000000571, 1.0634680000002845], [1.0634820000000218, 1.0635290000000168], [1.0635430000002088, 1.0635970000002999], [1.0636100000001534, 1.0636560000002646], [1.0636710000003404, 1.0637150000002293], [1.0637290000004214, 1.0637750000000779], [1.0637890000002699, 1.063832000000275], [1.0638490000001184, 1.0638930000000073], [1.0639100000003054, 1.0639540000001944], [1.0639730000002601, 1.0640180000000328], [1.0640330000001086, 1.0640790000002198], [1.0640940000002956, 1.0641410000002907], [1.0641550000000279, 1.0642030000003615], [1.0642179999999826, 1.0642649999999776], [1.0642810000003919, 1.064328000000387], [1.0643420000001242, 1.0643880000002355], [1.0644030000003113, 1.0644500000003063], [1.0644640000000436, 1.0645120000003772], [1.0645410000001903, 1.0647180000000844], [1.064734000000044, 1.0647840000001452], [1.0647980000003372, 1.0648470000000998], [1.0648610000002918, 1.0649090000001706], [1.0649230000003627, 1.0649720000001253], [1.0649880000000849, 1.0650350000000799], [1.0650500000001557, 1.0650990000003731], [1.0651139999999941, 1.0651620000003277], [1.065176000000065, 1.0652260000001661], [1.0653360000001157, 1.0653870000001007], [1.0654030000000603, 1.0654500000000553], [1.0654660000000149, 1.0655130000000099], [1.0655290000004243, 1.0655770000003031], [1.0655910000000404, 1.0656410000001415], [1.0656560000002173, 1.0657049999999799], [1.0657210000003943, 1.0657740000001468], [1.0657890000002226, 1.0658370000001014], [1.0658520000001772, 1.0659020000002783], [1.0659170000003542, 1.0659670000000006], [1.0659820000000764, 1.0660320000001775], [1.0660460000003695, 1.0661320000003798], [1.7623889999999847, 1.7625670000002174], [1.8125, 1.8129550000003292], [1.8130519999999706, 1.8132230000001073], [1.8132709999999861, 1.8133590000002187], [4.271596000000045, 4.2727650000001631], [5.2024000000001251, 5.2028190000000905], [5.8270090000000891, 5.8272680000000037], [5.8274930000002314, 5.8277040000002671], [5.8278370000002724, 5.8280650000001515], [5.8281920000003993, 5.8284950000002027], [5.8287430000000313, 5.828954000000067], [5.8290780000002087, 5.829319000000396], [5.8294470000000729, 5.8295729999999821], [5.8770860000004177, 5.8773240000000442], [5.8775330000003123, 5.8783490000000711]]}, \"shutils-3938\": {\"2\": [[2.0499320000003536, 2.0511590000000979]]}, \"shutils-3939\": {\"1\": [[2.0531780000001163, 2.0550270000003366]]}, \"rs:main Q:Reg-1763\": {\"0\": [[0.4291600000001381, 0.42933200000015859], [3.8527130000002217, 3.8528610000003027], [4.0689390000002277, 4.0690630000003694], [4.29213800000025, 4.2922070000004169], [4.2937160000001313, 4.2937780000002022], [4.304620000000341, 4.3047510000001239]], \"1\": [[0.0016010000003916502, 0.00174200000037672], [0.4303410000002259, 0.43045300000039788], [4.0532809999999699, 4.0534190000003036], [5.1964179999999942, 5.1965190000000803]], \"2\": [[0.43507399999998597, 0.43524999999999636], [1.1311100000002625, 1.1312340000004042], [1.1343260000003283, 1.1344390000003841], [1.1468620000000556, 1.1469990000000507], [3.8701580000001741, 3.8703520000003664], [5.1943810000002486, 5.1944940000003044], [5.2013930000002802, 5.2014970000000176], [5.8961440000002767, 5.8962580000002163], [5.8978520000000572, 5.8979450000001634]]}, \"sudo-3954\": {\"1\": [[5.1981920000002901, 5.1982259999999769], [5.2000200000002224, 5.2024000000001251]], \"2\": [[5.1897650000000795, 5.1942619999999806], [5.1944940000003044, 5.1967690000001312]]}, \"usb-storage-975\": {\"1\": [[3.4809390000000349, 3.4810270000002674], [3.4811600000002727, 3.4811760000002323], [3.4813240000003134, 3.4813430000003791], [4.0536300000003394, 4.0536600000000362], [4.0538710000000719, 4.0539360000002489], [4.0556180000003224, 4.0556390000001556], [4.0566720000001624, 4.0566960000001018], [4.0569030000001476, 4.0569890000001578], [4.0571039999999812, 4.0571300000001429], [4.0579810000003818, 4.0579970000003414], [4.058976000000257, 4.0589950000003228]], \"2\": [[1.4649460000000545, 1.4649760000002061], [1.4653760000001057, 1.4654000000000451], [1.4657380000003286, 1.4657660000002579], [5.4969430000001012, 5.4969730000002528], [5.4972600000000966, 5.4972820000002685], [5.4976200000000972, 5.4976440000000366]]}, \"ksoftirqd/2-23\": {\"2\": [[1.4657660000002579, 1.4658690000001116], [5.4976440000000366, 5.4977460000000065]]}, \"shutils-3926\": {\"1\": [[1.1407260000000861, 1.1431650000004083]]}, \"shutils-3925\": {\"2\": [[1.142634000000271, 1.1426690000002964], [1.1426940000001196, 1.1427090000001954], [1.1427550000003066, 1.1427690000000439], [1.1428140000002713, 1.1428280000000086], [1.1431000000002314, 1.1431420000003527], [1.143163000000186, 1.1442180000003646]]}, \"shutils-3929\": {\"2\": [[2.0257160000001022, 2.0276470000003428]]}, \"shutils-3928\": {\"2\": [[2.0217580000003181, 2.0230710000000727]]}, \"watchdog/2-21\": {\"2\": [[2.5406830000001719, 2.5406970000003639]]}, \"sshd-1747\": {\"1\": [[3.6839490000002115, 3.6851160000001073], [3.8516040000004068, 3.851643000000422], [3.8516660000000229, 3.8517010000000482], [3.8701730000002499, 3.8703770000001896], [3.8859940000002098, 3.8869830000003276], [4.0525450000000092, 4.0526150000000598], [4.0526400000003377, 4.052679000000353]], \"2\": [[4.0699750000003405, 4.0701710000003004]]}, \"systemd-1\": {\"0\": [[3.8517730000003212, 3.8522320000001855]]}, \"shutils-3933\": {\"1\": [[2.0370280000001912, 2.038850000000366]]}, \"shutils-3934\": {\"1\": [[2.0391100000001643, 2.0403270000001612]]}, \"ksoftirqd/1-17\": {\"1\": [[0.016777000000274711, 0.016849000000092929], [3.4813430000003791, 3.4813740000004145], [4.0566960000001018, 4.0567680000003747], [4.0568930000004002, 4.0569030000001476], [4.0589950000003228, 4.0590480000000753], [4.0590610000003835, 4.0590680000000248]]}, \"rt-app-3940\": {\"1\": [[2.4679180000002816, 2.4680820000003223], [3.4607930000001943, 3.4609490000002552]]}, \"rt-app-3941\": {\"1\": [[2.4680820000003223, 2.46817400000009]]}, \"sh-3952\": {\"2\": [[4.2960920000000442, 4.2998520000001008]]}, \"kworker/3:2-1646\": {\"3\": [[2.4168040000004112, 2.416859000000386]]}, \"bash-3957\": {\"2\": [[5.8783490000000711, 5.8888370000004215]]}, \"sudo-3959\": {\"2\": [[5.8981080000003203, 5.9013500000000931]]}, \"kworker/u12:0-3216\": {\"1\": [[0.36027400000011767, 0.36028800000030969], [1.9658880000001773, 1.9659050000000207]], \"2\": [[0.0036020000002281449, 0.0036460000001170556], [0.15566900000021633, 0.15570800000023155], [0.15600300000005518, 0.15604000000030283], [0.20588900000029753, 0.20592900000019654], [0.20660100000031889, 0.20674700000017765], [0.20712300000013784, 0.20723100000031991], [0.36046900000019377, 0.36058500000035565], [0.3610780000003615, 0.36115300000028583], [0.36140599999998813, 0.36144700000022567], [0.36181299999998373, 0.36188600000014048], [0.3621330000000853, 0.36217500000020664], [0.36253800000031333, 0.36260900000024776], [0.36271500000020751, 0.36275000000023283], [0.36433299999998781, 0.36434000000008382], [0.3646350000003622, 0.364676000000145], [1.0612790000000132, 1.061294000000089], [1.0613350000003265, 1.0613530000000537], [1.0613950000001751, 1.0614110000001347], [1.0614520000003722, 1.0614660000001095], [1.0615080000002308, 1.0615220000004228], [1.0615640000000894, 1.0615780000002815], [1.0616180000001805, 1.0616350000000239], [1.0616750000003776, 1.0616910000003372], [1.0617350000002261, 1.0617490000004182], [1.0617890000003172, 1.061804000000393], [1.0618460000000596, 1.0618600000002516], [1.0619030000002567, 1.0619180000003325], [1.0619599999999991, 1.0619740000001912], [1.0620160000003125, 1.0620320000002721], [1.0620730000000549, 1.0620880000001307], [1.0621290000003683, 1.0621439999999893], [1.0621869999999944, 1.0622010000001865], [1.0622440000001916, 1.0622580000003836], [1.0622980000002826, 1.062315000000126], [1.0623580000001311, 1.0623740000000907], [1.0624150000003283, 1.0624300000004041], [1.0624730000004092, 1.0624870000001465], [1.0625310000000354, 1.0625460000001112], [1.0625870000003488, 1.0626019999999698], [1.0626460000003135, 1.0626620000002731], [1.062706000000162, 1.062720000000354], [1.0627620000000206, 1.0627779999999802], [1.0628190000002178, 1.0628350000001774], [1.0628770000002987, 1.0628930000002583], [1.0629370000001472, 1.0629520000002231], [1.0629950000002282, 1.0630110000001878], [1.0630550000000767, 1.0630700000001525], [1.0631120000002738, 1.0631260000000111], [1.0631720000001224, 1.0631860000003144], [1.0632300000002033, 1.0632450000002791], [1.0632880000002842, 1.0633060000000114], [1.0633490000000165, 1.0633660000003147], [1.0634090000003198, 1.0634230000000571], [1.0634680000002845, 1.0634820000000218], [1.0635290000000168, 1.0635430000002088], [1.0635970000002999, 1.0636100000001534], [1.0636560000002646, 1.0636710000003404], [1.0637150000002293, 1.0637290000004214], [1.0637750000000779, 1.0637890000002699], [1.063832000000275, 1.0638490000001184], [1.0638930000000073, 1.0639100000003054], [1.0639540000001944, 1.0639730000002601], [1.0640180000000328, 1.0640330000001086], [1.0640790000002198, 1.0640940000002956], [1.0641410000002907, 1.0641550000000279], [1.0642030000003615, 1.0642179999999826], [1.0642649999999776, 1.0642810000003919], [1.064328000000387, 1.0643420000001242], [1.0643880000002355, 1.0644030000003113], [1.0644500000003063, 1.0644640000000436], [1.0645120000003772, 1.0645410000001903], [1.9663010000003851, 1.9663460000001578], [1.9667900000004011, 1.9668620000002193], [1.9671160000002601, 1.967160000000149], [1.9675210000000334, 1.9675950000000739], [1.9678450000001249, 1.9679190000001654], [2.0152110000003631, 2.0152520000001459], [2.0159100000000763, 2.0160510000000613], [2.0557940000003327, 2.055833000000348], [2.1047560000001795, 2.1047910000002048], [2.2076750000001084, 2.2077080000003662], [2.2080060000002959, 2.2080410000003212], [2.2578190000003815, 2.2578580000003967], [2.2585130000002209, 2.2586550000000898], [2.2590340000001561, 2.2590760000002774], [2.4143770000000586, 2.4144470000001093], [2.4147140000000036, 2.4147550000002411], [2.4151170000000093, 2.4151880000003985], [2.415454000000409, 2.4155560000003788], [2.4158110000003035, 2.4158520000000863], [2.4162170000004153, 2.4162890000002335], [2.4165380000004006, 2.4166830000003756], [2.4169000000001688, 2.416924999999992], [2.4170950000002449, 2.4171170000004167], [2.417283000000225, 2.4173030000001745], [2.4174649999999929, 2.4174850000003971], [2.4176449999999932, 2.4176650000003974], [2.4178230000002259, 2.4178450000003977], [2.4180049999999937, 2.418025000000398], [2.4181889999999839, 2.4182090000003882], [2.4184320000003936, 2.4184520000003431], [2.4186120000003939, 2.4186320000003434], [2.4187950000000455, 2.4188149999999951], [2.4189790000000357, 2.4190000000003238], [2.4191630000000259, 2.4191829999999754], [2.4193440000003648, 2.4193650000001981], [2.4195260000001326, 2.4195460000000821], [2.419709000000239, 2.4197290000001885], [2.419894000000113, 2.4199140000000625], [2.4200770000002194, 2.4200970000001689], [2.4202610000002096, 2.4202820000000429], [2.420444000000316, 2.4204640000002655], [2.4206670000003214, 2.4206870000002709], [2.4208510000003116, 2.4208710000002611], [2.421034000000418, 2.4210570000000189], [2.4212320000001455, 2.421252000000095], [2.4214190000002418, 2.4214380000003075], [2.4216040000001158, 2.4216250000004038], [2.421788000000106, 2.4218080000000555], [2.4219830000001821, 2.4220030000001316], [2.4221680000000561, 2.4221890000003441], [2.4223540000002686, 2.4223740000002181], [2.4225530000003346, 2.4225720000004003], [2.4227420000001985, 2.422762000000148], [2.4229250000003049, 2.4229450000002544], [2.4231110000000626, 2.4231320000003507], [2.4233000000003813, 2.4233189999999922], [2.4234880000003614, 2.4235090000001946], [2.4236890000001949, 2.4237090000001444], [2.4238750000004075, 2.4238940000000184], [2.4240610000001652, 2.4240800000002309], [2.4243150000002061, 2.4243370000003779], [2.4244990000001962, 2.4245190000001458], [2.4247180000002118, 2.4247390000000451], [2.4249080000004142, 2.4249280000003637], [2.4250960000003943, 2.4251160000003438], [2.4252840000003744, 2.4253029999999853], [2.4254880000003141, 2.4255080000002636], [2.4256750000004104, 2.4256950000003599], [2.4258630000003905, 2.42588300000034], [2.4260550000003605, 2.42607500000031], [2.4262410000001182, 2.4262610000000677], [2.4264280000002145, 2.4264490000000478], [2.4266290000000481, 2.4266500000003361], [2.4268190000002505, 2.4268380000003162], [2.4270060000003468, 2.4270260000002963], [2.4271929999999884, 2.4272120000000541], [2.4273790000002009, 2.4273990000001504], [2.4275680000000648, 2.4275900000002366], [2.427759000000151, 2.4277790000001005], [2.4279450000003635, 2.427965000000313], [2.4281330000003436, 2.4281530000002931], [2.4283450000002631, 2.4283640000003288], [2.4285360000003493, 2.4286369999999806], [2.4288040000001274, 2.4288240000000769], [2.4289940000003298, 2.4290140000002793], [2.429185000000416, 2.4292050000003655], [2.4293730000003961, 2.4293940000002294], [2.4295780000002196, 2.4295980000001691], [2.4297700000001896, 2.4297900000001391], [2.4299610000002758, 2.4299829999999929], [2.4301500000001397, 2.4301700000000892], [2.4304080000001704, 2.430431000000226], [2.4633330000001479, 2.4634200000000419], [2.46344100000033, 2.463528000000224], [2.4677230000002055, 2.4678160000003118], [2.4681440000003931, 2.4682240000001912], [2.4685000000004038, 2.4685990000002676], [3.46081200000026, 3.4608570000000327], [3.4610250000000633, 3.4610490000000027], [3.4611550000004172, 3.4612480000000687], [3.4616430000000946, 3.4616790000000037], [3.6136200000000827, 3.6136580000002141], [3.6143230000002404, 3.6143660000002455], [3.6637440000004062, 3.6637820000000829], [3.664433000000372, 3.6645730000000185], [3.6650830000003225, 3.6651180000003478], [3.6652320000002874, 3.6653830000000198]]}, \"kworker/u12:1-3942\": {\"1\": [[3.701090000000022, 3.7011480000001029], [3.9029550000000199, 3.9030139999999847], [4.2208780000000843, 4.2209150000003319], [4.222599000000173, 4.2227020000000266], [4.2710970000002817, 4.2711400000002868], [4.271788000000015, 4.2718370000002324], [4.2832640000001447, 4.2833460000001651], [5.1897069999999985, 5.1897640000001957], [5.2028000000000247, 5.2028400000003785], [5.8265089999999873, 5.8265500000002248], [5.8272190000002411, 5.8273610000001099], [5.8277030000003833, 5.8277740000003178], [5.8280250000002525, 5.8280690000001414], [5.8284940000003189, 5.8285750000000007], [5.8289160000003903, 5.8289570000001731], [5.8293220000000474, 5.8293950000002042], [5.8300480000002608, 5.830094000000372], [5.8765860000003158, 5.8766230000001087], [5.8772760000001654, 5.8774090000001706], [5.8888329999999769, 5.8889149999999972]], \"2\": [[3.6654190000003837, 3.6654840000001059], [3.6705390000001898, 3.6705560000000332], [3.6982330000000729, 3.6983200000004217], [3.9000500000001921, 3.900141000000076], [4.2861790000001747, 4.2862360000003719], [4.306681000000026, 4.3067220000002635], [4.9222990000002937, 4.9224160000003394], [4.9226700000003802, 4.9227090000003955], [4.9724280000000363, 4.9725430000003144], [4.9726500000001579, 4.9726870000004055], [4.972932000000128, 4.9729620000002797], [4.9730940000004011, 4.973124000000098], [5.1248650000002272, 5.1249860000002627], [5.1252400000003036, 5.1252819999999701], [5.1257660000001124, 5.1258609999999862], [5.1281850000000304, 5.1281990000002224], [5.1282350000001315, 5.1282540000001973], [5.1282750000000306, 5.1282890000002226], [5.1283170000001519, 5.1283320000002277], [5.1283490000000711, 5.1283650000000307], [5.1283849999999802, 5.1283990000001722], [5.1284200000000055, 5.1284340000001976], [5.1284530000002633, 5.1284670000000006], [5.1284900000000562, 5.1285030000003644], [5.1285230000003139, 5.1285360000001674], [5.1286720000002788, 5.1286910000003445], [5.128711000000294, 5.1287250000000313], [5.1287449999999808, 5.1287610000003951], [5.128791000000092, 5.1288050000002841], [5.1288220000001274, 5.1288370000002033], [5.1288600000002589, 5.1288739999999962], [5.1288930000000619, 5.1289070000002539], [5.1289310000001933, 5.1289450000003853], [5.1289639999999963, 5.1289780000001883], [5.1290000000003602, 5.1290149999999812], [5.1290340000000469, 5.1290490000001228], [5.1290700000004108, 5.1290840000001481], [5.1291060000003199, 5.1291200000000572], [5.1291500000002088, 5.1291650000002846], [5.1291840000003504, 5.1291970000002038], [5.1292190000003757, 5.129233000000113], [5.1292560000001686, 5.1292700000003606], [5.1292920000000777, 5.1293060000002697], [5.1293290000003253, 5.1293430000000626], [5.1293660000001182, 5.1293820000000778], [5.1749450000002071, 5.1749840000002223], [5.1753630000002886, 5.1754020000003038], [5.1868670000003476, 5.1869500000002517], [5.8915500000002794, 5.8916080000003603]]}, \"scp-3945\": {\"2\": [[3.8651320000003579, 3.8652670000001308], [3.8674150000001646, 3.8678970000000845]]}, \"kworker/u12:1-3947\": {\"2\": [[3.900141000000076, 3.9028430000003027]]}, \"kworker/u12:1-3944\": {\"2\": [[3.6983200000004217, 3.7009760000000824]]}, \"fie_test0-3941\": {\"1\": [[2.468326000000161, 2.468539000000419], [2.4687350000003789, 2.4727190000003247], [2.4845440000003691, 2.4886870000000272], [2.5005450000003293, 2.5047060000001693], [2.5166300000000774, 2.5207030000001396], [2.5325580000003356, 2.5366950000002362], [2.5485560000001897, 2.5526930000000903], [2.5645900000004076, 2.5687460000003739], [2.5805930000001354, 2.5847450000001118], [2.5965890000002219, 2.6007430000004206], [2.6125890000002983, 2.6167450000002646], [2.6285890000003747, 2.632745000000341], [2.6445900000003348, 2.6487480000000687], [2.6605890000000727, 2.6647430000002714], [2.6765640000003259, 2.6806900000001406], [2.6925880000003417, 2.6967420000000857], [2.7085890000003019, 2.7127450000002682], [2.724587000000156, 2.7287430000001223], [2.7405880000001162, 2.7447409999999763], [2.7565910000002987, 2.7607440000001588], [2.7725880000002689, 2.7767440000002352], [2.7885890000002291, 2.7927440000003116], [2.8045900000001893, 2.8087490000002617], [2.8205900000002657, 2.8247430000001259], [2.8365890000000036, 2.8407460000003084], [2.8525900000004185, 2.8567450000000463], [2.8685900000000402, 2.8727460000000065], [2.8845890000002328, 2.888742000000093], [2.900590000000193, 2.9047480000003816], [2.916588000000047, 2.9207440000000133], [2.9325880000001234, 2.9367470000001958], [2.9485900000004222, 2.9527430000002823], [2.9645900000000438, 2.9687460000000101], [2.9805900000001202, 2.9848110000002634], [2.9965930000003027, 3.0006780000003346], [3.0008670000001985, 3.0010230000002593], [3.012590000000273, 3.0167460000002393], [3.0285890000000109, 3.0327440000000934], [3.0445890000000873, 3.0487440000001698], [3.0605900000000474, 3.064752000000226], [3.0765920000003462, 3.0807440000003226], [3.0925879999999779, 3.0967430000000604], [3.1085900000002766, 3.1127450000003591], [3.1245880000001307, 3.1287420000003294], [3.1405930000000808, 3.1447450000000572], [3.1565880000002835, 3.1607440000002498], [3.1725890000002437, 3.17674500000021], [3.1885900000002039, 3.1927760000003218], [3.2045890000003965, 3.2087610000003224], [3.2205890000000181, 3.22476800000004], [3.236587000000327, 3.2407430000002933], [3.2525890000001709, 3.2567440000002534], [3.2685900000001311, 3.2727720000002591], [3.2845879999999852, 3.2887420000001839], [3.3005900000002839, 3.3047450000003664], [3.3165900000003603, 3.3207520000000841], [3.3325840000002245, 3.3367400000001908], [3.3485910000003969, 3.3527440000002571], [3.3645900000001348, 3.368771000000379], [3.3805890000003274, 3.3846800000001167], [3.3847000000000662, 3.3848500000003696], [3.3965920000000551, 3.4007460000002538], [3.4125880000001416, 3.4167460000003302], [3.4285890000001018, 3.4327450000000681], [3.4445880000002944, 3.4487470000003668], [3.4605910000000222, 3.4607930000001943], [3.4609490000002552, 3.4611950000003162]]}, \"scp-3948\": {\"2\": [[4.0662260000003698, 4.0663389999999708], [4.0670430000000124, 4.0675240000000485]]}, \"sudo-3956\": {\"2\": [[5.1967690000001312, 5.2000200000002224]]}, \"sudo-3957\": {\"1\": [[5.8916080000003603, 5.8965950000001612], [5.8966199999999844, 5.8983130000001438], [5.8995130000002973, 5.899605000000065]]}, \"in:imuxsock-1761\": {\"0\": [[0.428972000000158, 0.4291600000001381], [4.0687860000002729, 4.0689390000002277]], \"1\": [[0.43023400000038237, 0.4303410000002259], [1.1342190000000301, 1.1343980000001466], [1.1467590000002019, 1.1469420000003083], [3.8517970000002606, 3.8519120000000839], [4.0528699999999844, 4.05299100000002], [5.1963190000001305, 5.1964179999999942]], \"2\": [[0.0014940000000933651, 0.0016080000000329164], [0.43497100000013234, 0.43507399999998597], [1.1309850000002371, 1.1311100000002625], [3.8700420000000122, 3.8701580000001741], [4.2919700000002194, 4.2921530000003258], [4.2925520000003416, 4.2926760000000286], [4.2927000000004227, 4.2927300000001196], [4.2935780000002524, 4.2937150000002475], [4.3044620000000577, 4.3047430000001441], [5.1942619999999806, 5.1943810000002486], [5.2012940000004164, 5.2013930000002802], [5.8960420000003069, 5.8961440000002767], [5.8977660000000469, 5.8978520000000572]]}, \"sudo-3951\": {\"1\": [[4.2929960000001302, 4.296172000000297]]}, \"bash-3954\": {\"1\": [[5.1761570000003303, 5.1767060000001948], [5.1767400000003363, 5.1867540000002919]]}, \"sh-3925\": {\"2\": [[1.1369230000000243, 1.1407269999999698]]}, \"sh-3924\": {\"1\": [[1.1442200000001321, 1.1447090000001481]]}, \"kworker/u12:1-3950\": {\"1\": [[4.2833460000001651, 4.2860640000003514]]}, \"kworker/u12:1-3955\": {\"2\": [[5.1869500000002517, 5.1895960000001651]]}, \"sshd-3948\": {\"2\": [[4.0545170000000326, 4.0654309999999896]]}, \"sshd-3946\": {\"1\": [[3.8869830000003276, 3.8999440000002323], [3.9030139999999847, 3.9273390000003019], [3.9289680000001681, 3.9857530000003862], [3.9942880000003242, 3.9944800000002942], [3.9963970000003428, 4.024094000000332], [4.0244300000003932, 4.0246540000002824], [4.0248430000001463, 4.025492000000213], [4.0258010000002287, 4.0261130000003504], [4.0265940000003866, 4.0525450000000092], [4.0526150000000598, 4.0526400000003377], [4.052679000000353, 4.0528699999999844], [4.05299100000002, 4.0532809999999699], [4.0536600000000362, 4.0538710000000719], [4.0539360000002489, 4.0548810000000231], [4.0551340000001801, 4.0552590000002056], [4.0654200000003584, 4.0655970000002526], [4.0659960000002684, 4.0661290000002737], [4.0663190000000213, 4.0665290000001733], [4.0669530000000123, 4.0670580000000882], [4.0674640000002, 4.0678560000001198], [4.0681730000001153, 4.0686660000001211], [4.068688000000293, 4.0699730000001182]]}, \"kworker/u12:1-3958\": {\"1\": [[5.8889149999999972, 5.8915070000002743]]}, \"bash-3927\": {\"1\": [[2.0170530000000326, 2.0217200000001867]]}, \"sshd-3943\": {\"1\": [[3.6851160000001073, 3.6981200000000172], [3.7011480000001029, 3.7255020000002332], [3.8250960000000305, 3.8254430000001776], [3.8258840000003147, 3.8516040000004068], [3.851643000000422, 3.8516660000000229], [3.8517010000000482, 3.8517970000002606], [3.8519120000000839, 3.8521740000001046], [3.8523119999999835, 3.853577000000314], [3.8537129999999706, 3.8538360000002285], [3.8641990000000987, 3.8643810000003214], [3.8648810000004232, 3.8650410000000193], [3.8652430000001914, 3.8667750000004162], [3.8673220000000583, 3.8674290000003566], [3.8678340000001299, 3.8681890000002568], [3.8684360000002016, 3.8701730000002499], [3.8703770000001896, 3.87045500000022]], \"2\": [[3.7271820000000844, 3.7843920000000253], [3.7931260000000293, 3.7933200000002216], [3.7952640000003157, 3.8229840000003605], [3.8237120000003415, 3.8247120000000905]]}, \"bash-3922\": {\"1\": [[1.1128539999999703, 1.1233130000000529]]}, \"bash-3949\": {\"2\": [[4.2727650000001631, 4.283143999999993]]}, \"sudo-3949\": {\"1\": [[4.2862370000002556, 4.2929960000001302]], \"2\": [[4.2944660000002841, 4.2944990000000871], [4.3037010000002738, 4.3044620000000577], [4.3047430000001441, 4.3050240000002304], [4.3050480000001698, 4.3062740000000304]]}, \"bash-3940\": {\"1\": [[2.4646860000002562, 2.4677590000001146]]}, \"sh-3951\": {\"1\": [[4.3033130000003439, 4.3036980000001677]]}, \"kthreadd-3942\": {\"2\": [[3.6653830000000198, 3.6653989999999794]]}, \"rcu_sched-8\": {\"1\": [[0.00064900000006673508, 0.0006710000002385641], [0.0087620000003880705, 0.0087870000002112647], [0.016849000000092929, 0.016927000000123371], [0.024761000000125932, 0.02477900000030786], [4.3086570000000393, 4.3086740000003374], [4.316628000000037, 4.316649000000325], [4.3287629999999808, 4.3287820000000465]]}, \"sshd-3752\": {\"1\": [[0.0036420000001271546, 0.0038550000003851892], [0.15541300000040792, 0.15557400000034249], [0.15664300000025833, 0.15686500000037995], [0.20558400000027177, 0.20579300000008516], [0.2066530000001876, 0.2068730000000869], [0.20716700000002675, 0.20730200000025434], [0.3589470000001711, 0.35915800000020681], [0.36005999999997584, 0.36027400000011767], [0.36051500000030501, 0.36080000000038126], [0.36107600000013917, 0.36122300000033647], [0.36144500000000335, 0.36159700000007433], [0.36180899999999383, 0.3619380000000092], [0.36217600000009043, 0.36230599999998958], [0.36253600000009101, 0.36266100000011647], [0.36275200000000041, 0.36287300000003597], [0.36295800000016243, 0.3630950000001576], [0.36315000000013242, 0.36326700000017809], [0.36333200000035504, 0.36344800000006217], [0.363510000000133, 0.36362800000006246], [0.3636900000001333, 0.36383400000022448], [0.36402300000008836, 0.36414800000011383], [0.3643289999999979, 0.36446500000010928], [0.364676000000145, 0.36480200000005425], [0.40904799999998431, 0.40921400000024732], [0.40933300000006057, 0.40946500000018204], [0.43831600000021353, 0.43859400000019377], [1.060533000000305, 1.0608799999999974], [1.0612840000003416, 1.0645410000001903], [1.0646460000002662, 1.0653110000002926], [1.0653430000002118, 1.0662830000001122], [1.1105959999999868, 1.1108040000003712], [1.1116630000001351, 1.1118830000000344], [1.1475460000001476, 1.1477520000003096], [1.7620100000003731, 1.7622210000004088], [1.7626589999999851, 1.7628880000002027], [1.8121290000003683, 1.8123390000000654], [1.8127830000003087, 1.8130230000001575], [1.813057000000299, 1.8132430000000568], [1.8132690000002185, 1.8133860000002642], [1.9647939999999835, 1.965012999999999], [1.9659050000000207, 1.9661200000000463], [1.9663480000003801, 1.9664800000000469], [1.9667890000000625, 1.966914000000088], [1.9671560000001591, 1.9672880000002806], [1.9675220000003719, 1.9676550000003772], [1.9679160000000593, 1.9680520000001707], [2.0149110000002111, 2.0151160000000345], [2.0159630000002835, 2.0161790000001929], [2.0558340000002318, 2.0560440000003837], [2.2074250000000575, 2.2075820000000022], [2.2086260000000948, 2.2088650000000598], [2.2575220000003355, 2.2577250000003914], [2.2585659999999734, 2.2587840000001052], [2.2590770000001612, 2.2592140000001564], [2.4131990000000769, 2.4134170000002086], [2.4142840000004071, 2.4145040000003064], [2.4147550000002411, 2.4148830000003727], [2.4151180000003478, 2.4152450000001409], [2.415494000000308, 2.4156380000003992], [2.4158500000003187, 2.4159740000000056], [2.4162129999999706, 2.4163400000002184], [2.4167290000000321, 2.4168600000002698], [2.4169329999999718, 2.4170690000000832], [2.417124000000058, 2.4172450000000936], [2.4173110000001543, 2.4174300000004223], [2.4174920000000384, 2.4176090000000841], [2.4176720000000387, 2.4177880000002006], [2.417852000000039, 2.417971000000307], [2.4180320000000393, 2.4181530000000748], [2.4182150000001457, 2.4183970000003683], [2.4184600000003229, 2.41857600000003], [2.4186389999999847, 2.4187590000001364], [2.4188220000000911, 2.4189400000000205], [2.4190080000003036, 2.4191270000001168], [2.4191900000000714, 2.4193070000001171], [2.4193700000000717, 2.4194880000000012], [2.4195530000001781, 2.4196719999999914], [2.4197360000002845, 2.4198570000003201], [2.4199200000002747, 2.420039000000088], [2.4201040000002649, 2.4202230000000782], [2.4202880000002551, 2.4204060000001846], [2.4204710000003615, 2.4206240000003163], [2.4206940000003669, 2.4208150000004025], [2.4208780000003571, 2.4209960000002866], [2.4210630000002311, 2.4211950000003526], [2.421259000000191, 2.4213780000000042], [2.4214450000004035, 2.4215650000001006], [2.4216320000000451, 2.4217490000000907], [2.4218150000001515, 2.4219440000001669], [2.4220100000002276, 2.422128000000157], [2.4221950000001016, 2.4223140000003696], [2.4223820000001979, 2.4225129999999808], [2.4225790000000416, 2.4226980000003095], [2.4227680000003602, 2.4228870000001734], [2.4229520000003504, 2.4230710000001636], [2.4231389999999919, 2.4232600000000275], [2.4233260000000882, 2.4234470000001238], [2.4235160000002907, 2.4236490000002959], [2.4237160000002405, 2.4238330000002861], [2.4239010000001144, 2.4240200000003824], [2.4240890000000945, 2.4242730000000847], [2.4243430000001354, 2.4244590000002972], [2.424525000000358, 2.4246760000000904], [2.4247460000001411, 2.4248660000002928], [2.4249350000000049, 2.4250550000001567], [2.425122999999985, 2.425242000000253], [2.4253100000000813, 2.4254450000003089], [2.425514000000021, 2.4256320000004052], [2.4257020000000011, 2.4258210000002691], [2.4258920000002036, 2.4260110000000168], [2.426082000000406, 2.4262000000003354], [2.4262680000001637, 2.4263860000000932], [2.42645500000026, 2.4265850000001592], [2.4266560000000936, 2.4267750000003616], [2.4268450000004123, 2.4269630000003417], [2.4270330000003923, 2.4271499999999833], [2.4272180000002663, 2.4273339999999735], [2.4274060000002464, 2.4275230000002921], [2.4275980000002164, 2.4277170000000297], [2.4277860000001965, 2.4279020000003584], [2.427972000000409, 2.4280889999999999], [2.4281600000003891, 2.4283000000000357], [2.4283709999999701, 2.4284920000000056], [2.4286440000000766, 2.4287699999999859], [2.4288310000001729, 2.4289499999999862], [2.4290220000002591, 2.4291400000001886], [2.4292120000000068, 2.4293290000000525], [2.4294020000002092, 2.4295310000002246], [2.4296040000003813, 2.4297230000001946], [2.4297970000002351, 2.4299150000001646], [2.4299869999999828, 2.4301040000000285], [2.4301770000001852, 2.4303610000001754], [2.4304910000000746, 2.4306680000004235], [2.4632060000003548, 2.4633650000000671], [2.4634770000002391, 2.4636100000002443], [2.4677590000001146, 2.4679180000002816], [2.46817400000009, 2.468326000000161], [2.468539000000419, 2.4687350000003789], [3.4616820000001098, 3.461833000000297], [3.6133220000001529, 3.613524000000325], [3.6148170000001301, 3.6150360000001456], [3.6634470000003603, 3.6636480000001939], [3.6644840000003569, 3.6648210000003019], [3.6651220000003377, 3.6652090000002318], [3.6653110000002016, 3.6655310000001009], [4.2206840000003467, 4.2208780000000843], [4.2718370000002324, 4.2721980000001167]], \"2\": [[3.4608570000000327, 3.4610139999999774], [3.4610490000000027, 3.4611550000004172], [4.2227550000002338, 4.2229310000002442], [4.2708040000002256, 4.2710030000002916], [4.3067220000002635, 4.306919999999991], [4.9220930000001317, 4.9222990000002937], [4.9227090000003955, 4.9229340000001685], [4.9722280000000865, 4.9724280000000363], [4.9726870000004055, 4.9729019999999764], [4.9729620000002797, 4.9730940000004011], [4.973124000000098, 4.9732470000003559], [5.1246520000004239, 5.1248650000002272], [5.1252819999999701, 5.1257660000001124], [5.1258609999999862, 5.1271280000000843], [5.1271550000001298, 5.1281850000000304], [5.1281990000002224, 5.1282350000001315], [5.1282540000001973, 5.1282750000000306], [5.1282890000002226, 5.1283170000001519], [5.1283320000002277, 5.1283490000000711], [5.1283650000000307, 5.1283849999999802], [5.1283990000001722, 5.1284200000000055], [5.1284340000001976, 5.1284530000002633], [5.1284670000000006, 5.1284900000000562], [5.1285030000003644, 5.1285230000003139], [5.1285360000001674, 5.1286720000002788], [5.1286910000003445, 5.128711000000294], [5.1287250000000313, 5.1287449999999808], [5.1287610000003951, 5.128791000000092], [5.1288050000002841, 5.1288220000001274], [5.1288370000002033, 5.1288600000002589], [5.1288739999999962, 5.1288930000000619], [5.1289070000002539, 5.1289310000001933], [5.1289450000003853, 5.1289639999999963], [5.1289780000001883, 5.1290000000003602], [5.1290149999999812, 5.1290340000000469], [5.1290490000001228, 5.1290700000004108], [5.1290840000001481, 5.1291060000003199], [5.1291200000000572, 5.1291500000002088], [5.1291650000002846, 5.1291840000003504], [5.1291970000002038, 5.1292190000003757], [5.129233000000113, 5.1292560000001686], [5.1292700000003606, 5.1292920000000777], [5.1293060000002697, 5.1293290000003253], [5.1293430000000626, 5.1293660000001182], [5.1293820000000778, 5.1295950000003359], [5.1747690000001967, 5.1749450000002071], [5.1749840000002223, 5.1751050000002579], [5.1754020000003038, 5.1756350000000566], [5.2028420000001461, 5.2030349999999999], [5.8262020000001939, 5.8264110000000073], [5.827284000000418, 5.8274930000002314], [5.8277040000002671, 5.8278370000002724], [5.8280650000001515, 5.8281920000003993], [5.8284950000002027, 5.8287430000000313], [5.828954000000067, 5.8290780000002087], [5.829319000000396, 5.8294470000000729], [5.8305450000002566, 5.8307510000004186], [5.8762840000003962, 5.8764860000001136], [5.8773240000000442, 5.8775330000003123]]}}});\n",
+       "        }); /* TRAPPY_PUBLISH_REMOVE_LINE */\n",
+       "        </script>\n",
+       "        </div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"border-style: hidden;\">\n",
+       "<caption style=\"text-align:center; font: 24px sans-serif bold; color: black\">Scheduler task signals</caption>\n",
+       "<tr>\n",
+       "<td style=\"border-style: hidden;\"><div class=\"ilineplot\" id=\"fig_f340545ad6424a77a2dbb85b4915b323\"></div></td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "<td style=\"border-style: hidden;\"><div style=\"text-align:center\" id=\"fig_f340545ad6424a77a2dbb85b4915b323_legend\"></div></td>\n",
+       "</tr>\n",
+       "</table>\n",
+       "<script>\n",
+       "var fig_f340545ad6424a77a2dbb85b4915b323_data = {\"logscale\": false, \"strokeWidth\": 1.0, \"pointSize\": 2, \"name\": \"fig_f340545ad6424a77a2dbb85b4915b323\", \"step_plot\": true, \"fill_graph\": false, \"title\": \"\", \"drawPoints\": false, \"per_line\": 1, \"height\": 400, \"rangesel\": false, \"data\": {\"labels\": [\"index\", \"DataFrame 0:util_avg\", \"DataFrame 0:load_avg\", \"DataFrame 0:expected_util_avg\"], \"data\": [[2.4681650000002264, 249.0, 1002.0, 108.93137550152237], [2.4683210000002873, 249.0, 1002.0, 108.93137550152237], [2.4685300000001007, 249.0, 1002.0, 108.93137550152237], [2.4687300000000505, 249.0, 1002.0, 108.93137550152237], [2.4725510000002942, 262.0, 955.0, 108.93137550152237], [2.4727110000003449, 262.0, 955.0, 108.93137550152237], [2.4845190000000912, 207.0, 753.0, 108.93137550152237], [2.484541000000263, 207.0, 753.0, 108.93137550152237], [2.4845610000002125, 207.0, 753.0, 108.93137550152237], [2.4885480000002644, 223.0, 724.0, 108.93137550152237], [2.4886790000000474, 223.0, 724.0, 108.93137550152237], [2.5005210000003899, 177.0, 571.0, 108.93137550152237], [2.500543000000107, 177.0, 571.0, 108.93137550152237], [2.5005610000002889, 173.0, 559.0, 108.93137550152237], [2.5045480000003408, 195.0, 557.0, 108.93137550152237], [2.5046970000003057, 195.0, 557.0, 108.93137550152237], [2.516519000000244, 151.0, 430.0, 108.93137550152237], [2.5166269999999713, 151.0, 430.0, 108.93137550152237], [2.520549000000301, 171.0, 427.0, 108.93137550152237], [2.5206950000001598, 171.0, 427.0, 108.93137550152237], [2.5325250000000779, 136.0, 338.0, 108.93137550152237], [2.5325550000002295, 136.0, 338.0, 108.93137550152237], [2.5365500000002612, 157.0, 342.0, 108.93137550152237], [2.5366870000002564, 157.0, 342.0, 108.93137550152237], [2.5485220000000481, 125.0, 271.0, 108.93137550152237], [2.5485520000001998, 125.0, 271.0, 108.93137550152237], [2.5525510000002214, 147.0, 281.0, 108.93137550152237], [2.5526850000001104, 147.0, 281.0, 108.93137550152237], [2.5645480000002863, 114.0, 218.0, 108.93137550152237], [2.5645860000004177, 114.0, 218.0, 108.93137550152237], [2.5685540000004039, 140.0, 237.0, 108.93137550152237], [2.5687370000000556, 138.0, 233.0, 108.93137550152237], [2.5805490000002465, 109.0, 184.0, 108.93137550152237], [2.5805890000001455, 109.0, 184.0, 108.93137550152237], [2.5845540000000256, 132.0, 201.0, 108.93137550152237], [2.5847360000002482, 132.0, 201.0, 108.93137550152237], [2.5965479999999843, 105.0, 160.0, 108.93137550152237], [2.596585000000232, 105.0, 160.0, 108.93137550152237], [2.6005530000002182, 129.0, 179.0, 108.93137550152237], [2.6007340000001022, 129.0, 179.0, 108.93137550152237], [2.6125470000001769, 103.0, 142.0, 108.93137550152237], [2.6125850000003084, 103.0, 142.0, 108.93137550152237], [2.6165540000001783, 127.0, 163.0, 108.93137550152237], [2.616736000000401, 127.0, 163.0, 108.93137550152237], [2.6285470000002533, 99.0, 127.0, 108.93137550152237], [2.6285850000003848, 99.0, 127.0, 108.93137550152237], [2.6325540000002547, 126.0, 152.0, 108.93137550152237], [2.632734000000255, 124.0, 150.0, 108.93137550152237], [2.6445480000002135, 98.0, 118.0, 108.93137550152237], [2.6445860000003449, 98.0, 118.0, 108.93137550152237], [2.6485529999999926, 122.0, 141.0, 108.93137550152237], [2.6487390000002051, 122.0, 141.0, 108.93137550152237], [2.6605480000002899, 97.0, 112.0, 108.93137550152237], [2.6605850000000828, 97.0, 112.0, 108.93137550152237], [2.664553000000069, 122.0, 136.0, 108.93137550152237], [2.6647340000004078, 122.0, 136.0, 108.93137550152237], [2.6765220000002046, 97.0, 108.0, 108.93137550152237], [2.676560000000336, 97.0, 108.0, 108.93137550152237], [2.6805520000002616, 122.0, 132.0, 108.93137550152237], [2.6806800000003932, 122.0, 132.0, 108.93137550152237], [2.6925470000001042, 95.0, 103.0, 108.93137550152237], [2.6925840000003518, 95.0, 103.0, 108.93137550152237], [2.6965530000002218, 122.0, 129.0, 108.93137550152237], [2.6967330000002221, 121.0, 128.0, 108.93137550152237], [2.7085480000000643, 95.0, 101.0, 108.93137550152237], [2.7085860000001958, 95.0, 101.0, 108.93137550152237], [2.7125530000002982, 119.0, 125.0, 108.93137550152237], [2.7127360000004046, 119.0, 125.0, 108.93137550152237], [2.7245460000003732, 95.0, 100.0, 108.93137550152237], [2.7245840000000499, 95.0, 100.0, 108.93137550152237], [2.7285540000002584, 120.0, 124.0, 108.93137550152237], [2.7287350000001425, 120.0, 124.0, 108.93137550152237], [2.7405470000003334, 96.0, 99.0, 108.93137550152237], [2.74058500000001, 96.0, 99.0, 108.93137550152237], [2.7445529999999962, 120.0, 124.0, 108.93137550152237], [2.744731000000229, 120.0, 124.0, 108.93137550152237], [2.7565480000002935, 94.0, 96.0, 108.93137550152237], [2.7565870000003088, 94.0, 96.0, 108.93137550152237], [2.7605540000004112, 121.0, 123.0, 108.93137550152237], [2.7607350000002953, 120.0, 122.0, 108.93137550152237], [2.7725460000001476, 94.0, 96.0, 108.93137550152237], [2.772584000000279, 94.0, 96.0, 108.93137550152237], [2.776553000000149, 119.0, 121.0, 108.93137550152237], [2.7767340000000331, 119.0, 121.0, 108.93137550152237], [2.7885470000001078, 95.0, 96.0, 108.93137550152237], [2.7885850000002392, 95.0, 96.0, 108.93137550152237], [2.7925540000001092, 119.0, 121.0, 108.93137550152237], [2.7927360000003318, 119.0, 121.0, 108.93137550152237], [2.8045500000002903, 95.0, 96.0, 108.93137550152237], [2.8045870000000832, 95.0, 96.0, 108.93137550152237], [2.8085540000001856, 120.0, 121.0, 108.93137550152237], [2.8087400000003981, 120.0, 121.0, 108.93137550152237], [2.8205470000002606, 94.0, 95.0, 108.93137550152237], [2.8205860000002758, 94.0, 95.0, 108.93137550152237], [2.8245530000003782, 121.0, 122.0, 108.93137550152237], [2.8247340000002623, 120.0, 121.0, 108.93137550152237], [2.8365480000002208, 94.0, 95.0, 108.93137550152237], [2.8365860000003522, 94.0, 95.0, 108.93137550152237], [2.8405529999999999, 119.0, 120.0, 108.93137550152237], [2.8407369999999901, 119.0, 120.0, 108.93137550152237], [2.852549000000181, 95.0, 96.0, 108.93137550152237], [2.8525859999999739, 95.0, 96.0, 108.93137550152237], [2.8565530000000763, 119.0, 120.0, 108.93137550152237], [2.8567360000001827, 119.0, 120.0, 108.93137550152237], [2.8685480000003736, 95.0, 96.0, 108.93137550152237], [2.8685860000000503, 95.0, 96.0, 108.93137550152237], [2.8725540000000365, 120.0, 121.0, 108.93137550152237], [2.8727340000000368, 120.0, 121.0, 108.93137550152237], [2.8845479999999952, 94.0, 94.0, 108.93137550152237], [2.8845850000002429, 94.0, 94.0, 108.93137550152237], [2.8885540000001129, 121.0, 122.0, 108.93137550152237], [2.8887330000002294, 120.0, 120.0, 108.93137550152237], [2.9005490000004102, 94.0, 95.0, 108.93137550152237], [2.9005860000002031, 94.0, 95.0, 108.93137550152237], [2.9045540000001893, 119.0, 120.0, 108.93137550152237], [2.9047390000000632, 119.0, 120.0, 108.93137550152237], [2.916548000000148, 95.0, 95.0, 108.93137550152237], [2.9165850000003957, 95.0, 95.0, 108.93137550152237], [2.9205540000002657, 119.0, 120.0, 108.93137550152237], [2.9207350000001497, 119.0, 120.0, 108.93137550152237], [2.9325460000000021, 95.0, 96.0, 108.93137550152237], [2.9325840000001335, 95.0, 96.0, 108.93137550152237], [2.9365530000000035, 120.0, 121.0, 108.93137550152237], [2.9367380000003322, 120.0, 121.0, 108.93137550152237], [2.9485490000001846, 94.0, 94.0, 108.93137550152237], [2.9485859999999775, 94.0, 94.0, 108.93137550152237], [2.9525540000004185, 118.0, 119.0, 108.93137550152237], [2.9527340000004187, 118.0, 119.0, 108.93137550152237], [2.9645480000003772, 94.0, 95.0, 108.93137550152237], [2.9645860000000539, 94.0, 95.0, 108.93137550152237], [2.9685530000001563, 119.0, 120.0, 108.93137550152237], [2.9687370000001465, 119.0, 120.0, 108.93137550152237], [2.9805479999999989, 95.0, 95.0, 108.93137550152237], [2.9805860000001303, 95.0, 95.0, 108.93137550152237], [2.9845530000002327, 120.0, 120.0, 108.93137550152237], [2.9848020000003999, 120.0, 120.0, 108.93137550152237], [2.9965480000000753, 96.0, 96.0, 108.93137550152237], [2.9965890000003128, 96.0, 96.0, 108.93137550152237], [3.0005530000003091, 121.0, 121.0, 108.93137550152237], [3.0006710000002386, 121.0, 121.0, 108.93137550152237], [3.0008630000002086, 118.0, 121.0, 108.93137550152237], [3.0009530000002087, 118.0, 121.0, 108.93137550152237], [3.0125480000001517, 94.0, 96.0, 108.93137550152237], [3.0125860000002831, 94.0, 96.0, 108.93137550152237], [3.0165560000000369, 118.0, 121.0, 108.93137550152237], [3.0167370000003757, 118.0, 121.0, 108.93137550152237], [3.0285470000003443, 94.0, 96.0, 108.93137550152237], [3.028585000000021, 94.0, 96.0, 108.93137550152237], [3.0325540000003457, 119.0, 121.0, 108.93137550152237], [3.0327350000002298, 119.0, 121.0, 108.93137550152237], [3.0445470000004207, 95.0, 96.0, 108.93137550152237], [3.0445850000000974, 95.0, 96.0, 108.93137550152237], [3.0485530000000836, 120.0, 121.0, 108.93137550152237], [3.0487350000003062, 120.0, 121.0, 108.93137550152237], [3.0605470000000423, 95.0, 97.0, 108.93137550152237], [3.0605860000000575, 93.0, 95.0, 108.93137550152237], [3.06455300000016, 120.0, 122.0, 108.93137550152237], [3.0647430000003624, 120.0, 122.0, 108.93137550152237], [3.0765480000000025, 94.0, 95.0, 108.93137550152237], [3.0765880000003563, 94.0, 95.0, 108.93137550152237], [3.0805530000002364, 118.0, 119.0, 108.93137550152237], [3.0807350000000042, 118.0, 119.0, 108.93137550152237], [3.0925470000001951, 94.0, 95.0, 108.93137550152237], [3.092583999999988, 94.0, 95.0, 108.93137550152237], [3.0965530000003127, 119.0, 120.0, 108.93137550152237], [3.0967340000001968, 119.0, 120.0, 108.93137550152237], [3.1085480000001553, 95.0, 96.0, 108.93137550152237], [3.1085850000004029, 95.0, 96.0, 108.93137550152237], [3.1125530000003891, 120.0, 121.0, 108.93137550152237], [3.1127370000003793, 120.0, 121.0, 108.93137550152237], [3.1245470000003479, 93.0, 94.0, 108.93137550152237], [3.1245840000001408, 93.0, 94.0, 108.93137550152237], [3.1285530000000108, 120.0, 121.0, 108.93137550152237], [3.1287330000000111, 119.0, 120.0, 108.93137550152237], [3.1405500000000757, 94.0, 95.0, 108.93137550152237], [3.1405890000000909, 94.0, 95.0, 108.93137550152237], [3.1445530000000872, 118.0, 119.0, 108.93137550152237], [3.1447360000001936, 118.0, 119.0, 108.93137550152237], [3.1565460000001622, 94.0, 95.0, 108.93137550152237], [3.1565840000002936, 94.0, 95.0, 108.93137550152237], [3.1605530000001636, 119.0, 120.0, 108.93137550152237], [3.1607350000003862, 119.0, 120.0, 108.93137550152237], [3.1725480000000061, 95.0, 96.0, 108.93137550152237], [3.1725850000002538, 95.0, 96.0, 108.93137550152237], [3.17655300000024, 120.0, 120.0, 108.93137550152237], [3.1767360000003464, 120.0, 120.0, 108.93137550152237], [3.1885480000000825, 93.0, 94.0, 108.93137550152237], [3.188586000000214, 93.0, 94.0, 108.93137550152237], [3.1925540000002002, 120.0, 121.0, 108.93137550152237], [3.1927670000000035, 120.0, 120.0, 108.93137550152237], [3.2045480000001589, 94.0, 95.0, 108.93137550152237], [3.2045850000004066, 94.0, 95.0, 108.93137550152237], [3.2085530000003928, 119.0, 119.0, 108.93137550152237], [3.2087510000001203, 119.0, 119.0, 108.93137550152237], [3.2205470000003515, 95.0, 95.0, 108.93137550152237], [3.2205850000000282, 95.0, 95.0, 108.93137550152237], [3.2245530000000144, 119.0, 120.0, 108.93137550152237], [3.2247590000001765, 119.0, 120.0, 108.93137550152237], [3.2365460000000894, 95.0, 96.0, 108.93137550152237], [3.2365840000002208, 95.0, 96.0, 108.93137550152237], [3.2405530000000908, 120.0, 121.0, 108.93137550152237], [3.2407330000000911, 120.0, 121.0, 108.93137550152237], [3.2525470000000496, 94.0, 94.0, 108.93137550152237], [3.252585000000181, 94.0, 94.0, 108.93137550152237], [3.2565530000001672, 121.0, 121.0, 108.93137550152237], [3.2567360000002736, 120.0, 120.0, 108.93137550152237], [3.2685490000003483, 94.0, 95.0, 108.93137550152237], [3.2685860000001412, 94.0, 95.0, 108.93137550152237], [3.2725530000002436, 119.0, 119.0, 108.93137550152237], [3.272762000000057, 119.0, 119.0, 108.93137550152237], [3.2845420000003287, 95.0, 95.0, 108.93137550152237], [3.2845839999999953, 95.0, 95.0, 108.93137550152237], [3.28855300000032, 119.0, 120.0, 108.93137550152237], [3.2887330000003203, 119.0, 120.0, 108.93137550152237], [3.3005490000000464, 95.0, 96.0, 108.93137550152237], [3.300586000000294, 95.0, 96.0, 108.93137550152237], [3.3045530000003964, 120.0, 121.0, 108.93137550152237], [3.3047350000001643, 120.0, 121.0, 108.93137550152237], [3.3165490000001228, 94.0, 94.0, 108.93137550152237], [3.3165860000003704, 94.0, 94.0, 108.93137550152237], [3.3205540000003566, 121.0, 121.0, 108.93137550152237], [3.3207440000001043, 120.0, 120.0, 108.93137550152237], [3.3325410000002194, 94.0, 95.0, 108.93137550152237], [3.3325800000002346, 94.0, 95.0, 108.93137550152237], [3.3365550000003168, 119.0, 119.0, 108.93137550152237], [3.3367299999999886, 119.0, 119.0, 108.93137550152237], [3.3485480000003918, 95.0, 95.0, 108.93137550152237], [3.348587000000407, 95.0, 95.0, 108.93137550152237], [3.3525530000001709, 119.0, 120.0, 108.93137550152237], [3.3527350000003935, 119.0, 120.0, 108.93137550152237], [3.364549000000352, 95.0, 96.0, 108.93137550152237], [3.3645860000001448, 95.0, 96.0, 108.93137550152237], [3.3685540000001311, 120.0, 121.0, 108.93137550152237], [3.3687610000001769, 120.0, 121.0, 108.93137550152237], [3.3805480000000898, 94.0, 94.0, 108.93137550152237], [3.3805850000003375, 94.0, 94.0, 108.93137550152237], [3.3845540000002075, 121.0, 122.0, 108.93137550152237], [3.3846730000000207, 121.0, 122.0, 108.93137550152237], [3.3846960000000763, 118.0, 120.0, 108.93137550152237], [3.3847820000000866, 118.0, 120.0, 108.93137550152237], [3.39654900000005, 94.0, 95.0, 108.93137550152237], [3.3965880000000652, 94.0, 95.0, 108.93137550152237], [3.4005540000002838, 118.0, 120.0, 108.93137550152237], [3.4007360000000517, 118.0, 120.0, 108.93137550152237], [3.4125470000003588, 94.0, 96.0, 108.93137550152237], [3.4125840000001517, 94.0, 96.0, 108.93137550152237], [3.416555000000244, 119.0, 120.0, 108.93137550152237], [3.4167370000000119, 119.0, 120.0, 108.93137550152237], [3.428548000000319, 95.0, 96.0, 108.93137550152237], [3.4285850000001119, 95.0, 96.0, 108.93137550152237], [3.4325530000000981, 120.0, 121.0, 108.93137550152237], [3.4327350000003207, 120.0, 121.0, 108.93137550152237], [3.4445470000000569, 94.0, 94.0, 108.93137550152237], [3.4445850000001883, 94.0, 94.0, 108.93137550152237], [3.4485540000000583, 121.0, 122.0, 108.93137550152237], [3.4487380000000485, 120.0, 120.0, 108.93137550152237], [3.4605510000001232, 94.0, 95.0, 108.93137550152237], [3.4605880000003708, 94.0, 95.0, 108.93137550152237], [3.4607890000002044, 94.0, 95.0, 108.93137550152237], [3.4609440000003815, 94.0, 95.0, 108.93137550152237]]}};\n",
+       "</script>\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"http://cdnjs.cloudflare.com/ajax/libs/dygraph/1.1.1/dygraph-combined.js\" -->\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"http://dygraphs.com/extras/synchronizer.js\" -->\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js\" -->\n",
+       "\n",
+       "            <script>\n",
+       "            /* TRAPPY_PUBLISH_IMPORT = \"plotter/js/ILinePlot.js\" */\n",
+       "            /* TRAPPY_PUBLISH_REMOVE_START */\n",
+       "            var ilp_req = require.config( {\n",
+       "\n",
+       "                paths: {\n",
+       "                    \"dygraph-sync\": '/nbextensions/plotter_scripts/ILinePlot/synchronizer',\n",
+       "                    \"dygraph\": '/nbextensions/plotter_scripts/ILinePlot/dygraph-combined',\n",
+       "                    \"ILinePlot\": '/nbextensions/plotter_scripts/ILinePlot/ILinePlot',\n",
+       "                    \"underscore\": '/nbextensions/plotter_scripts/ILinePlot/underscore-min',\n",
+       "                },\n",
+       "\n",
+       "                shim: {\n",
+       "                    \"dygraph-sync\": [\"dygraph\"],\n",
+       "                    \"ILinePlot\": {\n",
+       "\n",
+       "                        \"deps\": [\"dygraph-sync\", \"dygraph\", \"underscore\"],\n",
+       "                        \"exports\":  \"ILinePlot\"\n",
+       "                    }\n",
+       "                }\n",
+       "            });\n",
+       "                /* TRAPPY_PUBLISH_REMOVE_STOP */\n",
+       "                ilp_req([\"require\", \"ILinePlot\"], function() { /* TRAPPY_PUBLISH_REMOVE_LINE */\n",
+       "                ILinePlot.generate(fig_f340545ad6424a77a2dbb85b4915b323_data);\n",
+       "            }); /* TRAPPY_PUBLISH_REMOVE_LINE */\n",
+       "            </script>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "examine_experiment(0)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/eas/load_tracking.py
+++ b/tests/eas/load_tracking.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2016, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from bart.common.Utils import select_window, area_under_curve
+from devlib.utils.misc import memoized
+from trappy.stats.grammar import Parser
+import pandas as pd
+
+from test import LisaTest, experiment_test
+
+UTIL_SCALE = 1024
+# Time in seconds to allow for util_avg to converge (i.e. ignored time)
+UTIL_AVG_CONVERGENCE_TIME = 0.3
+# Allowed margin between expected and observed util_avg value
+ERROR_MARGIN_PCT = 15
+
+class FreqInvarianceTest(LisaTest):
+    """
+    Goal
+    ====
+    Basic check for frequency invariant load tracking
+
+    Detailed Description
+    ====================
+    This test runs the same workload on the most capable CPU on the system at a
+    cross section of available frequencies. The trace is then examined to find
+    the average activation length of the workload, which is combined with the
+    known period to estimate an expected mean value for util_avg for each
+    frequency. The util_avg value is extracted from scheduler trace events and
+    its mean is compared with the expected value (ignoring the first 300ms so
+    that the signal can stabilize). The test fails if the observed mean is
+    beyond a certain error margin from the expected one. load_avg is then
+    similarly compared with the expected util_avg mean, under the assumption
+    that load_avg should equal util_avg when system load is light.
+
+    Expected Behaviour
+    ==================
+    Load tracking signals are scaled so that the workload results in roughly the
+    same util & load values regardless of frequency.
+    """
+
+    test_conf = {
+        'tools'    : [ 'rt-app' ],
+        'ftrace' : {
+            'events' : [
+                'sched_switch',
+                'sched_load_avg_task',
+                'sched_load_avg_cpu',
+                'sched_pelt_se',
+            ],
+        },
+        # cgroups required by freeze_userspace flag
+        'modules': ['cpufreq', 'cgroups'],
+    }
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super(FreqInvarianceTest, cls).runExperiments(*args, **kwargs)
+
+    @memoized
+    @classmethod
+    def _get_cpu(cls, target):
+        # Run on a 'big' CPU, or any CPU if not big.LITTLE
+        if hasattr(target, 'bl'):
+            return target.bl.bigs[0]
+        else:
+            return 0
+
+    @classmethod
+    def _getExperimentsConf(cls, test_env):
+        cpu = cls._get_cpu(test_env.target)
+
+        # 10% periodic RTApp workload:
+        wloads = {
+            'fie_10pct' : {
+                'type' : 'rt-app',
+                'conf' : {
+                    'class' : 'periodic',
+                    'params' : {
+                        'duty_cycle_pct': 10,
+                        'duration_s': 1,
+                        'period_ms': 16,
+                    },
+                    'tasks' : 1,
+                    'prefix' : 'fie_test',
+                    'cpus' : [cpu]
+                },
+            },
+        }
+
+        # Create a set of confs with different frequencies
+        # We'll run the 10% workload under each conf (i.e. at each frequency)
+        confs = []
+
+        all_freqs = test_env.target.cpufreq.list_frequencies(cpu)
+        # If we have loads of frequencies just test a cross-section so it
+        # doesn't take all day
+        cls.freqs = all_freqs[::len(all_freqs)/8 + 1]
+        for freq in cls.freqs:
+            confs.append({
+                'tag' : 'freq_{}'.format(freq),
+                'flags' : ['ftrace', 'freeze_userspace'],
+                'cpufreq' : {
+                    'freqs' : {cpu: freq},
+                    'governor' : 'userspace',
+                },
+            })
+
+        return {
+            'wloads': wloads,
+            'confs': confs,
+        }
+
+    def get_expected_util_avg(self, experiment):
+        """
+        Examine trace to figure out an expected mean for util_avg
+
+        Assumes an RT-App workload with a single task with a single phase,
+        running on a CPU with the highest max capacity in the system
+
+        This takes into account the frequency the workload was run at, but
+        doesn't use the kernel's data for compute capacities at each frequency,
+        instead it assumes that these values scale linearly.
+        """
+        [task] = experiment.wload.tasks.keys()
+        sched_assert = self.get_sched_assert(experiment, task)
+
+        [freq] = experiment.conf['cpufreq']['freqs'].values()
+        freq_scaling_factor = float(freq) / max(self.freqs)
+        duty_cycle_pct = sched_assert.getDutyCycle(self.get_window(experiment))
+
+        return UTIL_SCALE * (duty_cycle_pct / 100.) * freq_scaling_factor
+
+    def get_sched_task_signals(self, experiment, signals):
+        """
+        Get a pandas.DataFrame with the sched signals for the workload task
+
+        This examines scheduler load tracking trace events, supporting either
+        sched_load_avg_task or sched_pelt_se. You will need a target kernel that
+        includes these events.
+
+        :param experiment: Experiment to get trace for
+        :param signals: List of load tracking signals to extract. Probably a
+                        subset of ``['util_avg', 'load_avg']``
+        :returns: :class:`pandas.DataFrame` with a column for each signal for
+                  the experiment's workload task
+        """
+        [task] = experiment.wload.tasks.keys()
+        trace = self.get_trace(experiment)
+
+        # There are two different scheduler trace events that expose the load
+        # tracking signals. Neither of them is in mainline. Eventually they
+        # should be unified but for now we'll just check for both types of
+        # event.
+        # TODO: Add support for this parsing in Trappy and/or tasks_analysis
+        if 'sched_load_avg_task' in trace.available_events:
+            event = 'sched_load_avg_task'
+        elif 'sched_pelt_se' in trace.available_events:
+            event = 'sched_pelt_se'
+        else:
+            raise ValueError('No sched_load_avg_task or sched_pelt_se events. '
+                             'Does the kernel support them?')
+
+        df = getattr(trace.ftrace, event).data_frame
+        signals = df[df['comm'] == task][signals]
+        return select_window(signals, self.get_window(experiment))
+
+    def get_signal_mean(self, experiment, signal,
+                        ignore_first_s=UTIL_AVG_CONVERGENCE_TIME):
+        """
+        Get the mean of a scheduler signal for the experiment's task
+
+        Ignore the first `ignore_first_s` seconds of the signal.
+        """
+        (wload_start, wload_end) = self.get_window(experiment)
+        window = (wload_start + ignore_first_s, wload_end)
+
+        signal = self.get_sched_task_signals(experiment, [signal])[signal]
+        signal = select_window(signal, window)
+        return area_under_curve(signal) / (window[1] - window[0])
+
+    def _test_signal(self, experiment, tasks, signal_name):
+        [task] = tasks
+        exp_util = self.get_expected_util_avg(experiment)
+        signal_mean = self.get_signal_mean(experiment, signal_name)
+
+        error_margin = exp_util * (ERROR_MARGIN_PCT / 100.)
+        [freq] = experiment.conf['cpufreq']['freqs'].values()
+
+        msg = 'Saw {} around {}, expected {} at freq {}'.format(
+            signal_name, signal_mean, exp_util, freq)
+        self.assertAlmostEqual(signal_mean, exp_util, delta=error_margin,
+                               msg=msg)
+
+    @experiment_test
+    def test_task_util_avg(self, experiment, tasks):
+        """
+        Test that the mean of the util_avg signal matched the expected value
+        """
+        return self._test_signal(experiment, tasks, 'util_avg')
+
+    @experiment_test
+    def test_task_load_avg(self, experiment, tasks):
+        """
+        Test that the mean of the load_avg signal matched the expected value
+
+        Assuming that the system was under little stress (so the task was
+        RUNNING whenever it was RUNNABLE) and that the task was run with a
+        'nice' value of 0, the load_avg should be similar to the util_avg. So,
+        this test does the same as test_task_util_avg but for load_avg.
+        """
+        return self._test_signal(experiment, tasks, 'load_avg')


### PR DESCRIPTION
See [commit message](https://github.com/ARM-software/lisa/commit/3224f5a344ddd8f16967fd6163289bd160d3f63e).

This test is quite simple so I've tried to make it an example of how we could design tests so that they can be used both from the command line as automated tests, and via notebooks as diagnostic/analysis tools. That means I've also added a couple of commits to make instantiating tests from notebooks easier. The interface for doing that is a bit bizarre (instantiate then `setUpClass`) but it works. The test/target configuration is also not inline in the notebook, instead the config comes from `target.config`. I personally like that, but it might be confusing invisible magic to someone new to LISA.