### PR TITLE
Energy model-based tests, RFC v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@
 sudo: required
 language: python
 install:
-  - pip install --upgrade Cython trappy bart-py devlib psutil wrapt ipython jupyter
+  - pip install --upgrade Cython trappy bart-py devlib psutil wrapt ipython jupyter matplotlib
 script:
   - cd $TRAVIS_BUILD_DIR
   - source init_env && lisa-test tests/lisa/

--- a/ipynb/tests/Generic_EAS_Tests.ipynb
+++ b/ipynb/tests/Generic_EAS_Tests.ipynb
@@ -1,0 +1,697 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "# Run Generic Automated EAS tests\n",
+    "This is a starting-point notebook for running tests from the generic EAS suite in `tests/eas/generic.py`. The test classes that are imported here provide helper methods to aid analysis of the cause of failure. You can use Python's `help` built-in to find those methods (or you can just read the docstrings in the code).\n",
+    "\n",
+    "These tests make estimation of the energy efficiency of task placements, without directly examining the behaviour of cpufreq or cpuidle. Several test classes are provided, the only difference between them being the workload that is used."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-01-23 18:50:17,847 INFO    : root         : Using LISA logging configuration:\n",
+      "2017-01-23 18:50:17,847 INFO    : root         :   /home/brendan/sources/lisa/logging.conf\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%matplotlib inline\n",
+    "\n",
+    "import logging\n",
+    "from conf import LisaLogging\n",
+    "LisaLogging.setup()#level=logging.WARNING)\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from perf_analysis import PerfAnalysis\n",
+    "\n",
+    "import trappy\n",
+    "from trappy import ILinePlot\n",
+    "from trappy.stats.grammar import Parser"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run test workload\n",
+    "\n",
+    "If you simply want to run all the tests and get pass/fail results, use this command in the LISA shell: `lisa-test tests/eas/generic.py`. This notebook is intended as a starting point for analysing what scheduler behaviour was judged to be faulty.\n",
+    "\n",
+    "Target configuration is taken from `$LISA_HOME/target.config` - you'll need to edit that file to provide connection details for the target you want to test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from tests.eas.generic import TwoBigTasks, TwoBigThreeSmall, RampUp, RampDown, EnergyModelWakeMigration, OneSmallTask"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default we'll run the EnergyModelWakeMigration test, which runs a workload alternating between high and low-intensity. All the other test classes shown above have the same interface, but run different workloads. To run the tests on different workloads, change this line below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "    Test EAS for tasks alternating beetween 10% and 50%\n",
+      "    \n"
+     ]
+    }
+   ],
+   "source": [
+    "t = EnergyModelWakeMigration(methodName=\"test_task_placement\")\n",
+    "print t.__doc__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-01-23 18:50:18,176 INFO    : LisaTest     : Setup tests execution engine...\n",
+      "2017-01-23 18:50:18,178 INFO    : TestEnv      : Using base path: /home/brejac01/sources/lisa\n",
+      "2017-01-23 18:50:18,178 INFO    : TestEnv      : Loading default (file) target configuration\n",
+      "2017-01-23 18:50:18,179 INFO    : TestEnv      : Loading target configuration [/home/brejac01/sources/lisa/target.config]...\n",
+      "2017-01-23 18:50:18,181 INFO    : TestEnv      : Loading custom (inline) test configuration\n",
+      "2017-01-23 18:50:18,182 INFO    : TestEnv      : Devlib modules to load: ['bl', u'cpuidle', 'cgroups', 'cpufreq']\n",
+      "2017-01-23 18:50:18,183 INFO    : TestEnv      : Connecting linux target:\n",
+      "2017-01-23 18:50:18,184 INFO    : TestEnv      :   username : brendan\n",
+      "2017-01-23 18:50:18,185 INFO    : TestEnv      :       host : 192.168.2.2\n",
+      "2017-01-23 18:50:18,186 INFO    : TestEnv      :   password : password\n",
+      "2017-01-23 18:50:18,187 INFO    : TestEnv      : Connection settings:\n",
+      "2017-01-23 18:50:18,188 INFO    : TestEnv      :    {'username': u'brendan', 'host': u'192.168.2.2', 'password': u'password'}\n",
+      "2017-01-23 18:50:25,803 INFO    : TestEnv      : Initializing target workdir:\n",
+      "2017-01-23 18:50:25,805 INFO    : TestEnv      :    /home/brendan/devlib-target\n",
+      "2017-01-23 18:50:29,349 INFO    : CGroups      : Available controllers:\n",
+      "2017-01-23 18:50:31,076 INFO    : CGroups      :   schedtune    : /home/brendan/devlib-target/cgroups/devlib_cgh2\n",
+      "2017-01-23 18:50:31,749 INFO    : TestEnv      : Topology:\n",
+      "2017-01-23 18:50:31,751 INFO    : TestEnv      :    [[0, 3, 4, 5], [1, 2]]\n",
+      "2017-01-23 18:50:34,373 INFO    : TestEnv      : Loading default EM:\n",
+      "2017-01-23 18:50:34,374 INFO    : TestEnv      :    /home/brejac01/sources/lisa/libs/utils/platforms/juno.json\n",
+      "2017-01-23 18:50:36,104 INFO    : TestEnv      : Enabled tracepoints:\n",
+      "2017-01-23 18:50:36,106 INFO    : TestEnv      :    sched_overutilized\n",
+      "2017-01-23 18:50:36,107 INFO    : TestEnv      :    sched_energy_diff\n",
+      "2017-01-23 18:50:36,108 INFO    : TestEnv      :    sched_load_avg_task\n",
+      "2017-01-23 18:50:36,109 INFO    : TestEnv      :    sched_load_avg_cpu\n",
+      "2017-01-23 18:50:36,110 INFO    : TestEnv      :    sched_migrate_task\n",
+      "2017-01-23 18:50:36,111 INFO    : TestEnv      :    sched_switch\n",
+      "2017-01-23 18:50:36,112 INFO    : TestEnv      :    cpu_frequency\n",
+      "2017-01-23 18:50:36,114 INFO    : EnergyMeter  : HWMON module not enabled\n",
+      "2017-01-23 18:50:36,115 WARNING : EnergyMeter  : Energy sampling disabled by configuration\n",
+      "2017-01-23 18:50:36,116 INFO    : TestEnv      : Set results folder to:\n",
+      "2017-01-23 18:50:36,117 INFO    : TestEnv      :    /home/brejac01/sources/lisa/results/20170123_185036\n",
+      "2017-01-23 18:50:36,118 INFO    : TestEnv      : Experiment results available also in:\n",
+      "2017-01-23 18:50:36,119 INFO    : TestEnv      :    /home/brejac01/sources/lisa/results_latest\n",
+      "2017-01-23 18:50:36,121 INFO    : Executor     : Loading custom (inline) test configuration\n",
+      "2017-01-23 18:50:36,121 INFO    : Executor     : \n",
+      "2017-01-23 18:50:36,123 INFO    : Executor     : ################################################################################\n",
+      "2017-01-23 18:50:36,124 INFO    : Executor     : Experiments configuration\n",
+      "2017-01-23 18:50:36,125 INFO    : Executor     : ################################################################################\n",
+      "2017-01-23 18:50:36,126 INFO    : Executor     : Configured to run:\n",
+      "2017-01-23 18:50:36,127 INFO    : Executor     :      1 target configurations:\n",
+      "2017-01-23 18:50:36,128 INFO    : Executor     :       energy_aware\n",
+      "2017-01-23 18:50:36,129 INFO    : Executor     :      1 workloads (1 iterations each)\n",
+      "2017-01-23 18:50:36,130 INFO    : Executor     :       wake_migration\n",
+      "2017-01-23 18:50:36,131 INFO    : Executor     : Total: 1 experiments\n",
+      "2017-01-23 18:50:36,132 INFO    : Executor     : Results will be collected under:\n",
+      "2017-01-23 18:50:36,133 INFO    : Executor     :       /home/brejac01/sources/lisa/results/20170123_185036\n",
+      "2017-01-23 18:50:36,134 INFO    : Executor     : rt-app workloads found, installing tool on target\n",
+      "2017-01-23 18:50:38,252 INFO    : LisaTest     : Experiments execution...\n",
+      "2017-01-23 18:50:38,254 INFO    : Executor     : \n",
+      "2017-01-23 18:50:38,255 INFO    : Executor     : ################################################################################\n",
+      "2017-01-23 18:50:38,256 INFO    : Executor     : Experiments execution\n",
+      "2017-01-23 18:50:38,257 INFO    : Executor     : ################################################################################\n",
+      "2017-01-23 18:50:38,258 INFO    : Executor     : \n",
+      "2017-01-23 18:50:38,259 INFO    : Executor     : ================================================================================\n",
+      "2017-01-23 18:50:38,260 INFO    : Executor     : configuring target for [energy_aware] experiments\n",
+      "2017-01-23 18:50:39,976 INFO    : Executor     : Set scheduler feature: ENERGY_AWARE\n",
+      "2017-01-23 18:50:40,881 WARNING : Executor     : cpufreq governor not specified, using currently configured governor\n",
+      "2017-01-23 18:50:40,883 INFO    : Workload     : Setup new workload wake_migration\n",
+      "2017-01-23 18:50:40,884 INFO    : Workload     : Workload duration defined by longest task\n",
+      "2017-01-23 18:50:40,885 INFO    : Workload     : Default policy: SCHED_OTHER\n",
+      "2017-01-23 18:50:40,886 INFO    : Workload     : ------------------------\n",
+      "2017-01-23 18:50:40,888 INFO    : Workload     : task [task_wmig0], sched: using default policy\n",
+      "2017-01-23 18:50:40,889 INFO    : Workload     :  | calibration CPU: 1\n",
+      "2017-01-23 18:50:40,890 INFO    : Workload     :  | loops count: 2\n",
+      "2017-01-23 18:50:40,891 INFO    : Workload     : + phase_000001: duration 1.000000 [s] (10 loops)\n",
+      "2017-01-23 18:50:40,892 INFO    : Workload     : |  period   100000 [us], duty_cycle  10 %\n",
+      "2017-01-23 18:50:40,893 INFO    : Workload     : |  run_time  10000 [us], sleep_time  90000 [us]\n",
+      "2017-01-23 18:50:40,894 INFO    : Workload     : + phase_000002: duration 1.000000 [s] (10 loops)\n",
+      "2017-01-23 18:50:40,895 INFO    : Workload     : |  period   100000 [us], duty_cycle  50 %\n",
+      "2017-01-23 18:50:40,896 INFO    : Workload     : |  run_time  50000 [us], sleep_time  50000 [us]\n",
+      "2017-01-23 18:50:40,897 INFO    : Workload     : ------------------------\n",
+      "2017-01-23 18:50:40,897 INFO    : Workload     : task [task_wmig1], sched: using default policy\n",
+      "2017-01-23 18:50:40,898 INFO    : Workload     :  | calibration CPU: 1\n",
+      "2017-01-23 18:50:40,899 INFO    : Workload     :  | loops count: 2\n",
+      "2017-01-23 18:50:40,900 INFO    : Workload     : + phase_000001: duration 1.000000 [s] (10 loops)\n",
+      "2017-01-23 18:50:40,901 INFO    : Workload     : |  period   100000 [us], duty_cycle  10 %\n",
+      "2017-01-23 18:50:40,902 INFO    : Workload     : |  run_time  10000 [us], sleep_time  90000 [us]\n",
+      "2017-01-23 18:50:40,903 INFO    : Workload     : + phase_000002: duration 1.000000 [s] (10 loops)\n",
+      "2017-01-23 18:50:40,904 INFO    : Workload     : |  period   100000 [us], duty_cycle  50 %\n",
+      "2017-01-23 18:50:40,905 INFO    : Workload     : |  run_time  50000 [us], sleep_time  50000 [us]\n",
+      "2017-01-23 18:50:41,966 INFO    : Executor     : ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
+      "2017-01-23 18:50:41,968 INFO    : Executor     : Experiment 0/1, [energy_aware:wake_migration] 1/1\n",
+      "2017-01-23 18:50:41,976 WARNING : Executor     : FTrace events collection enabled\n",
+      "2017-01-23 18:50:48,009 INFO    : Workload     : Workload execution START:\n",
+      "2017-01-23 18:50:48,011 INFO    : Workload     :    /home/brendan/devlib-target/bin/rt-app /home/brendan/devlib-target/run_dir/wake_migration_00.json 2>&1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-01-23 18:50:57,357 INFO    : Executor     : Collected FTrace binary trace:\n",
+      "2017-01-23 18:50:57,359 INFO    : Executor     :    <res_dir>/rtapp:energy_aware:wake_migration/1/trace.dat\n",
+      "2017-01-23 18:50:57,360 INFO    : Executor     : Collected FTrace function profiling:\n",
+      "2017-01-23 18:50:57,361 INFO    : Executor     :    <res_dir>/rtapp:energy_aware:wake_migration/1/trace_stat.json\n",
+      "2017-01-23 18:50:57,362 INFO    : Executor     : --------------------------------------------------------------------------------\n",
+      "2017-01-23 18:50:57,363 INFO    : Executor     : \n",
+      "2017-01-23 18:50:57,365 INFO    : Executor     : ################################################################################\n",
+      "2017-01-23 18:50:57,366 INFO    : Executor     : Experiments execution completed\n",
+      "2017-01-23 18:50:57,367 INFO    : Executor     : ################################################################################\n",
+      "2017-01-23 18:50:57,368 INFO    : Executor     : Results available in:\n",
+      "2017-01-23 18:50:57,369 INFO    : Executor     :       /home/brejac01/sources/lisa/results/20170123_185036\n"
+     ]
+    }
+   ],
+   "source": [
+    "t.setUpClass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "experiment = t.executor.experiments[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Examine trace\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`get_power_df` and `get_expected_power_df` look at the ftrace results from the workload estimation and judge the energy efficiency of the system, considering *only task placement* (assuming perfect load-tracking/prediction, cpuidle, and cpufreq systems). The energy estimation doesn't take every single wakeup and idle period into account, but simply estimates an average power usage over the time that each task spent attached to each CPU during each phase of the rt-app workload.\n",
+    "\n",
+    "These return DataFrames estimating the energy usage of the system under each task placement. `estimated_power` will represent this estimation for the scheduling pattern that we actually observed, while `expected_power` will represent our estimation of how much power an **optimal** scheduling pattern would use.\n",
+    "\n",
+    "Check the docstrings for these functions (and other functions in the test class) for more detail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# print t.get_power_df.__doc__\n",
+    "estimated_power = t.get_power_df(experiment)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-01-23 18:50:58,352 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:58,355 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:58,356 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:58,361 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:58,363 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:58,367 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:58,369 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:58,374 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:58,375 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:58,378 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:58,380 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:58,381 INFO    : EnergyModel  :    EnergyModel - Done\n"
+     ]
+    }
+   ],
+   "source": [
+    "# print t.get_expected_power_df.__doc__\n",
+    "expected_power = t.get_expected_power_df(experiment)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot Schedule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "trace = t.get_trace(experiment)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "/*\n",
+       " *    Copyright 2015-2016 ARM Limited\n",
+       " *\n",
+       " * Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+       " * you may not use this file except in compliance with the License.\n",
+       " * You may obtain a copy of the License at\n",
+       " *\n",
+       " *     http://www.apache.org/licenses/LICENSE-2.0\n",
+       " *\n",
+       " * Unless required by applicable law or agreed to in writing, software\n",
+       " * distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+       " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+       " * See the License for the specific language governing permissions and\n",
+       " * limitations under the License.\n",
+       " */\n",
+       "\n",
+       ".d3-tip {\n",
+       "  line-height: 1;\n",
+       "  padding: 12px;\n",
+       "  background: rgba(0, 0, 0, 0.6);\n",
+       "  color: #fff;\n",
+       "  border-radius: 2px;\n",
+       "  position: absolute !important;\n",
+       "  z-index: 99999;\n",
+       "}\n",
+       "\n",
+       ".d3-tip:after {\n",
+       "  box-sizing: border-box;\n",
+       "  pointer-events: none;\n",
+       "  display: inline;\n",
+       "  font-size: 10px;\n",
+       "  width: 100%;\n",
+       "  line-height: 1;\n",
+       "  color: rgba(0, 0, 0, 0.6);\n",
+       "  content: \"\\25BC\";\n",
+       "  position: absolute !important;\n",
+       "  z-index: 99999;\n",
+       "  text-align: center;\n",
+       "}\n",
+       "\n",
+       ".d3-tip.n:after {\n",
+       "  margin: -1px 0 0 0;\n",
+       "  top: 100%;\n",
+       "  left: 0;\n",
+       "}\n",
+       "\n",
+       ".contextRect {\n",
+       "  fill: lightgray;\n",
+       "  fill-opacity: 0.5;\n",
+       "  stroke: black;\n",
+       "  stroke-width: 1;\n",
+       "  stroke-opacity: 1;\n",
+       "  pointer-events: none;\n",
+       "  shape-rendering: crispEdges;\n",
+       "}\n",
+       "\n",
+       ".chart {\n",
+       "  shape-rendering: crispEdges;\n",
+       "}\n",
+       "\n",
+       ".mini text {\n",
+       "  font: 9px sans-serif;\n",
+       "}\n",
+       "\n",
+       ".main text {\n",
+       "  font: 12px sans-serif;\n",
+       "}\n",
+       "\n",
+       ".axis line, .axis path {\n",
+       "  stroke: black;\n",
+       "}\n",
+       "\n",
+       ".miniItem {\n",
+       "  stroke-width: 8;\n",
+       "}\n",
+       "\n",
+       ".brush .extent {\n",
+       "\n",
+       "  stroke: #000;\n",
+       "  fill-opacity: .125;\n",
+       "  shape-rendering: crispEdges;\n",
+       "}\n",
+       "</style>\n",
+       "<div id=\"fig_e02b442c14224f68bbbc94f0db857a28\" class=\"eventplot\">\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js\" -->\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"http://labratrevenge.com/d3-tip/javascripts/d3.tip.v0.6.3.js\" -->\n",
+       "\n",
+       "        <script>\n",
+       "            /* TRAPPY_PUBLISH_IMPORT = \"plotter/js/EventPlot.js\" */\n",
+       "            /* TRAPPY_PUBLISH_REMOVE_START */\n",
+       "            var req = require.config( {\n",
+       "\n",
+       "                paths: {\n",
+       "\n",
+       "                    \"EventPlot\": '/nbextensions/plotter_scripts/EventPlot/EventPlot',\n",
+       "                    \"d3-tip\": '/nbextensions/plotter_scripts/EventPlot/d3.tip.v0.6.3',\n",
+       "                    \"d3-plotter\": '/nbextensions/plotter_scripts/EventPlot/d3.min'\n",
+       "                },\n",
+       "                waitSeconds: 15,\n",
+       "                shim: {\n",
+       "                    \"d3-plotter\" : {\n",
+       "                        \"exports\" : \"d3\"\n",
+       "                    },\n",
+       "                    \"d3-tip\": [\"d3-plotter\"],\n",
+       "                    \"EventPlot\": {\n",
+       "\n",
+       "                        \"deps\": [\"d3-tip\", \"d3-plotter\" ],\n",
+       "                        \"exports\":  \"EventPlot\"\n",
+       "                    }\n",
+       "                }\n",
+       "            });\n",
+       "            /* TRAPPY_PUBLISH_REMOVE_STOP */\n",
+       "            \n",
+       "        req([\"require\", \"EventPlot\"], function() { /* TRAPPY_PUBLISH_REMOVE_LINE */\n",
+       "            EventPlot.generate('fig_e02b442c14224f68bbbc94f0db857a28', '/nbextensions/', {\"lanes\": [{\"id\": 0, \"label\": \"CPU :0\"}, {\"id\": 1, \"label\": \"CPU :1\"}, {\"id\": 2, \"label\": \"CPU :2\"}, {\"id\": 3, \"label\": \"CPU :3\"}, {\"id\": 4, \"label\": \"CPU :4\"}, {\"id\": 5, \"label\": \"CPU :5\"}], \"colorMap\": null, \"keys\": [\"task_wmig1-5556\", \"bash-5554\", \"task_wmig0-5555\", \"sshd-5560\", \"sshd-5563\", \"sshd-5557\", \"sudo-5574\", \"bash-5571\", \"bash-5533\", \"bash-5566\", \"sudo-5536\", \"sshd-5559\", \"sshd-5562\", \"sshd-5565\", \"sudo-5566\", \"sudo-5533\", \"sudo-5571\", \"sh-5539\", \"sh-5569\", \"systemd-journal-173\", \"bash-5559\", \"bash-5565\", \"bash-5562\", \"bash-5541\", \"sudo-5568\", \"sudo-5576\", \"kworker/u12:2-5564\", \"kworker/u12:2-5561\", \"kworker/u12:2-5575\", \"kworker/u12:2-5558\", \"kworker/u12:2-5534\", \"bash-5536\", \"shutils-5540\", \"busybox-5542\", \"busybox-5548\", \"kworker/u12:0-5572\", \"busybox-5550\", \"shutils-5570\", \"sudo-5535\", \"busybox-5552\", \"modprobe-5537\", \"sudo-5538\", \"shutils-5545\", \"sudo-5573\", \"shutils-5547\", \"shutils-5543\", \"shutils-5549\", \"shutils-5569\", \"sudo-5529\", \"busybox-5546\", \"busybox-5544\", \"bash-5574\", \"modprobe-5567\", \"sshd-240\", \"kworker/u12:0-5567\", \"shutils-5552\", \"sh-5577\", \"shutils-5546\", \"shutils-5548\", \"shutils-5550\", \"shutils-5553\", \"shutils-5551\", \"shutils-5544\", \"kworker/1:0-889\", \"kworker/u12:2-5537\", \"modprobe-5572\", \"sshd-5424\", \"shutils-5542\", \"shutils-5539\", \"shutils-5541\", \"rs:main Q:Reg-259\", \"sh-5531\", \"sh-5568\", \"systemd-1\", \"kworker/0:2-132\", \"jbd2/sda1-8-105\", \"sh-5538\", \"scp-5562\", \"kworker/5:0-5389\", \"scp-5565\", \"scp-5559\", \"busybox-5553\", \"bash-5426\", \"in:imuxsock-257\", \"rt-app-5554\", \"busybox-5551\", \"kworker/4:2-179\", \"kworker/3:0-1798\", \"rt-app-5555\", \"modprobe-5558\", \"ksoftirqd/0-3\", \"ksoftirqd/5-28\", \"kworker/2:1-5431\", \"usb-storage-98\", \"kworker/u12:0-5231\", \"kworker/u12:2-3631\", \"rcu_preempt-7\", \"rt-app-5556\", \"ksoftirqd/3-20\", \"rcu_sched-8\", \"kworker/0:1H-108\", \"kworker/3:1H-107\", \"ksoftirqd/1-12\", \"kworker/5:1H-159\", \"kworker/2:0-5411\"], \"stride\": false, \"showSummary\": true, \"xDomain\": [1.9000028260052204e-05, 9.0550550000043586], \"data\": {\"bash-5566\": {\"1\": [[7.4371260000043549, 7.4416020000353456]], \"2\": [[7.4366550000268035, 7.4370220000273548]]}, \"bash-5565\": {\"2\": [[7.2294070000061765, 7.2308620000258088]]}, \"bash-5562\": {\"2\": [[7.0692970000091009, 7.0707430000184104]]}, \"modprobe-5572\": {\"3\": [[8.3470439999946393, 8.347440000041388], [8.3474780000397004, 8.347492000029888]]}, \"kworker/2:0-5411\": {\"2\": [[7.8791269999928772, 7.879142000048887]]}, \"rcu_preempt-7\": {\"0\": [[7.4469730000128038, 7.4469970000209287], [7.4510529999970458, 7.4510830000508577], [7.4550380000146106, 7.4550620000227354], [7.4589400000404567, 7.458963000040967], [7.463171000010334, 7.4631940000108443], [7.4710260000429116, 7.471047000028193], [7.4750220000278205, 7.4750440000207163], [7.4790270000230521, 7.4790480000083335], [7.4830220000003465, 7.4830430000438355], [7.4870340000488795, 7.4870530000189319], [8.3430910000461154, 8.3431270000291988], [8.3469530000002123, 8.3469800000311807], [8.3510540000279434, 8.3510770000284538], [8.3549400000483729, 8.3549630000488833], [8.3592200000421144, 8.3592420000350103], [8.3670189999975264, 8.3670410000486299], [8.3710600000340492, 8.371080000011716]], \"1\": [[1.1109460000297986, 1.1109610000276007], [1.1149350000196137, 1.1149510000250302], [1.1189449999947101, 1.1189590000431053], [1.1229380000149831, 1.1229509999975562], [1.1269330000504851, 1.1269480000482872], [2.5549370000371709, 2.5549510000273585], [2.5590160000137985, 2.5590300000039861], [2.5630119999987073, 2.5630260000471026], [2.567090000025928, 2.5671060000313446], [6.787012999993749, 6.7870289999991655], [6.7911580000072718, 6.791170000040438], [6.7950300000375137, 6.7950450000353158], [6.7990260000224225, 6.7990390000049956], [6.8030090000247583, 6.8030230000149459], [6.8070140000199899, 6.8070259999949485], [6.8110070000402629, 6.8110210000304505], [6.8150150000001304, 6.8150270000332966], [6.8190180000383407, 6.8190300000132993], [6.8710270000156015, 6.8710430000210181]], \"2\": [[2.5710149999940768, 2.571029000042472], [6.5590300000039861, 6.5590470000170171], [6.5630220000166446, 6.5630360000068322], [6.5670300000347197, 6.5670440000249073], [6.5710220000473782, 6.5710340000223368], [6.5712139999959618, 6.571226000029128], [6.575094000028912, 6.5751060000038706], [6.7829400000046007, 6.7829610000480898], [7.4389460000093095, 7.4389599999994971], [7.4429430000018328, 7.4429590000072494]], \"3\": [[7.1029440000420436, 7.102963000012096], [7.1071260000462644, 7.1071450000163168], [7.1110520000220276, 7.1110710000502877], [7.1150980000384152, 7.1151170000084676], [7.1190320000168867, 7.1190519999945536], [7.1230740000028163, 7.1230930000310764], [7.1270310000400059, 7.1270510000176728], [7.131076000048779, 7.1310950000188313], [7.135043999995105, 7.1350640000309795], [7.1390750000136904, 7.1390940000419505], [7.1430750000290573, 7.1430939999991097], [7.1830180000397377, 7.1830380000174046], [7.1870160000398755, 7.1870350000099279], [7.1910050000296906, 7.1910260000149719], [7.1950130000477657, 7.1950310000102036], [7.1990030000451952, 7.1990230000228621], [7.2030120000126772, 7.2030310000409372], [7.2070030000177212, 7.2070229999953881], [7.2110129999928176, 7.2110310000134632], [7.2150020000408404, 7.2150230000261217], [7.2190130000235513, 7.2190310000441968], [7.2230020000133663, 7.2230229999986477], [7.2269550000200979, 7.2269770000129938], [7.2310259999940172, 7.2310480000451207], [7.2349560000002384, 7.2349770000437275], [7.2391030000289902, 7.2391250000218861], [7.2431460000225343, 7.2431670000078157], [7.2471390000428073, 7.2471600000280887], [7.2511450000456534, 7.2511650000233203], [7.2551370000001043, 7.2551570000359789]], \"4\": [[6.9070899999933317, 6.9071120000444353]], \"5\": [[0.0029700000304728746, 0.0029850000282749534], [0.0071940000052563846, 0.0072120000259019434], [0.011184000002685934, 0.011200000008102506], [0.015150999999605119, 0.015172000043094158], [0.019124000042211264, 0.019145000027492642], [0.023086000001057982, 0.023107000044547021], [0.41109000000869855, 0.4111269999993965], [0.41494800004875287, 0.41496800002641976], [0.41893899999558926, 0.4189600000390783], [0.42294200003379956, 0.42296100000385195], [0.42715900001348928, 0.42717999999877065], [0.43116199999349192, 0.43118400004459545], [0.43516700004693121, 0.43518900003982708], [0.43914800003403798, 0.43916800001170486], [0.44319300004281104, 0.44321500003570691], [0.44713000004412606, 0.44714900001417845], [1.1351550000254065, 1.1351920000161044], [1.1430140000302345, 1.1430360000231303], [1.1470090000075288, 1.1470310000004247], [1.1512180000427179, 1.1512380000203848], [1.1552090000477619, 1.1552310000406578], [1.1591290000360459, 1.1591469999984838], [2.015027999994345, 2.0150500000454485], [2.0191300000296906, 2.0191530000302009], [2.0229399999952875, 2.0229629999957979], [2.0269470000057481, 2.0269720000214875], [2.0309530000085942, 2.0309750000014901], [2.0349540000315756, 2.0349810000043362], [2.0389370000339113, 2.0389590000268072], [2.0429410000215285, 2.0429600000497885], [2.0472450000233948, 2.0472670000162907], [2.0512150000431575, 2.0512380000436679], [2.0552110000280663, 2.0552330000209622], [2.0591620000195689, 2.0591830000048503], [2.0631569999968633, 2.0631770000327379], [2.4470920000458136, 2.4471280000288971], [2.4511000000056811, 2.4511230000061914], [2.4550370000069961, 2.4550570000428706], [2.4590840000309981, 2.4591030000010505], [2.4630140000372194, 2.4630319999996573], [6.5792350000119768, 6.5792709999950603], [6.5830390000483021, 6.58305700001074], [6.7510220000403933, 6.7510460000485182], [6.7551740000490099, 6.7551960000419058], [6.7590130000025965, 6.7590310000232421], [6.775076000019908, 6.7751100000459701], [6.7791040000156499, 6.7791250000009313], [6.8790359999984503, 6.8790620000218041], [6.8830310000339523, 6.8830530000268482], [6.8870180000085384, 6.8870370000367984], [6.8910010000108741, 6.8910210000467487], [6.8950100000365637, 6.8950290000066161], [6.8990000000339933, 6.8990210000192747], [6.9029590000282042, 6.9029800000134856], [6.910950000048615, 6.9109720000415109], [6.9149390000384301, 6.9149650000035763], [6.9190170000074431, 6.919039000000339], [6.9230460000107996, 6.923066999996081], [6.9271189999999478, 6.9271390000358224], [6.9310220000334084, 6.9310410000034608], [6.9350420000264421, 6.9350630000117235], [6.938945000001695, 6.9389640000299551], [6.9430300000240095, 6.9430510000092909], [6.9471230000490323, 6.9471420000190847], [6.9510299999965355, 6.9510510000400245], [6.9550860000308603, 6.9551050000009127], [6.9590310000348836, 6.959052000020165], [6.9630130000296049, 6.9630330000072718], [6.9670060000498779, 6.9670260000275448], [6.9710150000173599, 6.9710340000456199], [6.9750110000022687, 6.9750310000381432], [6.97901200002525, 6.9790300000458956], [7.0270210000453517, 7.0270430000382476], [7.0310129999998026, 7.0310320000280626], [7.0350000000325963, 7.0350210000178777], [7.0390100000076927, 7.0390280000283383], [7.0429989999975078, 7.0430180000257678], [7.0470119999954477, 7.0470310000237077], [7.0510110000032, 7.0510290000238456], [7.0549999999930151, 7.0550220000441186], [7.0590100000263192, 7.0590289999963716], [7.0630000000237487, 7.0630200000014156], [7.0670240000472404, 7.0670460000401363], [7.0710860000108369, 7.0711080000037327], [7.0750150000094436, 7.0750390000175685], [7.0791400000452995, 7.0791610000305809], [7.0831420000176877, 7.0831630000029691], [7.0871840000036173, 7.0872059999965131], [7.0911800000467338, 7.0911990000167862], [7.0950639999937266, 7.0950860000448301], [7.0989430000190623, 7.0989640000043437], [8.3751679999986663, 8.3751890000421554], [8.3791889999993145, 8.3792090000351891], [8.3831800000043586, 8.383203000004869], [8.3871340000187047, 8.3871530000469647], [9.0430860000196844, 9.0431209999951534], [9.0509380000294186, 9.0509620000375435], [9.0549580000224523, 9.0549840000458062]]}, \"shutils-5569\": {\"4\": [[7.4532100000069477, 7.4539360000053421]]}, \"kworker/u12:2-5564\": {\"2\": [[7.0980360000394285, 7.0980700000072829]], \"3\": [[7.0981580000370741, 7.1000080000376329]]}, \"kworker/u12:2-5561\": {\"2\": [[6.9356460000271909, 6.9356790000456385]], \"3\": [[6.9357760000275448, 6.9376260000281036]]}, \"systemd-journal-173\": {\"4\": [[0.00082300003850832582, 0.00092900003073737025], [0.0010400000028312206, 0.0017630000365898013], [0.41658100002678111, 0.4183020000346005], [0.41953300003660843, 0.42022200004430488], [1.1182140000164509, 1.118337000021711], [1.1184370000264607, 1.1194230000255629], [1.1194700000341982, 1.1201870000222698], [1.1266390000237152, 1.1274950000224635], [6.9012490000459366, 6.9023370000068098], [6.9103950000135228, 6.9112310000346042], [7.0644660000107251, 7.0654320000321604], [7.0733820000314154, 7.0741320000379346], [7.2242680000490509, 7.2252490000100806], [7.2330490000313148, 7.2338030000100844], [7.445921000035014, 7.4476680000079796], [7.4545849999994971, 7.4554639999987558], [8.3494230000069365, 8.349532000022009], [8.3497540000244044, 8.3506590000470169], [8.3507940000272356, 8.35157200001413], [8.3526249999995343, 8.3526859999983571], [8.3528060000389814, 8.3534320000326261], [9.0510320000466891, 9.052765000029467]]}, \"kworker/0:2-132\": {\"0\": [[0.19114800001261756, 0.19125800003530458], [6.7471260000020266, 6.7473520000348799], [9.0271020000218414, 9.0271829999983311]]}, \"sshd-5562\": {\"1\": [[7.066672999993898, 7.0692050000070594]], \"2\": [[7.0657150000333786, 7.0665720000397414]]}, \"sshd-5563\": {\"0\": [[7.1792800000403076, 7.179448000038974], [7.182715000002645, 7.2032619999954477], [7.2036010000156239, 7.2041210000170395], [7.2043500000145286, 7.2045630000066012], [7.2049490000354126, 7.2243290000478737], [7.2244920000084676, 7.2245600000023842], [7.2252300000400282, 7.22607000003336], [7.2262240000418387, 7.2263080000411719], [7.2308600000105798, 7.2309410000452772]], \"1\": [[7.0920900000492111, 7.0978220000397414], [7.1001760000362992, 7.1102210000390187], [7.1120000000228174, 7.1350320000201464], [7.1429350000107661, 7.1430120000150055], [7.2249050000100397, 7.2250099999946542], [7.2311329999938607, 7.2311869999975897], [7.2314420000184327, 7.2315130000351928], [7.2316210000426508, 7.2318400000222027], [7.2321890000021085, 7.2322339999955148], [7.2323880000039935, 7.2325650000129826], [7.2328350000316277, 7.2335660000098869]], \"2\": [[7.0916710000019521, 7.0919970000395551]]}, \"sshd-5560\": {\"0\": [[7.0192740000202321, 7.0194480000063777], [7.0229440000257455, 7.0434470000327565], [7.0438120000180788, 7.0443300000042655], [7.0445889999973588, 7.0448010000400245], [7.0451690000481904, 7.0645280000171624], [7.0646950000082143, 7.064832000003662], [7.0650060000480153, 7.0658549999934621], [7.0659779999987222, 7.0660610000486486], [7.0707399999955669, 7.0708380000432953], [7.0711299999966286, 7.0712120000389405]], \"1\": [[6.9295970000093803, 6.9354320000275038], [6.9377160000149161, 6.9479300000239164], [6.949659000034444, 6.9496849999995902], [6.9497440000413917, 6.9728549999999814], [6.9812360000214539, 6.9813130000256933], [7.0713960000430234, 7.0720300000393763], [7.072615000011865, 7.0726670000003651], [7.0728210000088438, 7.0730390000389889], [7.0731650000088848, 7.0738860000274144]], \"2\": [[6.9291500000399537, 6.9295010000350885]]}, \"modprobe-5567\": {\"2\": [[7.4431820000172593, 7.4438360000494868]]}, \"sshd-5565\": {\"1\": [[7.2269030000315979, 7.2293139999965206]], \"2\": [[7.2259330000379123, 7.2268030000268482]]}, \"sudo-5566\": {\"1\": [[7.4440450000111014, 7.446968000032939], [7.4479510000091977, 7.4479730000020936], [7.4542910000309348, 7.4552740000071935]]}, \"sudo-5568\": {\"2\": [[7.4468610000330955, 7.447202000010293]], \"3\": [[7.4472260000184178, 7.4490300000179559]]}, \"trace-cmd-5577\": {\"4\": [[9.0550550000043586, 9.0550550000043586]]}, \"sh-5569\": {\"2\": [[7.4490460000233725, 7.4491480000433512]], \"5\": [[7.4492380000301637, 7.4515840000240132]]}, \"sh-5568\": {\"3\": [[7.4539980000117794, 7.4542230000370182]]}, \"sshd-5559\": {\"1\": [[6.9035080000176094, 6.9060340000432916]], \"2\": [[6.9025300000212155, 6.9034080000128597]]}, \"sshd-5557\": {\"0\": [[6.8669150000205263, 6.8710530000389554], [6.8805719999945723, 6.881124000006821], [6.8813570000347681, 6.8815659999963827], [6.8819590000202879, 6.9013440000126138], [6.9015090000466444, 6.9016479999991134], [6.901824000000488, 6.9026860000449233], [6.9029050000244752, 6.9030680000432767], [6.9076240000431426, 6.9077230000402778], [6.9079960000235587, 6.9080800000228919], [6.9081120000337251, 6.9089000000385568], [6.9094710000208579, 6.9095430000452325], [6.9096910000080243, 6.909973000001628], [6.9101660000160336, 6.9115560000063851]], \"1\": [[6.7743740000296384, 6.7747480000252835], [6.8712190000223927, 6.8802180000348017]], \"2\": [[6.7748780000256374, 6.7789510000147857], [6.7789770000381395, 6.7807290000491776], [6.7833720000344329, 6.793552000017371], [6.795393000007607, 6.8184040000196546], [6.8261270000366494, 6.8261700000148267], [6.8633799999952316, 6.8634560000500642]]}, \"bash-5426\": {\"0\": [[0.35647900000913069, 0.35654400003841147], [0.35668300004908815, 0.3567200000397861], [0.35685400001239032, 0.35688700003083795], [0.35701300000073388, 0.35704600001918152], [0.35714400000870228, 0.35717700002714992], [0.35731900000246242, 0.35735200002091005], [0.35747800004901364, 0.35751000000163913], [0.35760899999877438, 0.35764300002483651], [0.35778500000014901, 0.35781800001859665], [0.35791600000811741, 0.35797700000694022], [0.35807600000407547, 0.35810900002252311], [0.3582350000506267, 0.35826900001848117], [0.35836800001561642, 0.35840100003406405], [0.35854300000937656, 0.35857700003543869], [0.35867400001734495, 0.35873600002378225], [0.35883400001330301, 0.35886800003936514], [0.35907000000588596, 0.35910400003194809], [0.35922800004482269, 0.35926200001267716], [0.35935899999458343, 0.35939200001303107], [0.35951800004113466, 0.35955300001660362], [0.35964999999850988, 0.35971500002779067], [0.35984799999278039, 0.35988300002645701], [0.36000800004694611, 0.36004200001480058], [0.36014000000432134, 0.36020100000314415], [0.36029900005087256, 0.36033300001872703], [0.36045900004683062, 0.36049400002229959], [0.36059300001943484, 0.36062700004549697], [0.36075400002300739, 0.36078899999847636], [0.36091500002657995, 0.36095000000204891], [0.36104800004977733, 0.3610820000176318], [0.36120800004573539, 0.36124400002881885], [0.3613420000183396, 0.36140600004000589], [0.36150400002952665, 0.36153900000499561], [0.3616650000330992, 0.36170000000856817], [0.36179799999808893, 0.36183300003176555], [0.36195900000166148, 0.3619950000429526], [0.36209300003247336, 0.36215800000354648], [0.36225700000068173, 0.36229300004197285], [0.36241800000425428, 0.3624540000455454], [0.36255100002745166, 0.36258600000292063], [0.36271200003102422, 0.36275000002933666], [0.36287599999923259, 0.36291200004052371], [0.36302800005069003, 0.36306500004138798], [0.3631910000112839, 0.36322800000198185], [0.36332600004971027, 0.36339200002839789], [0.36349100002553314, 0.3635270000086166], [0.36365300003672019, 0.36369000002741814], [0.3637870000093244, 0.36385200003860518], [0.36395000002812594, 0.36398700001882389], [0.36408500000834465, 0.36415000003762543], [0.36425000004237518, 0.36428600002545863], [0.36430400004610419, 0.36436800000956282], [0.36446200002683327, 0.36450000002514571], [0.36465800000587478, 0.36469600000418723], [0.36471400002483279, 0.36474900000030175], [0.3647620000410825, 0.36482100002467632], [0.36483500001486391, 0.36487099999794737], [0.3649660000228323, 0.36500400002114475], [0.36502200004179031, 0.36505600000964478], [0.3650970000308007, 0.36513200000626966], [0.3652280000387691, 0.36526700004469603], [0.36528500000713393, 0.36534800002118573], [0.36544200003845617, 0.36548100004438311], [0.36560600000666454, 0.36564400000497699], [0.36566200002562255, 0.36569700000109151], [0.36571000004187226, 0.36574500001734123], [0.36575700005050749, 0.36582000000635162], [0.36591500003123656, 0.3659540000371635], [0.36608100001467392, 0.36612000002060086], [0.36613800004124641, 0.36617400002432987], [0.36618700000690296, 0.36622200004057959], [0.3663440000382252, 0.36638399999355897], [0.36640100000659004, 0.36643700004788116], [0.36645000003045425, 0.3664860000135377], [0.36660800001118332, 0.36664900003233925], [0.36666699999477714, 0.36670400004368275], [0.36671600001864135, 0.36675200000172481], [0.36687300004996359, 0.36691400001291186], [0.36694800003897399, 0.36698600003728643], [0.36699900001985952, 0.3670640000491403], [0.36716100003104657, 0.36720400000922382], [0.36722200002986938, 0.36726000002818182], [0.36738000001059845, 0.36742100003175437], [0.36743800004478544, 0.36747600004309788], [0.36759500001790002, 0.36763600003905594], [0.36765400000149384, 0.36769100005039945], [0.36770300002535805, 0.367740000016056], [0.36786200001370162, 0.36790400004247203], [0.36792099999729544, 0.36793700000271201], [0.40648400003556162, 0.40652700001373887], [0.40653999999631196, 0.4074970000074245], [1.0581180000444874, 1.0581810000003316], [1.0583200000110082, 1.0583580000093207], [1.0583750000223517, 1.0584050000179559], [1.058418000000529, 1.0584460000391118], [1.0584580000140704, 1.0584859999944456], [1.0585850000497885, 1.0586180000100285], [1.058671000006143, 1.0587020000093617], [1.0587150000501424, 1.0587430000305176], [1.0588379999971949, 1.0588710000156425], [1.0588880000286736, 1.0589170000166632], [1.058978000015486, 1.0590080000110902], [1.0591060000006109, 1.0591390000190586], [1.0591560000320897, 1.0592150000156835], [1.0593100000405684, 1.0593440000084229], [1.0593610000214539, 1.0593910000170581], [1.0594840000267141, 1.0595179999945685], [1.0595350000075996, 1.0595650000032037], [1.0595780000439845, 1.0596080000395887], [1.0597340000094846, 1.0597680000355467], [1.0597859999979846, 1.0598159999935888], [1.0598290000343695, 1.0598590000299737], [1.0598720000125468, 1.0599010000005364], [1.0599970000330359, 1.0600310000008903], [1.0600490000215359, 1.0600800000247546], [1.0600940000149421, 1.0601230000029318], [1.0602470000158064, 1.0602810000418685], [1.0602979999966919, 1.0603300000075251], [1.0603430000483058, 1.06037300004391], [1.0604850000236183, 1.0605190000496805], [1.0605370000121184, 1.060568000015337], [1.0605809999979101, 1.0606410000473261], [1.0606540000298992, 1.0606870000483468], [1.0607820000150241, 1.0608179999981076], [1.0608350000111386, 1.0608670000219718], [1.0609590000240132, 1.0609950000070967], [1.0610120000201277, 1.0610440000309609], [1.061057000013534, 1.0610890000243671], [1.0612120000296272, 1.0612480000127107], [1.0612650000257418, 1.0612980000441894], [1.0613110000267625, 1.0613420000299811], [1.0614369999966584, 1.061474000045564], [1.0614920000080019, 1.0615240000188351], [1.0615370000014082, 1.0615690000122413], [1.0616940000327304, 1.0617310000234284], [1.0617490000440739, 1.0617809999966994], [1.0617940000374801, 1.0618269999977201], [1.0619210000149906, 1.0619580000056885], [1.0619760000263341, 1.0620090000447817], [1.0620220000273548, 1.062054000038188], [1.0621790000004694, 1.062216000049375], [1.0622340000118129, 1.062268000037875], [1.0622800000128336, 1.0623130000312813], [1.062409000005573, 1.062445999996271], [1.0624640000169165, 1.0624980000429787], [1.0625100000179373, 1.0625430000363849], [1.0626679999986663, 1.0627059999969788], [1.0627240000176243, 1.0627580000436865], [1.0627710000262596, 1.0628040000447072], [1.062900000018999, 1.062954000022728], [1.0629729999927804, 1.063008000026457], [1.0631300000241026, 1.0631700000376441], [1.063188000000082, 1.0632240000413731], [1.0632370000239462, 1.0632710000500083], [1.0633670000243001, 1.0634050000226125], [1.0634220000356436, 1.0634570000111125], [1.0634690000442788, 1.0635030000121333], [1.0636270000250079, 1.0636660000309348], [1.0636839999933727, 1.0637200000346638], [1.0637330000172369, 1.0637680000509135], [1.0638630000175908, 1.0639020000235178], [1.0639200000441633, 1.0639560000272468], [1.0640490000369027, 1.0641180000384338], [1.0641360000008717, 1.0641720000421628], [1.0642660000012256, 1.0643070000223815], [1.0643240000354126, 1.0643600000184961], [1.064453000028152, 1.064492000034079], [1.0645099999965169, 1.0645770000410266], [1.0646710000000894, 1.0647110000136308], [1.0648090000031516, 1.064849000016693], [1.0648670000373386, 1.0649040000280365], [1.0650599999935366, 1.065102000022307], [1.0651200000429526, 1.0651570000336505], [1.0651700000162236, 1.0652070000069216], [1.0652190000400878, 1.0652550000231713], [1.0653509999974631, 1.065392000018619], [1.0654090000316501, 1.0654260000446811], [1.1081260000355542, 1.1081690000137314], [1.1081819999963045, 1.1091110000270419], [1.1273750000400469, 1.1277240000199527], [1.7592900000163354, 1.7593350000097416], [1.7594590000226162, 1.7594960000133142], [1.7596350000239909, 1.7596680000424385], [1.7597960000275634, 1.7598290000460111], [1.7599280000431463, 1.7599599999957718], [1.7601040000445209, 1.7601370000047609], [1.76026200002525, 1.7602959999931045], [1.7603940000408329, 1.7604170000413433], [1.8093900000094436, 1.8094170000404119], [1.809430000022985, 1.809724000049755], [1.8098360000294633, 1.8099760000477545], [1.810081000032369, 1.8101040000328794], [1.9615130000165664, 1.961546000035014], [1.9616470000473782, 1.9616800000076182], [1.9618060000357218, 1.9618389999959618], [1.9619650000240654, 1.961998000042513], [1.9620149999973364, 1.9620440000435337], [1.9620570000261068, 1.962085000006482], [1.9622090000193566, 1.9622420000378042], [1.9622600000002421, 1.9622890000464395], [1.9623020000290126, 1.9623300000093877], [1.962342000042554, 1.9623710000305437], [1.9624940000358038, 1.9625269999960437], [1.9625450000166893, 1.9625750000122935], [1.9625870000454597, 1.9626160000334494], [1.9626290000160225, 1.962684000027366], [1.9627810000092722, 1.962827000010293], [1.9628450000309385, 1.9628750000265427], [1.962991000036709, 1.9630250000045635], [1.963043000025209, 1.9631030000164174], [1.9631159999989904, 1.9631459999945946], [1.963244000042323, 1.9632780000101775], [1.9632950000232086, 1.9633260000264272], [1.9633390000090003, 1.9633690000046045], [1.9634920000098646, 1.9635270000435412], [1.9635450000059791, 1.9635760000091977], [1.9635890000499785, 1.9636180000379682], [1.9637420000508428, 1.9637760000186972], [1.9637940000393428, 1.9638250000425614], [1.96383700001752, 1.9638670000131242], [1.9638799999956973, 1.9639380000298843], [1.9640340000041761, 1.9640690000378527], [1.9640870000002906, 1.9641180000035092], [1.964237000036519, 1.964272000011988], [1.9642900000326335, 1.9643220000434667], [1.9643350000260398, 1.9643650000216439], [1.964488000026904, 1.9645240000099875], [1.9645410000230186, 1.9645730000338517], [1.9645860000164248, 1.9646170000196435], [1.9647400000249036, 1.9647770000156015], [1.9647950000362471, 1.9648279999964871], [1.9648410000372678, 1.9648990000132471], [1.9649940000381321, 1.96503100002883], [1.9651560000493191, 1.9651930000400171], [1.965211000002455, 1.9652440000209026], [1.9652570000034757, 1.9652890000143088], [1.9653019999968819, 1.9653340000077151], [1.9654560000053607, 1.9654920000466518], [1.9655100000090897, 1.9655430000275373], [1.9655550000024959, 1.9655870000133291], [1.9657100000185892, 1.9657470000092871], [1.9657640000223182, 1.9657980000483803], [1.9658120000385679, 1.9658710000221618], [1.9658850000123493, 1.965920000046026], [1.9660150000127032, 1.9660530000110157], [1.9660710000316612, 1.9661310000228696], [1.96622500004014, 1.9662630000384524], [1.9662799999932759, 1.9663150000269525], [1.9664680000278167, 1.9665060000261292], [1.9665240000467747, 1.9665580000146292], [1.9665709999972023, 1.9666330000036396], [1.9666460000444204, 1.9666800000122748], [1.9667750000371598, 1.9668140000430867], [1.9668590000364929, 1.9668750000419095], [2.0115959999966435, 2.0116210000123829], [2.0116330000455491, 2.0123350000358187], [2.0355620000045747, 2.0358650000416674], [2.1879970000009052, 2.1882140000234358], [2.23811299999943, 2.2386870000045747], [2.394116000039503, 2.395758000027854], [2.444171000039205, 2.4451120000449009], [7.4358000000356697, 7.4367250000359491], [8.3393459999933839, 8.3401840000296943], [8.3532640000339597, 8.3536090000416152]], \"1\": [[0.0014610000071115792, 0.0016870000399649143], [0.15424300002632663, 0.15435700002126396], [0.20433999999659136, 0.2046330000157468], [6.5555129999993369, 6.5556990000186488], [6.7076550000347197, 6.7077360000112094], [6.7576930000213906, 6.7579100000439212], [7.3857350000180304, 7.3868320000474341]], \"2\": [[0.42016800004057586, 0.42039300000760704], [7.4553440000163391, 7.4555680000339635], [8.0869970000348985, 8.087085000006482], [8.1370890000252984, 8.1373130000429228], [8.2892770000034943, 8.2902300000423566]], \"3\": [[8.9908380000269972, 8.9909050000132993], [8.9909680000273511, 8.9910140000283718], [8.9910280000185594, 8.9910660000168718], [8.9911010000505485, 8.9911390000488609], [8.9911510000238195, 8.9911890000221319], [8.9912030000123195, 8.9912400000030175], [8.9912810000241734, 8.9913190000224859], [8.9913309999974445, 8.9913689999957569], [8.9914080000016838, 8.9914470000076108], [8.991459000040777, 8.9914970000390895], [8.9915090000140481, 8.9915470000123605], [8.9915890000411309, 8.9916270000394434], [8.9916400000220165, 8.9916780000203289], [8.9916899999952875, 8.9917279999936], [8.9917400000267662, 8.9917780000250787], [8.9917900000000373, 8.9918279999983497], [8.9918410000391304, 8.9918790000374429], [8.9918910000124015, 8.9919300000183284], [8.9919430000009015, 8.991980999999214], [8.9919930000323802, 8.9920310000306927], [8.9920430000056513, 8.9920830000191927], [8.9920949999941513, 8.9921340000000782], [8.992147000040859, 8.9921850000391714], [8.99219700001413, 8.992236000020057], [8.9922490000026301, 8.9922890000161715], [8.9923010000493377, 8.992339999997057], [8.9923830000334419, 8.9924230000469834], [8.992435000021942, 8.9924740000278689], [8.9924860000028275, 8.9925260000163689], [8.9925380000495352, 8.992578000004869], [8.9925910000456497, 8.9926310000009835], [8.9926430000341497, 8.9926820000400767], [8.9926940000150353, 8.9927340000285767], [8.9927460000035353, 8.9927860000170767], [8.9927989999996498, 8.9928380000055768], [8.9928510000463575, 8.9928910000016913], [8.9929030000348575, 8.9929439999978058], [8.9929560000309721, 8.9929960000445135], [8.9930090000270866, 8.993049000040628], [8.993084000016097, 8.9931250000372529], [8.9931370000122115, 8.9931790000409819], [8.993192000023555, 8.9932330000447109], [8.9932450000196695, 8.9932860000408255], [8.9932990000233985, 8.9933409999939613], [8.9933530000271276, 8.9933949999976903], [8.9934060000232421, 8.9934479999938048], [8.9934600000269711, 8.9935019999975339], [8.9935140000307001, 8.9935560000012629], [8.9935680000344291, 8.9936100000049919], [8.9936220000381581, 8.9936640000087209], [8.9937050000298768, 8.9937480000080541], [8.9937610000488348, 8.9938030000193976], [8.9938149999943562, 8.9938570000231266], [8.9938689999980852, 8.9939110000268556], [8.9939440000453033, 8.993986000015866], [8.9939989999984391, 8.9940430000424385], [8.9940530000021681, 8.9940950000309385], [8.9941070000058971, 8.994150000042282], [8.9941620000172406, 8.9942040000460111], [8.9942160000209697, 8.9942589999991469], [8.9942710000323132, 8.9943630000343546]], \"5\": [[9.041006000014022, 9.0410550000378862], [9.0410850000334904, 9.0419410000322387]]}, \"modprobe-5558\": {\"1\": [[6.7831100000184961, 6.7831810000352561]]}, \"kworker/3:1H-107\": {\"3\": [[5.7713630000362173, 5.7713850000291131]]}, \"kworker/u12:2-3631\": {\"0\": [[0.35642600001301616, 0.35647900000913069], [0.35654400003841147, 0.35656200000084937], [0.3567200000397861, 0.356738000002224], [0.35688700003083795, 0.35690600000089034], [0.35704600001918152, 0.35706400003982708], [0.35717700002714992, 0.35723900003358722], [0.35735200002091005, 0.35737000004155561], [0.35751000000163913, 0.35752900002989918], [0.35764300002483651, 0.35766000003786758], [0.35781800001859665, 0.35783600003924221], [0.35797700000694022, 0.35799600003520027], [0.35810900002252311, 0.35812600003555417], [0.35826900001848117, 0.35828800004674122], [0.35840100003406405, 0.35841899999650195], [0.35857700003543869, 0.35859400004846975], [0.35873600002378225, 0.35875400004442781], [0.35886800003936514, 0.35888600000180304], [0.35910400003194809, 0.35912100004497916], [0.35926200001267716, 0.35927900002570823], [0.35939200001303107, 0.35941000003367662], [0.35955300001660362, 0.35957000002963468], [0.35971500002779067, 0.35973399999784306], [0.35988300002645701, 0.35990000003948808], [0.36004200001480058, 0.36006000003544614], [0.36020100000314415, 0.3602190000237897], [0.36033300001872703, 0.36035100003937259], [0.36049400002229959, 0.36051300005055964], [0.36062700004549697, 0.36067399999592453], [0.36078899999847636, 0.36080600001150742], [0.36095000000204891, 0.36096800002269447], [0.3610820000176318, 0.36110000003827736], [0.36124400002881885, 0.36126299999887124], [0.36140600004000589, 0.36142400000244379], [0.36153900000499561, 0.36155700002564117], [0.36170000000856817, 0.36171800002921373], [0.36183300003176555, 0.36185099999420345], [0.3619950000429526, 0.3620130000053905], [0.36215800000354648, 0.36217600002419204], [0.36229300004197285, 0.36230999999679625], [0.3624540000455454, 0.3624720000079833], [0.36258600000292063, 0.36263300001155585], [0.36275000002933666, 0.36276800004998222], [0.36291200004052371, 0.36294600000837818], [0.36306500004138798, 0.3631110000424087], [0.36322800000198185, 0.36324600002262741], [0.36339200002839789, 0.36341000004904345], [0.3635270000086166, 0.36354500002926216], [0.36369000002741814, 0.3637080000480637], [0.36385200003860518, 0.36387000000104308], [0.36398700001882389, 0.36400500003946945], [0.36415000003762543, 0.36416800000006333], [0.36428600002545863, 0.36430400004610419], [0.36436800000956282, 0.36438199999975041], [0.36450000002514571, 0.36451800004579127], [0.36469600000418723, 0.36471400002483279], [0.36474900000030175, 0.3647620000410825], [0.36482100002467632, 0.36483500001486391], [0.36487099999794737, 0.36488400003872812], [0.36500400002114475, 0.36502200004179031], [0.36505600000964478, 0.3650970000308007], [0.36513200000626966, 0.36514599999645725], [0.36526700004469603, 0.36528500000713393], [0.36534800002118573, 0.36536100000375882], [0.36548100004438311, 0.36549799999920651], [0.36564400000497699, 0.36566200002562255], [0.36569700000109151, 0.36571000004187226], [0.36574500001734123, 0.36575700005050749], [0.36582000000635162, 0.36583300004713237], [0.3659540000371635, 0.36597199999960139], [0.36612000002060086, 0.36613800004124641], [0.36617400002432987, 0.36618700000690296], [0.36622200004057959, 0.36623500002315268], [0.36638399999355897, 0.36640100000659004], [0.36643700004788116, 0.36645000003045425], [0.3664860000135377, 0.36649800004670396], [0.36664900003233925, 0.36666699999477714], [0.36670400004368275, 0.36671600001864135], [0.36675200000172481, 0.36676400003489107], [0.36691400001291186, 0.36694800003897399], [0.36698600003728643, 0.36699900001985952], [0.3670640000491403, 0.3670770000317134], [0.36720400000922382, 0.36722200002986938], [0.36726000002818182, 0.36730000004172325], [0.36742100003175437, 0.36743800004478544], [0.36747600004309788, 0.36748900002567098], [0.36763600003905594, 0.36765400000149384], [0.36769100005039945, 0.36770300002535805], [0.367740000016056, 0.36775299999862909], [0.36790400004247203, 0.36792099999729544], [0.406449000001885, 0.40648400003556162], [0.40652700001373887, 0.40653999999631196], [0.41249000001698732, 0.41259700001683086], [1.0580310000223108, 1.0580880000488833], [1.0581810000003316, 1.0582000000285916], [1.0583580000093207, 1.0583750000223517], [1.0584050000179559, 1.058418000000529], [1.0584460000391118, 1.0584580000140704], [1.0584859999944456, 1.0584990000352263], [1.0586180000100285, 1.058671000006143], [1.0587020000093617, 1.0587150000501424], [1.0587430000305176, 1.0587560000130907], [1.0588710000156425, 1.0588880000286736], [1.0589170000166632, 1.058978000015486], [1.0590080000110902, 1.0590209999936633], [1.0591390000190586, 1.0591560000320897], [1.0592150000156835, 1.0592290000058711], [1.0593440000084229, 1.0593610000214539], [1.0593910000170581, 1.0594039999996312], [1.0595179999945685, 1.0595350000075996], [1.0595650000032037, 1.0595780000439845], [1.0596080000395887, 1.0596200000145473], [1.0597680000355467, 1.0597859999979846], [1.0598159999935888, 1.0598290000343695], [1.0598590000299737, 1.0598720000125468], [1.0599010000005364, 1.0599130000337027], [1.0600310000008903, 1.0600490000215359], [1.0600800000247546, 1.0600940000149421], [1.0601230000029318, 1.0601360000437126], [1.0602810000418685, 1.0602979999966919], [1.0603300000075251, 1.0603430000483058], [1.06037300004391, 1.0603860000264831], [1.0605190000496805, 1.0605370000121184], [1.060568000015337, 1.0605809999979101], [1.0606410000473261, 1.0606540000298992], [1.0606870000483468, 1.0606990000233054], [1.0608179999981076, 1.0608350000111386], [1.0608670000219718, 1.0608800000045449], [1.0609950000070967, 1.0610120000201277], [1.0610440000309609, 1.061057000013534], [1.0610890000243671, 1.0611009999993257], [1.0612480000127107, 1.0612650000257418], [1.0612980000441894, 1.0613110000267625], [1.0613420000299811, 1.0613540000049397], [1.061474000045564, 1.0614920000080019], [1.0615240000188351, 1.0615370000014082], [1.0615690000122413, 1.0615819999948144], [1.0617310000234284, 1.0617490000440739], [1.0617809999966994, 1.0617940000374801], [1.0618269999977201, 1.0618390000308864], [1.0619580000056885, 1.0619760000263341], [1.0620090000447817, 1.0620220000273548], [1.062054000038188, 1.062067000020761], [1.062216000049375, 1.0622340000118129], [1.062268000037875, 1.0622800000128336], [1.0623130000312813, 1.0623250000062399], [1.062445999996271, 1.0624640000169165], [1.0624980000429787, 1.0625100000179373], [1.0625430000363849, 1.062556000018958], [1.0627059999969788, 1.0627240000176243], [1.0627580000436865, 1.0627710000262596], [1.0628040000447072, 1.0628170000272803], [1.062954000022728, 1.0629729999927804], [1.063008000026457, 1.0630200000014156], [1.0631700000376441, 1.063188000000082], [1.0632240000413731, 1.0632370000239462], [1.0632710000500083, 1.0632830000249669], [1.0634050000226125, 1.0634220000356436], [1.0634570000111125, 1.0634690000442788], [1.0635030000121333, 1.0635159999947064], [1.0636660000309348, 1.0636839999933727], [1.0637200000346638, 1.0637330000172369], [1.0637680000509135, 1.0637800000258721], [1.0639020000235178, 1.0639200000441633], [1.0639560000272468, 1.0639680000022054], [1.0641180000384338, 1.0641360000008717], [1.0641720000421628, 1.0641850000247359], [1.0643070000223815, 1.0643240000354126], [1.0643600000184961, 1.0643730000010692], [1.064492000034079, 1.0645099999965169], [1.0645770000410266, 1.0645900000235997], [1.0647110000136308, 1.0647290000342764], [1.064849000016693, 1.0648670000373386], [1.0649040000280365, 1.0649170000106096], [1.065102000022307, 1.0651200000429526], [1.0651570000336505, 1.0651700000162236], [1.0652070000069216, 1.0652190000400878], [1.0652550000231713, 1.0652680000057444], [1.065392000018619, 1.0654090000316501], [1.1080899999942631, 1.1081260000355542], [1.1081690000137314, 1.1081819999963045], [1.1141870000283234, 1.1143040000461042], [1.1162400000030175, 1.1163079999969341], [1.7592390000354499, 1.7592639999929816], [1.7593350000097416, 1.7593530000303872], [1.7594960000133142, 1.7595140000339597], [1.7596680000424385, 1.7596860000048764], [1.7598290000460111, 1.759847000008449], [1.7599599999957718, 1.7600240000174381], [1.7601370000047609, 1.7601550000254065], [1.7602959999931045, 1.7603130000061356], [1.8093700000317767, 1.8093900000094436], [1.8094170000404119, 1.809430000022985], [1.809724000049755, 1.8097380000399426], [1.8099760000477545, 1.8099960000254214], [1.9614660000079311, 1.9614890000084415], [1.961546000035014, 1.9615639999974519], [1.9616800000076182, 1.9616980000282638], [1.9618389999959618, 1.9618570000166073], [1.961998000042513, 1.9620149999973364], [1.9620440000435337, 1.9620570000261068], [1.962085000006482, 1.9620970000396483], [1.9622420000378042, 1.9622600000002421], [1.9622890000464395, 1.9623020000290126], [1.9623300000093877, 1.962342000042554], [1.9623710000305437, 1.9623830000055023], [1.9625269999960437, 1.9625450000166893], [1.9625750000122935, 1.9625870000454597], [1.9626160000334494, 1.9626290000160225], [1.962684000027366, 1.9626980000175536], [1.962827000010293, 1.9628450000309385], [1.9628750000265427, 1.9628870000015013], [1.9630250000045635, 1.963043000025209], [1.9631030000164174, 1.9631159999989904], [1.9631459999945946, 1.9631600000429899], [1.9632780000101775, 1.9632950000232086], [1.9633260000264272, 1.9633390000090003], [1.9633690000046045, 1.9633820000453852], [1.9635270000435412, 1.9635450000059791], [1.9635760000091977, 1.9635890000499785], [1.9636180000379682, 1.9636300000129268], [1.9637760000186972, 1.9637940000393428], [1.9638250000425614, 1.96383700001752], [1.9638670000131242, 1.9638799999956973], [1.9639380000298843, 1.9639510000124574], [1.9640690000378527, 1.9640870000002906], [1.9641180000035092, 1.9641300000366755], [1.964272000011988, 1.9642900000326335], [1.9643220000434667, 1.9643350000260398], [1.9643650000216439, 1.9644050000351854], [1.9645240000099875, 1.9645410000230186], [1.9645730000338517, 1.9645860000164248], [1.9646170000196435, 1.9646570000331849], [1.9647770000156015, 1.9647950000362471], [1.9648279999964871, 1.9648410000372678], [1.9648990000132471, 1.9649119999958202], [1.96503100002883, 1.9650490000494756], [1.9651930000400171, 1.965211000002455], [1.9652440000209026, 1.9652570000034757], [1.9652890000143088, 1.9653019999968819], [1.9653340000077151, 1.9653470000484958], [1.9654920000466518, 1.9655100000090897], [1.9655430000275373, 1.9655550000024959], [1.9655870000133291, 1.9655999999959022], [1.9657470000092871, 1.9657640000223182], [1.9657980000483803, 1.9658120000385679], [1.9658710000221618, 1.9658850000123493], [1.965920000046026, 1.9659330000285991], [1.9660530000110157, 1.9660710000316612], [1.9661310000228696, 1.9661440000054426], [1.9662630000384524, 1.9662799999932759], [1.9663150000269525, 1.9663270000019111], [1.9665060000261292, 1.9665240000467747], [1.9665580000146292, 1.9665709999972023], [1.9666330000036396, 1.9666460000444204], [1.9666800000122748, 1.9666929999948479], [1.9668140000430867, 1.9668590000364929], [2.0115760000189766, 2.0115959999966435], [2.0116210000123829, 2.0116330000455491], [2.3940799999982119, 2.394116000039503], [2.395758000027854, 2.3957780000055209], [2.4441400000359863, 2.444171000039205], [2.4451120000449009, 2.4451330000301823], [2.5548820000258274, 2.5549710000050254], [2.554989000025671, 2.5550079999957234], [2.5552010000101291, 2.5552290000487119], [2.555532000027597, 2.5555540000204928], [3.4152130000293255, 3.4152730000205338], [6.5554300000076182, 6.5554870000341907], [6.5557150000240654, 6.5557360000093468], [6.7075320000294596, 6.7075880000484176], [6.707914000027813, 6.70795300003374], [6.7575749999959953, 6.757620999997016], [6.7577250000322238, 6.7577450000098906], [6.7578720000456087, 6.7578930000308901], [6.7579790000454523, 6.7579980000155047], [6.7808080000104383, 6.7809230000129901], [6.783257000031881, 6.7833020000252873], [6.9355030000442639, 6.9355790000408888]], \"5\": [[0.0016850000247359276, 0.0017300000181421638], [0.1540720000048168, 0.15412399999331683], [0.15443500003311783, 0.15449500002432615], [0.20416900003328919, 0.20422000001417473], [0.20453099999576807, 0.20460300002014264], [0.20462999999290332, 0.20464800001354888], [0.41466300003230572, 0.41470800002571195], [0.42038500000489876, 0.42041600000811741], [1.1277010000194423, 1.1277430000482127], [2.0358410000335425, 2.0358840000117198], [2.1877589999930933, 2.1878100000321865], [2.1881900000153109, 2.188242000003811], [2.2378759999992326, 2.2379260000307113], [2.2382860000361688, 2.2383370000170544], [2.2386120000155643, 2.2386310000438243], [2.2388000000501052, 2.2388440000358969], [6.9376810000394471, 6.9377250000252388], [7.0978840000461787, 7.0979650000226684], [7.1000630000489764, 7.1001060000271536], [7.3855639999965206, 7.3856170000508428], [7.3858619999955408, 7.3859030000166968], [7.3859240000019781, 7.3859440000378527], [7.3859760000486858, 7.3860010000062175], [7.3860310000018217, 7.3860480000148527], [7.3860790000180714, 7.386095000023488], [7.3861250000190921, 7.3861420000321232], [7.3861710000201128, 7.3861870000255294], [7.3862160000135191, 7.3862340000341646], [7.3862650000373833, 7.3862810000427999], [7.386311000038404, 7.3863290000008419], [7.3863580000470392, 7.3863760000094771], [7.3864049999974668, 7.3864220000104979], [7.3864509999984875, 7.3864670000039041], [7.3865010000299662, 7.3865170000353828], [7.3865499999956228, 7.3865660000010394], [7.3865950000472367, 7.3866120000020601], [7.3866410000482574, 7.3866569999954663], [7.3866910000215285, 7.386707000026945], [7.3867360000149347, 7.3867530000279658], [7.3867820000159554, 7.3867990000289865], [7.3868290000245906, 7.3868470000452362], [8.2896450000116602, 8.2896750000072643], [8.2896990000153892, 8.2897160000284202], [8.2897530000191182, 8.2897710000397637], [8.2898010000353679, 8.2898189999978058], [8.2898480000440031, 8.2898649999988265], [8.2898940000450239, 8.2899109999998473], [8.2899430000106804, 8.289959000016097], [8.2899930000421591, 8.2900090000475757], [8.2900380000355653, 8.2900550000485964], [8.2900830000289716, 8.2901010000496171], [8.2901300000376068, 8.2901470000506379], [8.290175000031013, 8.2901910000364296], [8.2902190000168048, 8.2902370000374503], [8.9940219999989495, 8.9940540000097826], [8.9944310000282712, 8.9944460000260733], [9.0409600000130013, 9.041006000014022], [9.0410550000378862, 9.0410850000334904], [9.0468570000375621, 9.0470170000335202], [9.0490430000354536, 9.0490850000060163]]}, \"sudo-5573\": {\"1\": [[8.3504250000114553, 8.3507439999957569], [8.3511370000196621, 8.3522720000473782]], \"5\": [[8.3508410000358708, 8.3509570000460371]]}, \"sudo-5571\": {\"2\": [[8.3475530000287108, 8.3504260000190698], [8.3515300000435673, 8.3515539999934845], [8.3522630000370555, 8.3531950000324287]]}, \"sudo-5576\": {\"0\": [[9.0524430000223219, 9.0542049999930896]], \"1\": [[9.0520370000158437, 9.0523570000077598]]}, \"sudo-5574\": {\"2\": [[9.0429720000247471, 9.0467910000006668], [9.0491540000075474, 9.0520390000310726], [9.0530860000289977, 9.0531030000420287]]}, \"busybox-5552\": {\"5\": [[2.0329490000149235, 2.0339160000439733]]}, \"busybox-5553\": {\"2\": [[2.0351420000079088, 2.0352950000087731]]}, \"busybox-5550\": {\"4\": [[2.0295010000118054, 2.0305159999988973]]}, \"busybox-5551\": {\"1\": [[2.0316450000391342, 2.031793000001926]]}, \"ksoftirqd/0-3\": {\"0\": [[0.35898800002178177, 0.35900700005004182], [0.42009800003143027, 0.42017400002805516], [0.42019400000572205, 0.42020900000352412], [0.42221200000494719, 0.42225300002610311], [1.7356310000177473, 1.7356680000084452], [5.8317540000425652, 5.8318000000435859], [7.879735000024084, 7.8797790000098757], [8.3710340000106953, 8.3710600000340492]]}, \"ksoftirqd/5-28\": {\"5\": [[0.011166000040248036, 0.011184000002685934], [2.0472280000103638, 2.0472450000233948], [5.7738020000397228, 5.7739000000292435], [5.7739180000498891, 5.7739370000199415], [6.9230180000304244, 6.9230460000107996]]}, \"bash-5559\": {\"2\": [[6.9061260000453331, 6.9076280000153929]]}, \"bash-5554\": {\"1\": [[2.4455080000334419, 2.5548890000209212]], \"2\": [[2.4450270000379533, 2.4454039999982342]]}, \"ksoftirqd/3-20\": {\"3\": [[7.1150800000177696, 7.1150980000384152], [7.2431150000193156, 7.2431460000225343]]}, \"kworker/3:0-1798\": {\"3\": [[2.0149920000112616, 2.0150610000127926], [5.767076000047382, 5.7671689999988303], [7.8791790000395849, 7.8792180000455119], [8.3469710000208579, 8.3470439999946393]]}, \"bash-5533\": {\"1\": [[0.40789100003894418, 0.41240800003288314]], \"2\": [[0.40742000000318512, 0.40778599999612197]]}, \"sh-5577\": {\"1\": [[9.0541430000448599, 9.0542540000169538]], \"4\": [[9.0542720000375994, 9.0549730000202544]]}, \"bash-5536\": {\"1\": [[1.109033000015188, 1.1094049999956042]], \"2\": [[1.1095070000155829, 1.1109510000096634]]}, \"shutils-5539\": {\"5\": [[1.1249520000419579, 1.1249760000500828], [1.1249910000478849, 1.1250090000103228], [1.1250350000336766, 1.125054000003729], [1.1250790000194684, 1.1250960000324994], [1.1251219999976456, 1.1251390000106767], [1.1252950000343844, 1.1260300000431016]]}, \"kworker/5:0-5389\": {\"5\": [[2.0189790000440553, 2.0191300000296906], [4.7589819999993779, 4.7590809999965131], [6.7550860000192188, 6.7551740000490099], [9.0470170000335202, 9.0470970000023954]]}, \"kworker/u12:0-5567\": {\"2\": [[7.4419020000495948, 7.4419329999946058]], \"5\": [[7.4420720000052825, 7.4429710000404157]]}, \"kworker/u12:2-5534\": {\"2\": [[0.41266400000313297, 0.41269399999873713]], \"3\": [[0.41279400000348687, 0.41461199999321252]]}, \"busybox-5544\": {\"1\": [[2.0195340000209399, 2.0202590000117198]], \"5\": [[2.0191530000302009, 2.0194380000466481]]}, \"busybox-5546\": {\"2\": [[2.0228280000155792, 2.0235480000264943]]}, \"busybox-5542\": {\"0\": [[2.0155700000468642, 2.0168000000412576]], \"1\": [[2.015121000004001, 2.0154810000094585]]}, \"busybox-5548\": {\"3\": [[2.0260400000261143, 2.0270750000490807]]}, \"bash-5541\": {\"1\": [[2.0122680000495166, 2.0126220000092871]], \"2\": [[2.0127220000140369, 2.0145280000288039]]}, \"scp-5562\": {\"2\": [[7.0712730000377633, 7.0713340000365861], [7.072656000033021, 7.0728460000245832]]}, \"modprobe-5537\": {\"1\": [[1.1151630000094883, 1.116115000040736]]}, \"scp-5565\": {\"2\": [[7.2315780000062659, 7.2316370000480674], [7.2322250000433996, 7.2324120000121184]]}, \"kworker/5:1H-159\": {\"5\": [[5.7739000000292435, 5.7739180000498891]]}, \"usb-storage-98\": {\"0\": [[0.41684000001987442, 0.41689700004644692], [0.41908600000897422, 0.41911300003994256], [0.42007300001569092, 0.42009800003143027], [0.42022200004430488, 0.42024300002958626], [0.42132399999536574, 0.42134600004646927], [0.42219400004250929, 0.42221200000494719], [1.7351370000396855, 1.735173000022769], [1.7353880000300705, 1.7354110000305809], [1.7356100000324659, 1.7356310000177473], [5.8313450000132434, 5.8313809999963269], [5.8317260000039823, 5.8317540000425652], [7.8792130000074394, 7.8792520000133663], [7.8793310000328347, 7.8793520000181161], [7.8797050000284798, 7.879735000024084]], \"1\": [[3.78324000001885, 3.7832650000345893], [3.7835180000402033, 3.7835310000227764], [3.7838570000021718, 3.7838670000201091], [5.767468000005465, 5.7674980000010692]], \"2\": [[5.7677980000153184, 5.7678520000190474], [5.7701130000059493, 5.77012600004673], [5.7710970000480302, 5.7711070000077598]], \"3\": [[0.41665200004354119, 0.41668700001901016], [0.42044600000372157, 0.4204790000221692], [5.7715280000120401, 5.7715600000228733], [5.772006000042893, 5.7720570000237785], [5.7728920000372455, 5.7729350000154227]], \"5\": [[5.7737690000212751, 5.7738020000397228], [5.8310820000478998, 5.8311260000336915]]}, \"task_wmig1-5556\": {\"1\": [[2.5672769999946468, 2.5728400000371039], [2.6552820000215434, 2.6655080000055023], [3.7835310000227764, 3.7838570000021718], [3.783889000013005, 3.8429280000273138], [3.8430870000156574, 3.8482260000309907], [3.8552830000407994, 3.9063000000314787], [3.9552840000251308, 4.0063289999961853], [4.0552820000448264, 4.1063260000082664], [4.1552260000025854, 4.2062420000438578], [4.2552230000146665, 4.3062689999933355], [4.3552250000066124, 4.4062740000081249], [4.4552240000339225, 4.5062770000076853], [4.5552829999942333, 4.565539000032004], [5.767863999994006, 5.8390220000292175], [5.8552810000255704, 5.9063029999961145], [5.955223000026308, 6.0062700000125915], [6.0552230000030249, 6.1063100000028498], [6.1552249999949709, 6.2062390000210144], [6.2552279999945313, 6.3062239999999292], [6.3552220000419766, 6.4062410000478849], [6.4552240000339225, 6.5062650000327267], [6.5552250000182539, 6.555346000008285], [6.5554940000292845, 6.5555129999993369], [6.5556990000186488, 6.5557080000289716]], \"2\": [[4.6654740000376478, 4.6757070000167005], [4.7552420000429265, 4.7589500000467524], [4.75896400003694, 4.7655130000202917]], \"3\": [[2.5550180000136606, 2.5671150000416674]], \"4\": [[4.8553400000091642, 4.8589890000293963], [4.8591290000476874, 4.8819090000470169], [4.9552900000126101, 4.9818090000189841], [5.0552829999942333, 5.0815550000406802], [5.1552810000139289, 5.1818090000306256], [5.2552840000134893, 5.2816750000347383], [5.3552849999978207, 5.381470000022091], [5.4552810000022873, 5.4814410000108182], [5.5552829999942333, 5.7675080000190064]], \"5\": [[2.7553640000405721, 2.7817740000318736], [2.8552919999929145, 2.8813500000396743], [2.955277000030037, 2.9816450000507757], [3.0553010000148788, 3.0816270000068471], [3.1553019999992102, 3.1814660000381991], [3.2552650000434369, 3.2815500000142492], [3.3552630000049248, 3.3815750000067055], [3.4552640000474639, 3.4815440000384115], [3.5552700000116602, 3.7832730000372976]]}, \"ksoftirqd/1-12\": {\"1\": [[3.7838670000201091, 3.783889000013005]]}, \"systemd-1\": {\"3\": [[6.9014120000065304, 6.9016350000165403]]}, \"sshd-5424\": {\"0\": [[0.15379500004928559, 0.15403299999888986], [0.2039020000374876, 0.20413000002736226], [0.20465700002387166, 0.20487000001594424], [0.3561980000231415, 0.35642600001301616], [0.35656200000084937, 0.35668300004908815], [0.356738000002224, 0.35685400001239032], [0.35690600000089034, 0.35701300000073388], [0.35706400003982708, 0.35714400000870228], [0.35723900003358722, 0.35731900000246242], [0.35737000004155561, 0.35747800004901364], [0.35752900002989918, 0.35760899999877438], [0.35766000003786758, 0.35778500000014901], [0.35783600003924221, 0.35791600000811741], [0.35799600003520027, 0.35807600000407547], [0.35812600003555417, 0.3582350000506267], [0.35828800004674122, 0.35836800001561642], [0.35841899999650195, 0.35854300000937656], [0.35859400004846975, 0.35867400001734495], [0.35875400004442781, 0.35883400001330301], [0.35888600000180304, 0.35898800002178177], [0.35900700005004182, 0.35907000000588596], [0.35912100004497916, 0.35922800004482269], [0.35927900002570823, 0.35935899999458343], [0.35941000003367662, 0.35951800004113466], [0.35957000002963468, 0.35964999999850988], [0.35973399999784306, 0.35984799999278039], [0.35990000003948808, 0.36000800004694611], [0.36006000003544614, 0.36014000000432134], [0.3602190000237897, 0.36029900005087256], [0.36035100003937259, 0.36045900004683062], [0.36051300005055964, 0.36059300001943484], [0.36067399999592453, 0.36075400002300739], [0.36080600001150742, 0.36091500002657995], [0.36096800002269447, 0.36104800004977733], [0.36110000003827736, 0.36120800004573539], [0.36126299999887124, 0.3613420000183396], [0.36142400000244379, 0.36150400002952665], [0.36155700002564117, 0.3616650000330992], [0.36171800002921373, 0.36179799999808893], [0.36185099999420345, 0.36195900000166148], [0.3620130000053905, 0.36209300003247336], [0.36217600002419204, 0.36225700000068173], [0.36230999999679625, 0.36241800000425428], [0.3624720000079833, 0.36255100002745166], [0.36263300001155585, 0.36271200003102422], [0.36276800004998222, 0.36287599999923259], [0.36294600000837818, 0.36302800005069003], [0.3631110000424087, 0.3631910000112839], [0.36324600002262741, 0.36332600004971027], [0.36341000004904345, 0.36349100002553314], [0.36354500002926216, 0.36365300003672019], [0.3637080000480637, 0.3637870000093244], [0.36387000000104308, 0.36395000002812594], [0.36400500003946945, 0.36408500000834465], [0.36416800000006333, 0.36425000004237518], [0.36438199999975041, 0.36446200002683327], [0.36451800004579127, 0.36465800000587478], [0.36488400003872812, 0.3649660000228323], [0.36514599999645725, 0.3652280000387691], [0.36536100000375882, 0.36544200003845617], [0.36549799999920651, 0.36560600000666454], [0.36583300004713237, 0.36591500003123656], [0.36597199999960139, 0.36608100001467392], [0.36623500002315268, 0.3663440000382252], [0.36649800004670396, 0.36660800001118332], [0.36676400003489107, 0.36687300004996359], [0.3670770000317134, 0.36716100003104657], [0.36730000004172325, 0.36738000001059845], [0.36748900002567098, 0.36759500001790002], [0.36775299999862909, 0.36786200001370162], [0.36793700000271201, 0.36805500002810732], [0.40627199999289587, 0.406449000001885], [0.4074970000074245, 0.40764799999305978], [0.42045200004940853, 0.42064500000560656], [1.0578190000378527, 1.0580310000223108], [1.0580880000488833, 1.0581180000444874], [1.0582000000285916, 1.0583200000110082], [1.0584990000352263, 1.0585850000497885], [1.0587560000130907, 1.0588379999971949], [1.0590209999936633, 1.0591060000006109], [1.0592290000058711, 1.0593100000405684], [1.0594039999996312, 1.0594840000267141], [1.0596200000145473, 1.0597340000094846], [1.0599130000337027, 1.0599970000330359], [1.0601360000437126, 1.0602470000158064], [1.0603860000264831, 1.0604850000236183], [1.0606990000233054, 1.0607820000150241], [1.0608800000045449, 1.0609590000240132], [1.0611009999993257, 1.0612120000296272], [1.0613540000049397, 1.0614369999966584], [1.0615819999948144, 1.0616940000327304], [1.0618390000308864, 1.0619210000149906], [1.062067000020761, 1.0621790000004694], [1.0623250000062399, 1.062409000005573], [1.062556000018958, 1.0626679999986663], [1.0628170000272803, 1.062900000018999], [1.0630200000014156, 1.0631300000241026], [1.0632830000249669, 1.0633670000243001], [1.0635159999947064, 1.0636270000250079], [1.0637800000258721, 1.0638630000175908], [1.0639680000022054, 1.0640490000369027], [1.0641850000247359, 1.0642660000012256], [1.0643730000010692, 1.064453000028152], [1.0645900000235997, 1.0646710000000894], [1.0647290000342764, 1.0648090000031516], [1.0649170000106096, 1.0650599999935366], [1.0652680000057444, 1.0653509999974631], [1.0654260000446811, 1.0655130000086501], [1.1079139999928884, 1.1080899999942631], [1.1091110000270419, 1.1092630000202917], [1.759124000032898, 1.7592390000354499], [1.7592639999929816, 1.7592900000163354], [1.7593530000303872, 1.7594590000226162], [1.7595140000339597, 1.7596350000239909], [1.7596860000048764, 1.7597960000275634], [1.759847000008449, 1.7599280000431463], [1.7600240000174381, 1.7601040000445209], [1.7601550000254065, 1.76026200002525], [1.7603130000061356, 1.7603940000408329], [1.8092969999997877, 1.8093700000317767], [1.8097380000399426, 1.8098360000294633], [1.8099960000254214, 1.810081000032369], [1.9613910000189207, 1.9614660000079311], [1.9614890000084415, 1.9615130000165664], [1.9615639999974519, 1.9616470000473782], [1.9616980000282638, 1.9618060000357218], [1.9618570000166073, 1.9619650000240654], [1.9620970000396483, 1.9622090000193566], [1.9623830000055023, 1.9624940000358038], [1.9626980000175536, 1.9627810000092722], [1.9628870000015013, 1.962991000036709], [1.9631600000429899, 1.963244000042323], [1.9633820000453852, 1.9634920000098646], [1.9636300000129268, 1.9637420000508428], [1.9639510000124574, 1.9640340000041761], [1.9641300000366755, 1.964237000036519], [1.9644050000351854, 1.964488000026904], [1.9646570000331849, 1.9647400000249036], [1.9649119999958202, 1.9649940000381321], [1.9650490000494756, 1.9651560000493191], [1.9653470000484958, 1.9654560000053607], [1.9655999999959022, 1.9657100000185892], [1.9659330000285991, 1.9660150000127032], [1.9661440000054426, 1.96622500004014], [1.9663270000019111, 1.9664680000278167], [1.9666929999948479, 1.9667750000371598], [1.9668750000419095, 1.9669780000112951], [2.0115050000022165, 2.0115760000189766], [2.0123350000358187, 2.0124550000182353], [2.1874870000174269, 2.187720000045374], [2.1882300000288524, 2.1884330000029877], [2.2376100000110455, 2.2378390000085346], [2.2386870000045747, 2.2388090000022203], [2.2388430000282824, 2.2390350000350736], [2.3938530000159517, 2.3940799999982119], [2.3957780000055209, 2.3959230000036769], [2.4439430000493303, 2.4441400000359863], [2.4451330000301823, 2.4452750000054948], [6.5554870000341907, 6.5557150000240654], [6.5557360000093468, 6.5558830000227317], [6.7073530000052415, 6.7075320000294596], [6.70795300003374, 6.7081640000105835], [6.7574030000250787, 6.7575749999959953], [6.7577450000098906, 6.7578720000456087], [6.7578930000308901, 6.7579790000454523], [6.7579980000155047, 6.7581050000153482], [7.3853600000147708, 7.3855160000384785], [7.3859810000285506, 7.3870480000041425], [7.4355480000376701, 7.4357440000167117], [7.4367470000288449, 7.4368860000395216], [8.0866960000130348, 8.0868740000296384], [8.0873230000142939, 8.0875300000188872], [8.1367900000186637, 8.1369670000276528], [8.1373890000395477, 8.1375969999935478], [8.288964000006672, 8.2891490000183694], [8.2895770000177436, 8.2903900000383146], [8.3391340000089258, 8.3392929999972694], [8.3401990000274964, 8.3403430000180379], [8.3536780000431463, 8.3538680000347085], [8.99055300001055, 8.9907510000048205], [8.99100300000282, 8.9910750000271946], [8.9911050000227988, 8.9912560000084341], [8.991314000042621, 8.9913830000441521], [8.9914149999967776, 8.9915620000101626], [8.9915940000209957, 8.9923570000100881], [8.9923890000209212, 8.9930579999927431], [8.9930889999959618, 8.993679000006523], [8.9937180000124499, 8.9943250000360422], [8.9943560000392608, 8.9945090000401251], [9.0407120000454597, 9.040917000034824]], \"3\": [[0.0017980000120587647, 0.0019800000009126961], [1.1278000000165775, 1.1279920000233687], [2.0359420000459068, 2.036147000035271], [7.4557400000048801, 7.4559379999991506]], \"4\": [[2.5550030000158586, 2.5551500000292435], [2.5554170000250451, 2.5556530000176281]], \"5\": [[0.15449500002432615, 0.15472200000658631], [9.0419410000322387, 9.0420750000048429]]}, \"kworker/2:1-5431\": {\"2\": [[0.0029380000196397305, 0.0029850000282749534], [0.11508700001286343, 0.1151149999932386], [0.11586499999975786, 0.11588100000517443], [1.1109510000096634, 1.1109740000101738], [1.1149450000375509, 1.1149760000407696], [1.1157380000222474, 1.115756000042893], [1.7350210000295192, 1.7350600000354461], [1.7356570000411011, 1.7356700000236742], [2.0149439999950118, 2.014993000018876], [2.1150830000406131, 2.1151110000209883], [2.115862000035122, 2.1158770000329241], [2.7910820000106469, 2.7911070000263862], [3.1150830000406131, 3.1151100000133738], [3.1158610000275075, 3.1158770000329241], [3.7830640000174753, 3.7831679999944754], [3.7838850000407547, 3.7838970000157133], [4.1150810000253841, 4.1151090000057593], [4.1158590000122786, 4.1158750000176951], [4.7589500000467524, 4.75896400003694], [5.1150860000052489, 5.1151210000389256], [5.1158730000024661, 5.1158870000508614], [5.7789280000142753, 5.779013000021223], [5.8309250000165775, 5.8309540000045672], [5.8317790000000969, 5.8317890000180341], [6.1150849999976344, 6.1151140000438318], [6.115862000035122, 6.1158780000405386], [6.7789510000147857, 6.7789770000381395], [7.115049000014551, 7.1150720000150613], [7.1158070000237785, 7.1158220000215806], [7.8790210000006482, 7.8791269999928772], [7.8797610000474378, 7.8797740000300109], [8.1150220000417903, 8.1150450000423007], [8.1157970000058413, 8.1158109999960288], [9.0429490000242367, 9.0429720000247471]]}, \"in:imuxsock-257\": {\"0\": [[7.4469970000209287, 7.4470740000251681]], \"1\": [[7.0738860000274144, 7.0739410000387579], [7.2244730000384152, 7.2245500000426546]], \"2\": [[7.2331260000355542, 7.2331880000419915], [7.4460250000120141, 7.4460890000336803]], \"4\": [[0.00092900003073737025, 0.0010400000028312206], [1.118337000021711, 1.1184370000264607], [1.1194230000255629, 1.1194700000341982], [6.9023370000068098, 6.9024429999990389], [7.0654320000321604, 7.0655380000243895], [8.349532000022009, 8.3496290000039153], [8.3506590000470169, 8.3507190000382252], [8.3526859999983571, 8.3527370000374503]], \"5\": [[0.41668900003423914, 0.41679800004931167], [0.41759399999864399, 0.4176430000225082], [0.41958899999735877, 0.41963000001851469], [1.1267260000458919, 1.1268189999973401], [6.9105360000394285, 6.9106130000436679], [7.4546810000319965, 7.454773000034038], [9.051216000050772, 9.0513180000125431], [9.0520510000060312, 9.0521070000249892]]}, \"kworker/u12:2-5537\": {\"1\": [[1.1143659999943338, 1.1143960000481457]], \"3\": [[1.1145390000310726, 1.1149699999950826]]}, \"sudo-5529\": {\"1\": [[0.00038700003642588854, 0.0014610000071115792], [0.0016870000399649143, 0.0016960000502876937]]}, \"scp-5559\": {\"2\": [[6.9080650000250898, 6.9081180000212044], [6.9095280000474304, 6.9097080000210553]]}, \"kworker/u12:2-5558\": {\"1\": [[6.7809899999992922, 6.7810220000101253]], \"5\": [[6.7811080000246875, 6.7829460000502877]]}, \"shutils-5550\": {\"2\": [[2.0286600000108592, 2.0287670000107028]], \"5\": [[2.0287850000313483, 2.029411000024993]]}, \"shutils-5551\": {\"2\": [[2.0306250000139698, 2.0308270000386983]], \"5\": [[2.0308450000011362, 2.0309530000085942], [2.0309750000014901, 2.0316250000032596]]}, \"shutils-5552\": {\"0\": [[2.0322710000327788, 2.0329270000220276]], \"5\": [[2.032011000032071, 2.0321830000029877]]}, \"shutils-5553\": {\"0\": [[2.0340350000187755, 2.0340840000426397]], \"2\": [[2.0341060000355355, 2.0342750000418164]], \"3\": [[2.0343630000133999, 2.0351220000302419]]}, \"rs:main Q:Reg-259\": {\"3\": [[0.41677900002105162, 0.41688700002850965], [0.42012900003464893, 0.42027000000234693], [1.118499000032898, 1.1186380000435747], [1.11953300004825, 1.1196080000372604], [1.1268020000425167, 1.1269210000173189], [6.902425000036601, 6.9025940000428818], [6.9106660000397824, 6.9107820000499487], [7.0655200000037439, 7.0656740000122227], [7.0741060000145808, 7.0742100000497885], [7.2246100000338629, 7.2247600000118837], [7.2332540000206791, 7.2333640000433661], [7.4461690000025555, 7.4463180000311695], [7.4471520000370219, 7.4472260000184178], [7.4547560000210069, 7.4548880000365898]], \"4\": [[8.3496290000039153, 8.3497540000244044], [8.3507190000382252, 8.3507940000272356], [8.3527370000374503, 8.3528060000389814]], \"5\": [[0.001091000041924417, 0.0012420000275596976], [9.0513180000125431, 9.0514529999927618], [9.0521070000249892, 9.052209000044968]]}, \"rt-app-5556\": {\"3\": [[2.5549640000099316, 2.5550010000006296]]}, \"rt-app-5555\": {\"2\": [[2.5549250000040047, 2.5550290000392124]]}, \"rt-app-5554\": {\"1\": [[6.555346000008285, 6.5554940000292845]]}, \"jbd2/sda1-8-105\": {\"3\": [[5.7671689999988303, 5.7673669999931008], [5.7713850000291131, 5.7715280000120401], [5.7739370000199415, 5.7739790000487119]], \"5\": [[0.41641400003572926, 0.41659600002458319], [0.42013899999437854, 0.42023300001164898], [0.42223100003320724, 0.42225699999835342]]}, \"sshd-240\": {\"0\": [[6.7736610000138171, 6.7745940000168048], [6.9285780000500381, 6.9293930000276305], [7.0910300000105053, 7.0918560000136495]], \"3\": [[7.06454200000735, 7.0645990000339225], [7.0739509999984875, 7.0741060000145808], [7.2243390000076033, 7.2243940000189468], [7.2335680000251159, 7.2337319999933243]], \"5\": [[6.9013510000077076, 6.9014100000495091], [6.9115619999938644, 6.911729000043124]]}, \"sudo-5538\": {\"1\": [[1.1192730000475422, 1.1195690000313334], [1.1196010000421666, 1.120718999998644]]}, \"sudo-5536\": {\"2\": [[1.1109740000101738, 1.1140610000002198], [1.1162900000344962, 1.1192570000421256], [1.1200270000263117, 1.1200510000344366], [1.1263460000045598, 1.127299000043422]]}, \"sudo-5535\": {\"2\": [[0.41759100003400818, 0.41790000000037253], [0.41792300000088289, 0.41909300000406802]]}, \"sudo-5533\": {\"1\": [[0.41469900001538917, 0.41759399999864399], [0.41827399999601766, 0.41829200001666322], [0.41916700004367158, 0.42009700002381578]]}, \"kworker/1:0-889\": {\"1\": [[0.84308399999281392, 0.8432909999974072], [1.843066000030376, 1.8432320000138134], [2.8430870000156574, 2.843302000022959], [3.8429280000273138, 3.8430870000156574], [4.8430860000080429, 4.8433430000441149], [5.8430180000141263, 5.8431810000329278], [6.791097000008449, 6.7911580000072718], [6.8430170000065118, 6.8431800000253133], [7.8430229999939911, 7.8431880000280216], [8.8430260000168346, 8.8432260000263341]]}, \"kworker/u12:0-5231\": {\"0\": [[7.3859610000508837, 7.3859810000285506], [7.3870480000041425, 7.3870630000019446], [7.4357440000167117, 7.4358000000356697], [7.4367250000359491, 7.4367470000288449], [7.4417280000052415, 7.4418400000431575], [7.4439200000488199, 7.4439770000171848], [7.4556420000153594, 7.4556840000441298], [8.0868740000296384, 8.0869320000056177], [8.0872850000159815, 8.0873230000142939], [8.1369670000276528, 8.1370220000389963], [8.1373520000488497, 8.1373890000395477], [8.2891490000183694, 8.2892080000019632], [8.2895350000471808, 8.2895770000177436], [8.2903900000383146, 8.2904050000361167], [8.3392929999972694, 8.3393459999933839], [8.3401840000296943, 8.3401990000274964], [8.3451520000235178, 8.3452520000282675], [8.9943250000360422, 8.9943560000392608]], \"3\": [[8.347440000041388, 8.3474780000397004], [8.3536540000350215, 8.3536880000028759], [8.4232770000235178, 8.4233390000299551], [8.9907950000488199, 8.9908380000269972], [8.9909050000132993, 8.9909680000273511], [8.9910140000283718, 8.9910280000185594], [8.9910660000168718, 8.9911010000505485], [8.9911390000488609, 8.9911510000238195], [8.9911890000221319, 8.9912030000123195], [8.9912400000030175, 8.9912810000241734], [8.9913190000224859, 8.9913309999974445], [8.9913689999957569, 8.9914080000016838], [8.9914470000076108, 8.991459000040777], [8.9914970000390895, 8.9915090000140481], [8.9915470000123605, 8.9915890000411309], [8.9916270000394434, 8.9916400000220165], [8.9916780000203289, 8.9916899999952875], [8.9917279999936, 8.9917400000267662], [8.9917780000250787, 8.9917900000000373], [8.9918279999983497, 8.9918410000391304], [8.9918790000374429, 8.9918910000124015], [8.9919300000183284, 8.9919430000009015], [8.991980999999214, 8.9919930000323802], [8.9920310000306927, 8.9920430000056513], [8.9920830000191927, 8.9920949999941513], [8.9921340000000782, 8.992147000040859], [8.9921850000391714, 8.99219700001413], [8.992236000020057, 8.9922490000026301], [8.9922890000161715, 8.9923010000493377], [8.992339999997057, 8.9923830000334419], [8.9924230000469834, 8.992435000021942], [8.9924740000278689, 8.9924860000028275], [8.9925260000163689, 8.9925380000495352], [8.992578000004869, 8.9925910000456497], [8.9926310000009835, 8.9926430000341497], [8.9926820000400767, 8.9926940000150353], [8.9927340000285767, 8.9927460000035353], [8.9927860000170767, 8.9927989999996498], [8.9928380000055768, 8.9928510000463575], [8.9928910000016913, 8.9929030000348575], [8.9929439999978058, 8.9929560000309721], [8.9929960000445135, 8.9930090000270866], [8.993049000040628, 8.993084000016097], [8.9931250000372529, 8.9931370000122115], [8.9931790000409819, 8.993192000023555], [8.9932330000447109, 8.9932450000196695], [8.9932860000408255, 8.9932990000233985], [8.9933409999939613, 8.9933530000271276], [8.9933949999976903, 8.9934060000232421], [8.9934479999938048, 8.9934600000269711], [8.9935019999975339, 8.9935140000307001], [8.9935560000012629, 8.9935680000344291], [8.9936100000049919, 8.9936220000381581], [8.9936640000087209, 8.9937050000298768], [8.9937480000080541, 8.9937610000488348], [8.9938030000193976, 8.9938149999943562], [8.9938570000231266, 8.9938689999980852], [8.9939110000268556, 8.9939440000453033], [8.993986000015866, 8.9939989999984391], [8.9940430000424385, 8.9940530000021681], [8.9940950000309385, 8.9941070000058971], [8.994150000042282, 8.9941620000172406], [8.9942040000460111, 8.9942160000209697], [8.9942589999991469, 8.9942710000323132]]}, \"shutils-5549\": {\"0\": [[2.0276550000417046, 2.0285470000235364]], \"2\": [[2.0273680000100285, 2.027568000019528]]}, \"shutils-5548\": {\"4\": [[2.0251920000300743, 2.025344000023324]], \"5\": [[2.0254310000455007, 2.0260180000332184]]}, \"shutils-5547\": {\"3\": [[2.0242070000385866, 2.0250680000171997]], \"4\": [[2.0238230000250041, 2.0241160000441596]]}, \"shutils-5546\": {\"0\": [[2.0222160000121221, 2.0228060000226833]], \"5\": [[2.0219720000168309, 2.0221270000329241]]}, \"shutils-5545\": {\"4\": [[2.0209620000096038, 2.0218469999963418]], \"5\": [[2.0205270000151359, 2.020864000020083]]}, \"shutils-5544\": {\"1\": [[2.0183580000302754, 2.0184700000099838]], \"5\": [[2.0185560000245459, 2.0189790000440553]]}, \"shutils-5543\": {\"1\": [[2.0170040000230074, 2.0171950000221841]], \"3\": [[2.0172870000242256, 2.0182430000277236]]}, \"shutils-5542\": {\"1\": [[2.0144820000277832, 2.0145760000450537]], \"3\": [[2.0146710000117309, 2.0149640000308864]]}, \"shutils-5541\": {\"1\": [[2.0236190000432543, 2.0237820000038482], [2.0248819999978878, 2.0248950000386685], [2.0250460000243038, 2.0252190000028349], [2.0271440000506118, 2.0273160000215285], [2.0283560000243597, 2.0283690000069328], [2.0285190000431612, 2.0286920000216924], [2.0305060000391677, 2.0306640000198968], [2.0316000000457279, 2.0316159999929368], [2.035284000041429, 2.0354919999954291]], \"2\": [[2.0168650000123307, 2.0170400000060908], [2.0180490000057034, 2.0180620000464842], [2.0182159999967553, 2.0183989999932237], [2.0203259999980219, 2.0204930000472814], [2.0216559999971651, 2.0216690000379458], [2.0218220000388101, 2.0220050000352785], [2.0318590000388213, 2.0320470000151545], [2.0339060000260361, 2.0340699999942444], [2.0350949999992736, 2.0351120000123046]]}, \"shutils-5540\": {\"3\": [[1.1241180000361055, 1.1253230000147596]], \"4\": [[1.1235250000027008, 1.1240240000188351]]}, \"task_wmig0-5555\": {\"2\": [[2.5553170000202954, 2.5655690000276081], [2.655222000030335, 2.665467000042554], [3.7832080000080168, 3.7838850000407547], [3.7838970000157133, 3.8477150000398979], [3.8552210000343621, 3.9062960000010207], [3.955223000026308, 4.0062250000191852], [4.0552230000030249, 4.1062740000197664], [4.1552820000215434, 4.2063010000274517], [4.2552819999982603, 4.3063340000226162], [4.3552830000407994, 4.4063330000499263], [4.4552820000099018, 4.5062770000076853], [4.5552240000106394, 4.5654429999995045], [4.6552230000379495, 4.6654740000376478], [5.7680370000307448, 5.7701130000059493], [5.77012600004673, 5.7710970000480302], [5.7711070000077598, 5.7789280000142753], [5.779013000021223, 5.8309250000165775], [5.8309540000045672, 5.8317790000000969], [5.8317890000180341, 5.8389890000107698], [5.8552210000343621, 5.9062649999978021], [5.9552810000022873, 6.0063519999966957], [6.0552820000448264, 6.1062820000224747], [6.1552840000367723, 6.2063310000230558], [6.2552819999982603, 6.3063340000226162], [6.3552810000255704, 6.4063090000418015], [6.4552879999973811, 6.5062820000457577], [6.5552840000018477, 6.5553690000087954]], \"4\": [[2.7555350000038743, 2.7589760000118986], [2.759070000029169, 2.7817730000242591], [2.8552660000277683, 2.8814980000024661], [2.9553020000457764, 2.9815260000177659], [3.0552840000018477, 3.081469000026118], [3.1552830000291578, 3.1815640000277199], [3.2553060000063851, 3.2818149999948218], [3.3553070000489242, 3.3814810000476427], [3.4553090000408702, 3.4815590000362135], [3.5553080000099726, 3.7831780000124127]], \"5\": [[4.7553500000503846, 4.7589819999993779], [4.7590809999965131, 4.7816830000374466], [4.8553450000472367, 4.881684000021778], [4.9553010000381619, 4.9815800000214949], [5.0553020000224933, 5.0814770000288263], [5.1553000000421889, 5.1816120000439696], [5.2553010000265203, 5.281957000028342], [5.3553020000108518, 5.381470000022091], [5.4553010000381619, 5.4814469999982975], [5.5553020000224933, 5.7678610000293702]]}, \"kworker/u12:0-5572\": {\"1\": [[8.3453210000297986, 8.3453520000330172]], \"3\": [[8.345452000037767, 8.3469710000208579]]}, \"kworker/4:2-179\": {\"4\": [[0.0029700000304728746, 0.002992000023368746], [2.7589760000118986, 2.759070000029169], [4.8589890000293963, 4.8591290000476874], [6.902968000038527, 6.9030690000508912], [7.8791790000395849, 7.8792180000455119], [9.0549730000202544, 9.0550550000043586]]}, \"bash-5574\": {\"1\": [[9.0418340000323951, 9.0421410000417382]], \"2\": [[9.0422480000415817, 9.0429490000242367]]}, \"kworker/0:1H-108\": {\"0\": [[0.42017400002805516, 0.42019400000572205], [0.42225300002610311, 0.42227000003913417]]}, \"bash-5571\": {\"1\": [[8.3400879999971949, 8.3404030000092462]], \"2\": [[8.3405000000493601, 8.3450860000448301]]}, \"sh-5531\": {\"2\": [[8.7000022176653147e-05, 0.00031400000443682075]]}, \"sh-5538\": {\"1\": [[1.1260990000446327, 1.1262780000106432]]}, \"sh-5539\": {\"3\": [[1.1206800000509247, 1.1208559999940917]], \"5\": [[1.1209590000216849, 1.1235140000353567]]}, \"shutils-5570\": {\"2\": [[7.4516060000169091, 7.4519480000017211]], \"4\": [[7.4520360000315122, 7.4532100000069477]]}, \"rcu_sched-8\": {\"5\": [[0.0029850000282749534, 0.0030020000413060188], [0.0071760000428184867, 0.0071940000052563846], [0.011200000008102506, 0.011218000028748065]]}, \"kworker/u12:2-5575\": {\"0\": [[9.0471470000338741, 9.0489880000241101]], \"1\": [[9.0470190000487491, 9.0470510000013746]]}}});\n",
+       "        }); /* TRAPPY_PUBLISH_REMOVE_LINE */\n",
+       "        </script>\n",
+       "        </div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "trappy.plotter.plot_trace(trace.ftrace)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot estimated ideal and estimated power usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This plot shows how the power estimation for the observed scheduling pattern varies from the estimated power for an ideal schedule.\n",
+    "\n",
+    "Where the plotted value for the observed power is higher than the plotted ideal power, the system was wasting power (e.g. a low-intensity task was unnecessarily placed on a high-power CPU). Where the observed value is *lower* than the ideal value, this means the system was *too* efficient (e.g. a high-intensity task was placed on a low-power CPU that could not accomadate its compute requirements)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"border-style: hidden;\">\n",
+       "<tr>\n",
+       "<td style=\"border-style: hidden;\"><div class=\"ilineplot\" id=\"fig_3f538e0e0eec4fea97e09499fc1224d4\"></div></td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "<td style=\"border-style: hidden;\"><div style=\"text-align:center\" id=\"fig_3f538e0e0eec4fea97e09499fc1224d4_legend\"></div></td>\n",
+       "</tr>\n",
+       "</table>\n",
+       "<script>\n",
+       "var fig_3f538e0e0eec4fea97e09499fc1224d4_data = {\"logscale\": false, \"strokeWidth\": 1.0, \"pointSize\": 2, \"name\": \"fig_3f538e0e0eec4fea97e09499fc1224d4\", \"step_plot\": true, \"fill_graph\": false, \"title\": \"\", \"drawPoints\": false, \"per_line\": 1, \"height\": 400, \"rangesel\": false, \"data\": {\"labels\": [\"index\", \"DataFrame 0:ideal_power\", \"DataFrame 0:observed_power\"], \"data\": [[2.5549250000040047, 83.38553191489362, 41.0], [2.5550180000136606, 83.38553191489362, 84.69276595744681], [2.5553170000202954, 83.38553191489362, 168.19588346344202], [2.5672769999946468, 83.38553191489362, 177.07434052757793], [2.7553640000405721, 83.38553191489362, 168.19588346344202], [2.7555350000038743, 83.38553191489362, 102.45787234042554], [3.5549250000040047, 500.20034542314335, 267.0], [3.7832080000080168, 500.20034542314335, 409.5094991364421], [3.7835310000227764, 500.20034542314335, 500.20034542314335], [4.5549250000040047, 83.38553191489362, 177.07434052757793], [4.6654740000376478, 83.38553191489362, 152.0062350119904], [4.7553500000503846, 83.38553191489362, 168.19588346344202], [4.8553400000091642, 83.38553191489362, 102.45787234042554], [5.5549250000040047, 500.20034542314335, 267.0], [5.767863999994006, 500.20034542314335, 409.5094991364421], [5.7680370000307448, 500.20034542314335, 500.20034542314335], [6.5549250000040047, 41.0, 41.0]]}};\n",
+       "</script>\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"http://cdnjs.cloudflare.com/ajax/libs/dygraph/1.1.1/dygraph-combined.js\" -->\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"http://dygraphs.com/extras/synchronizer.js\" -->\n",
+       "<!-- TRAPPY_PUBLISH_SOURCE_LIB = \"https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js\" -->\n",
+       "\n",
+       "            <script>\n",
+       "            /* TRAPPY_PUBLISH_IMPORT = \"plotter/js/ILinePlot.js\" */\n",
+       "            /* TRAPPY_PUBLISH_REMOVE_START */\n",
+       "            var ilp_req = require.config( {\n",
+       "\n",
+       "                paths: {\n",
+       "                    \"dygraph-sync\": '/nbextensions/plotter_scripts/ILinePlot/synchronizer',\n",
+       "                    \"dygraph\": '/nbextensions/plotter_scripts/ILinePlot/dygraph-combined',\n",
+       "                    \"ILinePlot\": '/nbextensions/plotter_scripts/ILinePlot/ILinePlot',\n",
+       "                    \"underscore\": '/nbextensions/plotter_scripts/ILinePlot/underscore-min',\n",
+       "                },\n",
+       "\n",
+       "                shim: {\n",
+       "                    \"dygraph-sync\": [\"dygraph\"],\n",
+       "                    \"ILinePlot\": {\n",
+       "\n",
+       "                        \"deps\": [\"dygraph-sync\", \"dygraph\", \"underscore\"],\n",
+       "                        \"exports\":  \"ILinePlot\"\n",
+       "                    }\n",
+       "                }\n",
+       "            });\n",
+       "                /* TRAPPY_PUBLISH_REMOVE_STOP */\n",
+       "                ilp_req([\"require\", \"ILinePlot\"], function() { /* TRAPPY_PUBLISH_REMOVE_LINE */\n",
+       "                ILinePlot.generate(fig_3f538e0e0eec4fea97e09499fc1224d4_data);\n",
+       "            }); /* TRAPPY_PUBLISH_REMOVE_LINE */\n",
+       "            </script>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df = pd.concat([\n",
+    "        expected_power.sum(axis=1), estimated_power.sum(axis=1)], \n",
+    "               axis=1, keys=['ideal_power', 'observed_power']).fillna(method='ffill')\n",
+    "\n",
+    "ILinePlot(df, column=df.columns.tolist(), drawstyle='steps-post').view()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot CPU frequency"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-01-23 18:50:59,019 WARNING : Analysis     : Events [cpu_frequency] not found, plot DISABLED!\n"
+     ]
+    }
+   ],
+   "source": [
+    "trace.analysis.frequency.plotClusterFrequencies()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assertions\n",
+    "These are the assertions used to generate pass/fail results s. They aren't very useful in this interactive context - it's much more interesting to examine plots like the one above and see whether the behaviour was desirable or not. These are intended for automated regression testing. Nonetheless, let's see what the results would be for this run."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`test_slack` checks the \"slack\" reported by the rt-app workload. If this slack was negative, this means the workload didn't receive enough CPU capacity. In a real system this would represent lacking interactive performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test_slack failed:\n",
+      "task task_wmig0 missed 10.0% of activations\n",
+      "\tCheck trace file: /home/brejac01/sources/lisa/results/20170123_185036/rtapp:energy_aware:wake_migration/1/trace.dat\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    t.test_slack()\n",
+    "except AssertionError as e:\n",
+    "    print \"test_slack failed:\"\n",
+    "    print e\n",
+    "else:\n",
+    "    print \"test_slack passed\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`test_task_placement` checks that the task placement was energy efficient, taking advantage of lower-power CPUs whenever possible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-01-23 18:50:59,076 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:59,079 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:59,080 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:59,083 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:59,084 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:59,086 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:59,087 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:59,090 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:59,092 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:59,094 INFO    : EnergyModel  :    EnergyModel - Done\n",
+      "2017-01-23 18:50:59,095 INFO    : EnergyModel  :    EnergyModel - Searching 36 configurations for optimal task placement...\n",
+      "2017-01-23 18:50:59,096 INFO    : EnergyModel  :    EnergyModel - Done\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test_task_placement passed\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    t.test_task_placement()\n",
+    "except AssertionError as e:\n",
+    "    print \"test_task_placement failed:\"\n",
+    "    print e\n",
+    "else:\n",
+    "    print \"test_task_placement passed\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/libs/utils/energy_model.py
+++ b/libs/utils/energy_model.py
@@ -1,0 +1,630 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2016, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from collections import namedtuple
+from itertools import product
+import logging
+import operator
+
+import pandas as pd
+import numpy as np
+
+from devlib.utils.misc import memoized
+
+"""Classes for modeling and estimating energy usage of CPU systems"""
+
+class EnergyModelCapacityError(Exception):
+    """Used by :meth:`EnergyModel.get_optimal_placements`"""
+    pass
+
+class ActiveState(namedtuple('ActiveState', ['capacity', 'power'])):
+    """Represents power and compute capacity at a given frequency
+
+    :param capacity: Relative compute capacity at frequency
+    :param power: Power usage at frequency
+    """
+    def __new__(cls, capacity=None, power=None):
+        return super(ActiveState, cls).__new__(cls, capacity, power)
+
+class _CpuTree(object):
+    """Internal class. Abstract representation of a CPU topology.
+
+    Each node contains either a single CPU or a set of child nodes.
+    """
+    def __init__(self, cpu, children):
+        if (cpu is None) == (children is None):
+            raise ValueError('Provide exactly one of: cpu or children')
+
+        self.parent = None
+
+        if cpu is not None:
+            self.cpus = (cpu,)
+            self.children = []
+        else:
+            if len(children) == 0:
+                raise ValueError('children cannot be empty')
+            self.cpus = tuple(sorted(set().union(*[n.cpus for n in children])))
+            self.children = children
+            for child in children:
+                child.parent = self
+
+        self.name = None
+
+    def __repr__(self):
+        name_bit = ''
+        if self.name:
+            name_bit = 'name="{}", '.format(self.name)
+
+        if self.children:
+            return '{}({}children={})'.format(
+                self.__class__.__name__, name_bit, self.children)
+        else:
+            return '{}({}cpus={})'.format(
+                self.__class__.__name__, name_bit, self.cpus)
+
+    def _iter(self, include_non_leaves):
+        for child in self.children:
+            for child_i in child._iter(include_non_leaves):
+                yield child_i
+        if include_non_leaves or not self.children:
+            yield self
+
+    def iter_nodes(self):
+        """Iterate over nodes depth-first, post-order"""
+        return self._iter(True)
+
+    def iter_leaves(self):
+        """Iterate over leaves"""
+        return self._iter(False)
+
+class EnergyModelNode(_CpuTree):
+    """Describes topology and energy data for an EnergyModel.
+
+    Represents a CPU topology with energy data. The active and idle state data
+    represents the power usage of just the hardware resources of this topology
+    level, not its children. e.g. If the node represents a cluster, the power
+    numbers should not include power used by the CPU - that power should be
+    included the data of the child nodes.
+
+    Exactly one of ``cpu`` and ``children`` must be given.
+
+    :param active_states: Dict mapping frequencies to :class:`ActiveState`
+                          values. Compute capacity data is optional for
+                          non-leaf nodes.
+    :param idle_states: Dict mapping idle state names to power usage values
+    :param cpu: The CPU this node represents. If provided, this is a leaf node.
+    :type cpus: tuple(int)
+    :param children: Non-empty list of child :class:`EnergyModelNode` objects
+    :param name: Optional human-readable name for this node. Leaf (CPU) nodes
+                 have a default name of "cpuN" where N is the cpu number.
+
+    :ivar cpus: CPUs contained in this node. Includes those of child nodes.
+    """
+    def __init__(self, active_states, idle_states,
+                 cpu=None, children=None, name=None):
+        super(EnergyModelNode, self).__init__(cpu, children)
+
+        def is_monotonic(l, decreasing=False):
+            op = operator.ge if decreasing else operator.le
+            return all(op(a, b) for a, b in zip(l, l[1:]))
+
+        if active_states:
+            # Sanity check for active_states's frequencies
+            freqs = active_states.keys()
+            if not is_monotonic(freqs):
+                raise ValueError(
+                    'Active states frequencies are expected to be '
+                    'monotonically increasing. Freqs: {}'.format(freqs))
+
+            # Sanity check for active_states's powers
+            power_vals = [s.power for s in active_states.values()]
+            if not is_monotonic(power_vals):
+                raise ValueError(
+                    'Active states powers are expected to be '
+                    'monotonically increasing. Values: {}'.format(power_vals))
+
+        # Sanity check for idle_states powers
+        if idle_states:
+            power_vals = idle_states.values()
+            if not is_monotonic(power_vals, decreasing=True):
+                raise ValueError(
+                    'Idle states powers are expected to be '
+                    'monotonically decreasing. Values: {}'.format(power_vals))
+
+        if cpu is not None and not name:
+            name = 'cpu' + str(cpu)
+
+        self.name = name
+        self.active_states = active_states
+        self.idle_states = idle_states
+
+    @property
+    def max_capacity(self):
+        """Compute capacity at highest frequency"""
+        return max(s.capacity for s in self.active_states.values())
+
+class EnergyModelRoot(EnergyModelNode):
+    """
+    Convenience class for root of an EnergyModelNode tree.
+
+    Just like EnergyModelNode except that ``active_states`` and ``idle_states``
+    aren't required.
+    """
+    def __init__(self, active_states=None, idle_states=None,
+                 cpu=None, children=None, name=None):
+        return super(EnergyModelRoot, self).__init__(
+            active_states, idle_states, cpu, children, name)
+
+class PowerDomain(_CpuTree):
+    """Describes the power domain hierarchy for an EnergyModel.
+
+    Power domains are a description of the topological dependencies in hardware
+    for entering idle states. "Composite" states such as cluster-sleep states
+    require a set of CPUs to all be idle before that state can be entered. In
+    that case those CPUs can be grouped into a power domain, and that composite
+    state attached to the power domain. Note that cpuidle is not aware of these
+    dependencies; they are typically handled by the platform firmware.
+
+    Exactly one of ``cpu`` and ``children`` must be given. That is, leaves of
+    the PowerDomain tree always contain exactly one CPU - each CPU is
+    represented as being in a power domain of its own. This represents the
+    assumption that all CPUs have at least one idle state (such as ARM WFI) that
+    they can enter independently of other CPUs.
+
+    :param idle_states: List of names of idle states for this power domain. Does
+                        not store power data - these names are used as keys into
+                        the ``idle_states`` field of :class:`EnergyModelNode`
+                        objects.
+    :param cpu: The CPU this node represents. If provided, this is a leaf node.
+    :param children: Non-empty list of child :class:`PowerDomain` objects
+
+    :ivar cpus: CPUs contained in this node. Includes those of child nodes.
+    :type cpus: tuple(int)
+    """
+    def __init__(self, idle_states, cpu=None, children=None):
+        super(PowerDomain, self).__init__(cpu, children)
+        self.idle_states = idle_states
+
+class EnergyModel(object):
+    """Represents hierarchical CPU topology with power and capacity data
+
+    An energy model consists of
+
+    - A CPU topology, representing the physical (cache/interconnect) topology of
+      the CPUs.  Each node stores the energy usage of that node's hardware when
+      it is in each active or idle state. They also store a compute capacity at
+      each frequency, but this is only meaningful for leaf nodes (CPUs) and may
+      be None at higher levels. These capacity values are relative; the maximum
+      capacity would usually be 1024, the value of SCHED_CAPACITY_SCALE in the
+      Linux kernel scheduler.  Use EnergyModelNodes to describe this.
+
+    - A power domain topology, representing the hierarchy of areas that can be
+      powered down (idled).
+      The power domains are a single tree. Leaf nodes must contain exactly one
+      CPU and the root node must indirectly contain every CPU. Each power domain
+      has a list (maybe empty) of names of idle states that that domain can
+      enter.
+      Use PowerDomains to describe this.
+
+    - A set of frequency domains, representing groups of CPUs whose clock
+      frequencies must be equal (probably because they share a clock). The
+      frequency domains must be a partition of the CPUs.
+
+    :ivar cpu_nodes: List of leaf (CPU) :class:`EnergyModelNode`
+    :ivar cpus: List of logical CPU numbers in the system
+
+    :param root_node: Root of :class:`EnergyModelNode` tree
+    :param root_power_domain: Root of :class:`PowerDomain` tree
+    :param freq_domains: Collection of collections of logical CPU numbers
+                         representing frequency (clock) domains.
+
+    .. note::
+      The most signficant shortcomings of the model are:
+
+        1. Voltage domains are assumed to be congruent to frequency domains
+
+        2. Idle state power is assumed to be independent of voltage
+
+        3. Temperature is ignored entirely
+
+    .. _cpu-utils:
+
+    .. admonition:: ``cpu_utils``: CPU util distributions
+
+        Used throughout this module: A ``cpu_utils`` is a list ``u`` where
+        ``u[N]`` is the sum of the frequency-invariant, capacity-invariant
+        utilization of tasks placed on CPU N. That is, the quantity represented
+        by a CPU runqueue's util_avg in the Linux kernel scheduler's
+        load-tracking system with EAS features enabled.
+
+        The range of utilization values is 0 -
+        :attr:`EnergyModel.capacity_scale`.
+
+        This represents a static utilization, assuming that tasks don't change
+        in size (for example representing a set of fixed periodic RT-App
+        workloads). For workloads that change over time, a series of
+        ``cpu_utils`` items would be needed to describe the utilization, with a
+        distinct estimation for each item in the series.
+    """
+
+    capacity_scale = 1024
+    """The relative computational capacity of the most powerful CPU at its
+    highest available frequency.
+    """
+
+    def __init__(self, root_node, root_power_domain, freq_domains):
+        self.cpus = root_node.cpus
+        if self.cpus != tuple(range(len(self.cpus))):
+            raise ValueError('CPU IDs [{}] are sparse'.format(self.cpus))
+
+        # Check that freq_domains is a partition of the CPUs
+        fd_intersection = set().intersection(*freq_domains)
+        if fd_intersection:
+            raise ValueError('CPUs {} exist in multiple freq domains'.format(
+                fd_intersection))
+        fd_difference = set(self.cpus) - set().union(*freq_domains)
+        if fd_difference:
+            raise ValueError('CPUs {} not in any frequency domain'.format(
+                fd_difference))
+        self.freq_domains = freq_domains
+
+        # Check that nodes with energy data are all within a frequency domain
+        for node in root_node.iter_nodes():
+            if not node.active_states or node.idle_states:
+                continue
+            cpu_freq_doms = []
+            for cpu in node.cpus:
+                [cpu_freq_dom] = [d for d in freq_domains if cpu in d]
+                cpu_freq_doms.append(cpu_freq_dom)
+            if not all(d == cpu_freq_doms[0] for d in cpu_freq_doms[1:]):
+                raise ValueError(
+                    'Node {} (CPUs {}) '
+                    'has energy data and overlaps freq domains'.format(
+                        node.name, node.cpus))
+
+        def sorted_leaves(root):
+            # Get a list of the leaf (cpu) nodes of a _CpuTree in order of the
+            # CPU ID
+            ret = sorted(list(root.iter_leaves()), key=lambda n: n.cpus[0])
+            assert all(len(n.cpus) == 1 for n in ret)
+            return ret
+
+        self.root = root_node
+        self.cpu_nodes = sorted_leaves(root_node)
+        self.cpu_pds = sorted_leaves(root_power_domain)
+        assert len(self.cpu_pds) == len(self.cpu_nodes)
+
+        self._log = logging.getLogger('EnergyModel')
+
+        max_cap = max(n.max_capacity for n in self.cpu_nodes)
+        if max_cap != self.capacity_scale:
+            self._log.warning(
+                'Unusual max capacity (%s), overriding capacity_scale', max_cap)
+            self.capacity_scale = max_cap
+
+    def _cpus_with_capacity(self, cap):
+        """
+        Helper method to find the CPUs whose max capacity equals cap
+        """
+        return [c for c in self.cpus
+                if self.cpu_nodes[c].max_capacity == cap]
+
+    @property
+    @memoized
+    def biggest_cpus(self):
+        """
+        The CPUs with the highest compute capacity at their highest frequency
+        """
+        return self._cpus_with_capacity(self.capacity_scale)
+
+    @property
+    @memoized
+    def littlest_cpus(self):
+        """
+        The CPUs with the lowest compute capacity at their highest frequency
+        """
+        min_cap = min(n.max_capacity for n in self.cpu_nodes)
+        return self._cpus_with_capacity(min_cap)
+
+    @property
+    @memoized
+    def is_heterogeneous(self):
+        """
+        True iff CPUs do not all have the same efficiency and OPP range
+        """
+        states = self.cpu_nodes[0].active_states
+        return any(c.active_states != states for c in self.cpu_nodes[1:])
+
+    def _guess_idle_states(self, cpus_active):
+        def find_deepest(pd):
+            if not any(cpus_active[c] for c in pd.cpus):
+                if pd.parent:
+                    parent_state = find_deepest(pd.parent)
+                    if parent_state:
+                        return parent_state
+                return pd.idle_states[-1] if len(pd.idle_states) else None
+            return None
+
+        return [find_deepest(pd) for pd in self.cpu_pds]
+
+    def guess_idle_states(self, cpus_active):
+        """Pessimistically guess the idle states that each CPU may enter
+
+        If a CPU has any tasks it is estimated that it may only enter its
+        shallowest idle state in between task activations. If all the CPUs
+        within a power domain have no tasks, they will all be judged able to
+        enter that domain's deepest idle state. If any CPU in a domain has work,
+        no CPUs in that domain are assumed to enter any domain shared state.
+
+        e.g. Consider a system with
+
+        - two power domains PD0 and PD1
+
+        - 4 CPUs, with CPUs [0, 1] in PD0 and CPUs [2, 3] in PD1
+
+        - 4 idle states: "WFI", "cpu-sleep", "cluster-sleep-0" and
+          "cluster-sleep-1", where the "cluster-sleep-*" states domain states,
+          i.e. a CPU can only enter those states when both CPUs in the domain
+          are idle.
+
+        Then here are some example inputs and outputs:
+
+        ::
+
+          # All CPUs idle:
+          [0, 0, 0, 0] -> ["cluster-sleep-1", "cluster-sleep-1",
+                           "cluster-sleep-1", "cluster-sleep-1"]
+
+          # All CPUs have work
+          [1, 1, 1, 1] -> ["WFI","WFI","WFI", "WFI"]
+
+          # One power domain active, the other idle
+          [0, 0, 1, 1] -> ["cluster-sleep-1", "cluster-sleep-1", "WFI","WFI"]
+
+          # One CPU active.
+          # Note that CPU 2 has no work but is assumed to never be able to enter
+          # any "cluster" state.
+          [0, 0, 0, 1] -> ["cluster-sleep-1", "cluster-sleep-1",
+                           "cpu-sleep","WFI"]
+
+        :param cpus_active: list where bool(cpus_active[N]) is False iff no
+                            tasks will run on CPU N.
+        :returns: List ``ret`` where ``ret[N]`` is the name of the estimated
+                  idle state that CPU N can enter during idle periods.
+
+        """
+        states = self._guess_idle_states(cpus_active)
+        return [s or c.idle_states.keys()[0]
+                for s, c in zip(states, self.cpu_nodes)]
+
+    def _guess_freqs(self, cpu_utils):
+        overutilized = False
+        # Find what frequency each CPU would need if it was alone in its
+        # frequency domain
+        ideal_freqs = [0 for _ in self.cpus]
+        for node in self.cpu_nodes:
+            [cpu] = node.cpus
+            required_cap = cpu_utils[cpu]
+
+            possible_freqs = [f for f, s in node.active_states.iteritems()
+                              if s.capacity >= required_cap]
+
+            if possible_freqs:
+                ideal_freqs[cpu] = min(possible_freqs)
+            else:
+                # CPU cannot provide required capacity, use max freq
+                ideal_freqs[cpu] = max(node.active_states.keys())
+                overutilized = True
+
+        # Rectify the frequencies among domains
+        freqs = [0 for _ in ideal_freqs]
+        for domain in self.freq_domains:
+            domain_freq = max(ideal_freqs[c] for c in domain)
+            for cpu in domain:
+                freqs[cpu] = domain_freq
+
+        return freqs, overutilized
+
+    def guess_freqs(self, cpu_utils):
+        """Work out CPU frequencies required to execute a workload
+
+        Find the lowest possible frequency for each CPU that provides enough
+        capacity to satisfy the utilization, taking into account frequency
+        domains.
+
+        :param cpu_utils: Utilization distribution, see
+                             :ref:`cpu_utils <cpu-utils>`
+        :returns: List ``ret`` where ``ret[N]`` is the frequency that CPU N must
+                  run at
+        """
+        freqs, _ = self._guess_freqs(cpu_utils)
+        return freqs
+
+    def _estimate_from_active_time(self, cpu_active_time, freqs, idle_states,
+                                   combine):
+        """Helper for estimate_from_cpu_util
+
+        Like estimate_from_cpu_util but uses active time i.e. proportion of time
+        spent not-idle in the range 0.0 - 1.0.
+
+        If combine=False, return idle and active power as separate components.
+        """
+        power = 0
+        ret = {}
+
+        assert all(0.0 <= a <= 1.0 for a in cpu_active_time)
+
+        for node in self.root.iter_nodes():
+            # Some nodes might not have energy model data, they could just be
+            # used to group other nodes (likely the root node, for example).
+            if not node.active_states or not node.idle_states:
+                continue
+
+            cpus = tuple(node.cpus)
+            # For now we assume topology nodes with energy models do not overlap
+            # with frequency domains
+            freq = freqs[cpus[0]]
+            assert all(freqs[c] == freq for c in cpus[1:])
+
+            # The active time of a node is estimated as the max of the active
+            # times of its children.
+            # This works great for the synthetic periodic workloads we use in
+            # LISA (where all threads wake up at the same time) but is probably
+            # no good for real workloads.
+            active_time = max(cpu_active_time[c] for c in cpus)
+            active_power = node.active_states[freq].power * active_time
+
+            _idle_power = max(node.idle_states[idle_states[c]] for c in cpus)
+            idle_power = _idle_power * (1 - active_time)
+
+            if combine:
+                ret[cpus] = active_power + idle_power
+            else:
+                ret[cpus] = {}
+                ret[cpus]["active"] = active_power
+                ret[cpus]["idle"] = idle_power
+
+        return ret
+
+    def estimate_from_cpu_util(self, cpu_utils, freqs=None, idle_states=None):
+        """
+        Estimate the energy usage of the system under a utilization distribution
+
+        Optionally also take freqs; a list of frequencies at which each CPU is
+        assumed to run, and idle_states, the idle states that each CPU can enter
+        between activations. If not provided, they will be estimated assuming an
+        ideal selection system (i.e. perfect cpufreq & cpuidle governors).
+
+        :param cpu_utils: Utilization distribution, see
+                             :ref:`cpu_utils <cpu-utils>`
+        :param freqs: List of CPU frequencies. Got from :meth:`guess_freqs` by
+                      default.
+        :param idle_states: List of CPU frequencies. Got from
+                            :meth:`guess_idle_states` by default.
+
+        :returns: Dict with power in bogo-Watts (bW), with contributions from
+                  each system component keyed with a tuple of the CPUs
+                  comprising that component (i.e. :attr:EnergyModelNode.cpus)
+
+                  ::
+
+                    {
+                        (0,)    : 10,
+                        (1,)    : 10,
+                        (0, 1)  : 5,
+                    }
+
+                  This represents CPUs 0 and 1 each using 10bW and their shared
+                  resources using 5bW for a total of 25bW.
+        """
+        if len(cpu_utils) != len(self.cpus):
+            raise ValueError(
+                'cpu_utils length ({}) must equal CPU count ({})'.format(
+                    len(cpu_utils), len(self.cpus)))
+
+        if freqs is None:
+            freqs = self.guess_freqs(cpu_utils)
+        if idle_states is None:
+            idle_states = self.guess_idle_states(cpu_utils)
+
+        cpu_active_time = []
+        for cpu, node in enumerate(self.cpu_nodes):
+            assert (cpu,) == node.cpus
+            cap = node.active_states[freqs[cpu]].capacity
+            cpu_active_time.append(min(float(cpu_utils[cpu]) / cap, 1.0))
+
+        return self._estimate_from_active_time(cpu_active_time,
+                                               freqs, idle_states, combine=True)
+
+    def get_optimal_placements(self, capacities):
+        """Find the optimal distribution of work for a set of tasks
+
+        Find a list of candidates which are estimated to be optimal in terms of
+        power consumption, but that do not result in any CPU becoming
+        over-utilized.
+
+        If no such candidates exist, i.e. the system being modeled cannot
+        satisfy the workload's throughput requirements, an
+        :class:`EnergyModelCapacityError` is raised. For example, if e was an
+        EnergyModel modeling two CPUs with capacity 1024, this error would be
+        raised by:
+
+        ::
+
+          e.get_optimal_placements({"t1": 800, "t2": 800, "t3: "800"})
+
+        This estimation assumes an ideal system of selecting OPPs and idle
+        states for CPUs.
+
+        .. note::
+            This is a brute force search taking time exponential wrt. the number
+            of tasks.
+
+        :param capacities: Dict mapping tasks to expected utilization
+                           values. These tasks are assumed not to change; they
+                           have a single static utilization value. A set of
+                           single-phase periodic RT-App tasks is an example of a
+                           suitable workload for this model.
+        :returns: List of ``cpu_utils`` items representing distributions of work
+                  under optimal task placements, see
+                  :ref:`cpu_utils <cpu-utils>`. Multiple task placements
+                  that result in the same CPU utilizations are considered
+                  equivalent.
+        """
+        tasks = capacities.keys()
+
+        num_candidates = len(self.cpus) ** len(tasks)
+        self._log.debug(
+            '%14s - Searching %d configurations for optimal task placement...',
+            'EnergyModel', num_candidates)
+
+        candidates = {}
+        excluded = []
+        for cpus in product(self.cpus, repeat=len(tasks)):
+            placement = {task: cpu for task, cpu in zip(tasks, cpus)}
+
+            util = [0 for _ in self.cpus]
+            for task, cpu in placement.items():
+                util[cpu] += capacities[task]
+            util = tuple(util)
+
+            # Filter out candidate placements that have tasks greater than max
+            # or that we have already determined that we cannot place.
+            if (any(u > self.capacity_scale for u in util) or util in excluded):
+                continue
+
+            if util not in candidates:
+                freqs, overutilized = self._guess_freqs(util)
+                if overutilized:
+                    # This isn't a valid placement
+                    excluded.append(util)
+                else:
+                    power = self.estimate_from_cpu_util(util, freqs=freqs)
+                    candidates[util] = sum(power.values())
+
+        if not candidates:
+            # The system can't provide full throughput to this workload.
+            raise EnergyModelCapacityError(
+                "Can't handle workload - total cap = {}".format(
+                    sum(capacities.values())))
+
+        # Whittle down to those that give the lowest energy estimate
+        min_power = min(p for p in candidates.itervalues())
+        ret = [u for u, p in candidates.iteritems() if p == min_power]
+
+        self._log.debug('%14s - Done', 'EnergyModel')
+        return ret

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -26,15 +26,16 @@ import time
 import unittest
 
 import devlib
+from devlib.utils.misc import memoized
+from devlib import Platform
+from trappy.stats.Topology import Topology
 
 from wlgen import RTA
 from energy import EnergyMeter
 from conf import JsonConf
-
-from devlib.utils.misc import memoized
-from trappy.stats.Topology import Topology
-
-from devlib import Platform
+from platforms.juno_energy import juno_energy
+from platforms.hikey_energy import hikey_energy
+from platforms.pixel_energy import pixel_energy
 
 USERNAME_DEFAULT = 'root'
 PASSWORD_DEFAULT = ''
@@ -416,12 +417,25 @@ class TestEnv(ShareState):
         # Initialize JUNO board
         elif self.conf['board'].upper() in ('JUNO', 'JUNO2'):
             platform = devlib.platform.arm.Juno()
+            self.nrg_model = juno_energy
             self.__modules = ['bl', 'hwmon', 'cpufreq']
 
         # Initialize OAK board
         elif self.conf['board'].upper() == 'OAK':
             platform = Platform(model='MT8173')
             self.__modules = ['bl', 'cpufreq']
+
+        # Initialized HiKey board
+        elif self.conf['board'].upper() == 'HIKEY':
+            self.nrg_model = hikey_energy
+            self.__modules = [ "cpufreq", "cpuidle" ]
+            platform = Platform(model='hikey')
+
+        # Initialize Pixel phone
+        elif self.conf['board'].upper() == 'PIXEL':
+            self.nrg_model = pixel_energy
+            self.__modules = ['bl', 'cpufreq']
+            platform = Platform(model='pixel')
 
         elif self.conf['board'] != 'UNKNOWN':
             # Initilize from platform descriptor (if available)

--- a/libs/utils/platforms/hikey_energy.py
+++ b/libs/utils/platforms/hikey_energy.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2016, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from energy_model import (ActiveState, EnergyModelNode, EnergyModelRoot,
+                          PowerDomain, EnergyModel)
+
+from collections import OrderedDict
+
+cluster_active_states = OrderedDict([
+    ( 208000, ActiveState(capacity=178, power=16)),
+    ( 432000, ActiveState(capacity=369, power=29)),
+    ( 729000, ActiveState(capacity=622, power=47)),
+    ( 960000, ActiveState(capacity=819, power=75)),
+    (1200000, ActiveState(capacity=1024, power=112))
+])
+
+cluster_idle_states = OrderedDict([
+    ('WFI', 47),
+    ('cpu-sleep', 47),
+    ('cluster-sleep', 0)
+])
+
+cpu_active_states = OrderedDict([
+    ( 208000,  ActiveState(capacity=178,  power=69)),
+    ( 432000,  ActiveState(capacity=369,  power=125)),
+    ( 729000,  ActiveState(capacity=622,  power=224)),
+    ( 960000,  ActiveState(capacity=819,  power=367)),
+    (1200000, ActiveState(capacity=1024, power=670))
+])
+
+cpu_idle_states = OrderedDict([
+    ('WFI', 15), ('cpu-sleep', 0), ('cluster-sleep', 0)
+])
+
+def cpu_pd(cpu):
+    return PowerDomain(cpu=cpu, idle_states=['WFI', 'cpu-sleep'])
+
+def cpu_node(cpu):
+    return EnergyModelNode(cpu=cpu,
+                           active_states=cpu_active_states,
+                           idle_states=cpu_idle_states)
+hikey_energy = EnergyModel(
+    root_node=EnergyModelRoot(children=[
+        EnergyModelNode(name='cluster0',
+                        children=[cpu_node(c) for c in [0, 1, 2, 3]],
+                        active_states=cluster_active_states,
+                        idle_states=cluster_idle_states),
+        EnergyModelNode(name='cluster1',
+                        children=[cpu_node(c) for c in [4, 5, 6, 7]],
+                        active_states=cluster_active_states,
+                        idle_states=cluster_idle_states)]),
+    root_power_domain=PowerDomain(idle_states=[], children=[
+        PowerDomain(idle_states=["cluster-sleep"], children=[
+            cpu_pd(c) for c in [0, 1, 2, 3]]),
+        PowerDomain(idle_states=["cluster-sleep"], children=[
+            cpu_pd(c) for c in [4, 5, 6, 7]])]),
+    freq_domains=[[0, 1, 2, 3, 4, 5, 6, 7]])

--- a/libs/utils/platforms/juno_energy.py
+++ b/libs/utils/platforms/juno_energy.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2016, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from collections import OrderedDict
+
+from energy_model import (ActiveState, EnergyModelNode, EnergyModelRoot,
+                          PowerDomain, EnergyModel)
+
+a53_cluster_active_states = OrderedDict([
+    (450000, ActiveState(power=26)),
+    (575000, ActiveState(power=30)),
+    (700000, ActiveState(power=39)),
+    (775000, ActiveState(power=47)),
+    (850000, ActiveState(power=57)),
+])
+
+# TODO warn if any of the idle states aren't represented by power domains
+a53_cluster_idle_states = OrderedDict([
+    ("WFI",               56),
+    ("cpu-sleep-0",       56),
+    ("cluster-sleep-0",   17),
+])
+
+a53_cpu_active_states = OrderedDict([
+    (450000, ActiveState(capacity=235, power=33)),
+    (575000, ActiveState(capacity=302, power=46)),
+    (700000, ActiveState(capacity=368, power=61)),
+    (775000, ActiveState(capacity=406, power=76)),
+    (850000, ActiveState(capacity=447, power=93)),
+])
+
+a53_cpu_idle_states = OrderedDict([
+    ("WFI",               6),
+    ("cpu-sleep-0",       0),
+    ("cluster-sleep-0",   0),
+])
+
+a53s = [0, 3, 4, 5]
+
+def a53_cpu_node(cpu):
+    return EnergyModelNode(cpu=cpu,
+                           active_states=a53_cpu_active_states,
+                           idle_states=a53_cpu_idle_states)
+
+a57_cluster_active_states = OrderedDict([
+    ( 450000, ActiveState(power=24)),
+    ( 625000, ActiveState(power=32)),
+    ( 800000, ActiveState(power=43)),
+    ( 950000, ActiveState(power=49)),
+    (1100000, ActiveState(power=64)),
+])
+
+a57_cluster_idle_states = OrderedDict([
+    ("WFI",               65),
+    ("cpu-sleep-0",       65),
+    ("cluster-sleep-0",   24),
+])
+
+a57_cpu_active_states = OrderedDict([
+    (450000,  ActiveState(capacity=417,   power=168)),
+    (625000,  ActiveState(capacity=579,   power=251)),
+    (800000,  ActiveState(capacity=744,   power=359)),
+    (950000,  ActiveState(capacity=883,   power=479)),
+    (1100000, ActiveState(capacity=1024,  power=616)),
+])
+
+a57_cpu_idle_states = OrderedDict([
+    ("WFI",               15),
+    ("cpu-sleep-0",       0),
+    ("cluster-sleep-0",   0),
+])
+
+a57s = [1, 2]
+
+def a57_cpu_node(cpu):
+    return EnergyModelNode(cpu=cpu,
+                           active_states=a57_cpu_active_states,
+                           idle_states=a57_cpu_idle_states)
+
+juno_energy = EnergyModel(
+    root_node=EnergyModelRoot(
+        children=[
+            EnergyModelNode(
+                name="cluster_a57",
+                active_states=a57_cluster_active_states,
+                idle_states=a57_cluster_idle_states,
+                children=[a57_cpu_node(c) for c in a57s]),
+            EnergyModelNode(
+                name="cluster_a53",
+                active_states=a53_cluster_active_states,
+                idle_states=a53_cluster_idle_states,
+                children=[a53_cpu_node(c) for c in a53s])]),
+    root_power_domain=PowerDomain(idle_states=[], children=[
+        PowerDomain(
+            idle_states=["cluster-sleep-0"],
+            children=[PowerDomain(idle_states=["WFI", "cpu-sleep-0"], cpu=c)
+                      for c in a57s]),
+        PowerDomain(
+            idle_states=["cluster-sleep-0"],
+            children=[PowerDomain(idle_states=["WFI", "cpu-sleep-0"], cpu=c)
+                      for c in a53s])]),
+    freq_domains=[a53s, a57s])

--- a/libs/utils/platforms/pixel_energy.py
+++ b/libs/utils/platforms/pixel_energy.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2016, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from energy_model import (ActiveState, EnergyModelNode, EnergyModelRoot,
+                          PowerDomain, EnergyModel)
+
+from collections import OrderedDict
+
+silver_cpu_active_states = OrderedDict([
+    ( 307200, ActiveState(capacity=149, power=90)),
+    ( 384000, ActiveState(capacity=188, power=111)),
+    ( 460800, ActiveState(capacity=225, power=133)),
+    ( 537600, ActiveState(capacity=257, power=160)),
+    ( 614400, ActiveState(capacity=281, power=182)),
+    ( 691200, ActiveState(capacity=315, power=210)),
+    ( 768000, ActiveState(capacity=368, power=251)),
+    ( 844800, ActiveState(capacity=406, power=306)),
+    ( 902400, ActiveState(capacity=428, power=332)),
+    ( 979200, ActiveState(capacity=469, power=379)),
+    (1056000, ActiveState(capacity=502, power=438)),
+    (1132800, ActiveState(capacity=538, power=494)),
+    (1209600, ActiveState(capacity=581, power=550)),
+    (1286400, ActiveState(capacity=611, power=613)),
+    (1363200, ActiveState(capacity=648, power=670)),
+    (1440000, ActiveState(capacity=684, power=752)),
+    (1516800, ActiveState(capacity=729, power=848)),
+    (1593600, ActiveState(capacity=763, power=925)),
+])
+
+silver_cluster_active_states = OrderedDict([
+    ( 307200, ActiveState(power=4)),
+    ( 384000, ActiveState(power=4)),
+    ( 460800, ActiveState(power=4)),
+    ( 537600, ActiveState(power=4)),
+    ( 614400, ActiveState(power=4)),
+    ( 691200, ActiveState(power=4)),
+    ( 768000, ActiveState(power=8)),
+    ( 844800, ActiveState(power=9)),
+    ( 902400, ActiveState(power=15)),
+    ( 979200, ActiveState(power=16)),
+    (1056000, ActiveState(power=21)),
+    (1132800, ActiveState(power=22)),
+    (1209600, ActiveState(power=29)),
+    (1286400, ActiveState(power=32)),
+    (1363200, ActiveState(power=42)),
+    (1440000, ActiveState(power=49)),
+    # This power value is 41 (invalid!) in the released kernel. Patch it to
+    # avoid errors.
+    (1516800, ActiveState(power=52)),
+    (1593600, ActiveState(power=52)),
+])
+
+gold_cpu_active_states = OrderedDict([
+    ( 307200, ActiveState(capacity=149, power=93)),
+    ( 384000, ActiveState(capacity=188, power=111)),
+    ( 460800, ActiveState(capacity=225, power=133)),
+    ( 537600, ActiveState(capacity=257, power=160)),
+    ( 614400, ActiveState(capacity=281, power=182)),
+    ( 691200, ActiveState(capacity=315, power=210)),
+    ( 748800, ActiveState(capacity=348, power=252)),
+    ( 825600, ActiveState(capacity=374, power=290)),
+    ( 902400, ActiveState(capacity=428, power=332)),
+    ( 979200, ActiveState(capacity=469, power=379)),
+    (1056000, ActiveState(capacity=502, power=438)),
+    (1132800, ActiveState(capacity=538, power=494)),
+    (1209600, ActiveState(capacity=581, power=550)),
+    (1286400, ActiveState(capacity=611, power=613)),
+    (1363200, ActiveState(capacity=648, power=670)),
+    (1440000, ActiveState(capacity=684, power=752)),
+    (1516800, ActiveState(capacity=729, power=848)),
+    (1593600, ActiveState(capacity=763, power=925)),
+    (1670400, ActiveState(capacity=795, power=1018)),
+    (1747200, ActiveState(capacity=832, power=1073)),
+    (1824000, ActiveState(capacity=868, power=1209)),
+    (1900800, ActiveState(capacity=905, power=1298)),
+    (1977600, ActiveState(capacity=952, power=1428)),
+    (2054400, ActiveState(capacity=979, power=1521)),
+    (2150400, ActiveState(capacity=1024, power=1715)),
+])
+
+gold_cluster_active_states = OrderedDict([
+    ( 307200, ActiveState(power=4)),
+    ( 384000, ActiveState(power=4)),
+    ( 460800, ActiveState(power=4)),
+    ( 537600, ActiveState(power=4)),
+    ( 614400, ActiveState(power=4)),
+    ( 691200, ActiveState(power=4)),
+    ( 748800, ActiveState(power=7)),
+    ( 825600, ActiveState(power=10)),
+    ( 902400, ActiveState(power=15)),
+    ( 979200, ActiveState(power=16)),
+    (1056000, ActiveState(power=21)),
+    (1132800, ActiveState(power=22)),
+    (1209600, ActiveState(power=29)),
+    (1286400, ActiveState(power=32)),
+    (1363200, ActiveState(power=42)),
+    (1440000, ActiveState(power=49)),
+    # This power value is 41 (invalid!) in the released kernel. Patch it to
+    # avoid errors.
+    (1516800, ActiveState(power=52)),
+    (1593600, ActiveState(power=52)),
+    (1670400, ActiveState(power=62)),
+    (1747200, ActiveState(power=69)),
+    (1824000, ActiveState(power=75)),
+    (1900800, ActiveState(power=81)),
+    (1977600, ActiveState(power=90)),
+    (2054400, ActiveState(power=93)),
+    (2150400, ActiveState(power=96)),
+])
+
+# TODO warn if any of the idle states aren't represented by power domains
+cpu_idle_states = OrderedDict([
+    ("WFI",               2),
+    ("cpu-sleep-0",       0),
+    ("cluster-sleep-0",   0),
+])
+
+cluster_idle_states = OrderedDict([
+    ("WFI",               0),
+    ("cpu-sleep-0",       0),
+    ("cluster-sleep-0",   0),
+])
+
+silvers = [0, 1]
+golds = [2, 3]
+
+def silver_cpu_node(cpu):
+    return EnergyModelNode(cpu=cpu,
+                           active_states=silver_cpu_active_states,
+                           idle_states=cpu_idle_states)
+
+def gold_cpu_node(cpu):
+    return EnergyModelNode(cpu=cpu,
+                           active_states=gold_cpu_active_states,
+                           idle_states=cpu_idle_states)
+
+def cpu_pd(cpu):
+    return PowerDomain(cpu=cpu, idle_states=["WFI", "cpu-sleep-0"])
+
+pixel_energy = EnergyModel(
+    root_node=EnergyModelRoot(children=[
+        EnergyModelNode(name='cluster_silver',
+                        children=[silver_cpu_node(c) for c in silvers],
+                        active_states=silver_cluster_active_states,
+                        idle_states=cluster_idle_states),
+        EnergyModelNode(name='cluster_gold',
+                        children=[gold_cpu_node(c) for c in golds],
+                        active_states=gold_cluster_active_states,
+                        idle_states=cluster_idle_states)]),
+    root_power_domain=PowerDomain(idle_states=[], children=[
+        PowerDomain(idle_states=['cluster-sleep-0'], children=[
+            cpu_pd(c) for c in silvers]),
+        PowerDomain(idle_states=['cluster-sleep-0'], children=[
+            cpu_pd(c) for c in golds])]),
+    freq_domains=[silvers, golds])

--- a/tests/eas/__init__.py
+++ b/tests/eas/__init__.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2016-2017, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest import SkipTest
+
+from bart.sched.SchedMultiAssert import SchedMultiAssert
+from devlib.target import TargetError
+from test import LisaTest
+
+WORKLOAD_DURATION_S = 5
+WORKLOAD_PERIOD_MS =  10
+SWITCH_WINDOW_HALF = 0.5
+SMALL_DCYCLE = 10
+BIG_DCYCLE = 100
+STEP_HIGH_DCYCLE = 50
+STEP_LOW_DCYCLE = 10
+EXPECTED_RESIDENCY_PCT = 85
+OFFLOAD_EXPECTED_BUSY_TIME_PCT = 97
+SET_IS_BIG_LITTLE = True
+SET_INITIAL_TASK_UTIL = True
+OFFLOAD_MIGRATION_MIGRATOR_DELAY = 1
+
+energy_aware_conf = {
+    "tag" : "energy_aware",
+    "flags" : ["ftrace", "freeze_userspace"],
+    "sched_features" : "ENERGY_AWARE",
+}
+
+class _EasTest(LisaTest):
+    """
+    Base class for EAS tests
+    """
+
+    test_conf = {
+        "ftrace" : {
+            "events" : [
+                "sched_overutilized",
+                "sched_energy_diff",
+                "sched_load_avg_task",
+                "sched_load_avg_cpu",
+                "sched_migrate_task",
+                "sched_switch"
+            ],
+        },
+        "modules": ["cgroups"],
+    }
+
+    # Set to true to run a test only on heterogeneous systems
+    skip_on_smp = False
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super(_EasTest, cls).runExperiments(*args, **kwargs)
+
+    @classmethod
+    def _getExperimentsConf(cls, test_env):
+        if cls.skip_on_smp and not test_env.nrg_model.is_heterogeneous:
+            raise SkipTest('Test not required on symmetric systems')
+        return super(_EasTest, cls)._getExperimentsConf(test_env)
+
+    @classmethod
+    def _experimentsInit(cls, *args, **kwargs):
+        super(_EasTest, cls)._experimentsInit(*args, **kwargs)
+
+        if SET_IS_BIG_LITTLE:
+            # This flag doesn't exist on mainline-integration kernels, so
+            # don't worry if the file isn't present (hence verify=False)
+            cls.target.write_value(
+                "/proc/sys/kernel/sched_is_big_little", 1, verify=False)
+
+        if SET_INITIAL_TASK_UTIL:
+            # This flag doesn't exist on all kernels, so don't worry if the file
+            # isn't present (hence verify=False)
+            cls.target.write_value(
+                "/proc/sys/kernel/sched_initial_task_util", 1024, verify=False)
+
+    def _do_test_first_cpu(self, experiment, tasks):
+        """Test that all tasks start on a big CPU"""
+
+        sched_assert = self.get_multi_assert(experiment)
+
+        self.assertTrue(
+            sched_assert.assertFirstCpu(
+                self.te.nrg_model.biggest_cpus,
+                rank=len(tasks)),
+            msg="Not all the new generated tasks started on a big CPU")

--- a/tests/eas/__init__.py
+++ b/tests/eas/__init__.py
@@ -57,6 +57,9 @@ class _EasTest(LisaTest):
             ],
         },
         "modules": ["cgroups"],
+        "cpufreq" : {
+            "governor" : "sched",
+        },
     }
 
     # Set to true to run a test only on heterogeneous systems

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -26,88 +26,18 @@ from bart.sched.SchedAssert import SchedAssert
 
 from devlib.target import TargetError
 
-from env import TestEnv
-from test import LisaTest, experiment_test
-
-# Global test configuration parameters
-WORKLOAD_DURATION_S = 5
-WORKLOAD_PERIOD_MS =  10
-SWITCH_WINDOW_HALF = 0.5
-SMALL_DCYCLE = 10
-BIG_DCYCLE = 100
-STEP_HIGH_DCYCLE = 50
-STEP_LOW_DCYCLE = 10
-EXPECTED_RESIDENCY_PCT = 85
-OFFLOAD_EXPECTED_BUSY_TIME_PCT = 97
-SET_IS_BIG_LITTLE = True
-SET_INITIAL_TASK_UTIL = True
-OFFLOAD_MIGRATION_MIGRATOR_DELAY = 1
-
-energy_aware_conf = {
-    "tag" : "energy_aware",
-    "flags" : ["ftrace", "freeze_userspace"],
-    "sched_features" : "ENERGY_AWARE",
-}
-
-class _EasTest(LisaTest):
-    """
-    Base class for EAS tests
-    """
-
-    test_conf = {
-        "ftrace" : {
-            "events" : [
-                "sched_overutilized",
-                "sched_energy_diff",
-                "sched_load_avg_task",
-                "sched_load_avg_cpu",
-                "sched_migrate_task",
-                "sched_switch",
-                "cpu_frequency"
-            ],
-        },
-        "modules": ["cgroups"],
-    }
-
-    # Set to true to run a test only on heterogeneous systems
-    skip_on_smp = False
-
-    @classmethod
-    def setUpClass(cls, *args, **kwargs):
-        super(_EasTest, cls).runExperiments(*args, **kwargs)
-
-    @classmethod
-    def _getExperimentsConf(cls, test_env):
-        if cls.skip_on_smp and not test_env.nrg_model.is_heterogeneous:
-            raise SkipTest('Test not required on symmetric systems')
-        return super(EasTest, cls)._getExperimentsConf(test_env)
-
-    @classmethod
-    def _experimentsInit(cls, *args, **kwargs):
-        super(_EasTest, cls)._experimentsInit(*args, **kwargs)
-
-        if SET_IS_BIG_LITTLE:
-            # This flag doesn't exist on mainline-integration kernels, so
-            # don't worry if the file isn't present (hence verify=False)
-            cls.target.write_value(
-                "/proc/sys/kernel/sched_is_big_little", 1, verify=False)
-
-        if SET_INITIAL_TASK_UTIL:
-            # This flag doesn't exist on all kernels, so don't worry if the file
-            # isn't present (hence verify=False)
-            cls.target.write_value(
-                "/proc/sys/kernel/sched_initial_task_util", 1024, verify=False)
-
-    def _do_test_first_cpu(self, experiment, tasks):
-        """Test that all tasks start on a big CPU"""
-
-        sched_assert = self.get_multi_assert(experiment)
-
-        self.assertTrue(
-            sched_assert.assertFirstCpu(
-                self.te.nrg_model.biggest_cpus,
-                rank=len(tasks)),
-            msg="Not all the new generated tasks started on a big CPU")
+from test import experiment_test
+from . import (_EasTest, energy_aware_conf,
+               WORKLOAD_DURATION_S,
+               WORKLOAD_PERIOD_MS,
+               SWITCH_WINDOW_HALF,
+               SMALL_DCYCLE,
+               BIG_DCYCLE,
+               STEP_LOW_DCYCLE,
+               STEP_HIGH_DCYCLE,
+               EXPECTED_RESIDENCY_PCT,
+               OFFLOAD_EXPECTED_BUSY_TIME_PCT,
+               OFFLOAD_MIGRATION_MIGRATOR_DELAY)
 
 class ForkMigration(_EasTest):
     """

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -62,7 +62,8 @@ class _EasTest(LisaTest):
                 "sched_load_avg_task",
                 "sched_load_avg_cpu",
                 "sched_migrate_task",
-                "sched_switch"
+                "sched_switch",
+                "cpu_frequency"
             ],
         },
         "modules": ["cgroups"],

--- a/tests/eas/acceptance.py
+++ b/tests/eas/acceptance.py
@@ -312,7 +312,7 @@ class OffloadMigrationAndIdlePull(_EasTest):
     @experiment_test
     def test_first_cpu(self, experiment, tasks):
         """Offload Migration and Idle Pull: Test First CPU"""
-        self._do_test_first_cpu(experiment, tasks)
+        self._do_test_first_cpu(experiment, [t for t in tasks if "early" in t])
 
     @experiment_test
     def test_big_cpus_fully_loaded(self, experiment, tasks):

--- a/tests/eas/generic.py
+++ b/tests/eas/generic.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2016, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from math import isnan
+
+import numpy as np
+import pandas as pd
+
+from bart.common.Utils import area_under_curve
+
+from energy_model import EnergyModelCapacityError
+from perf_analysis import PerfAnalysis
+from test import experiment_test
+from trace import Trace
+from . import _EasTest, energy_aware_conf, WORKLOAD_PERIOD_MS
+
+class _EnergyModelTest(_EasTest):
+    """
+    "Abstract" base class for generic EAS tests using the EnergyModel class
+
+    Subclasses should provide a .workloads member to populate the 'wloads' field
+    of the experiments_conf for the Executor. A set of helper methods are
+    provided for making assertions about behaviour, most importantly the _test*
+    methods which make assertions in a generic way.
+    """
+
+    negative_slack_allowed_pct = 15
+    """Percentage of RT-App task activations with negative slack allowed"""
+
+    energy_est_threshold_pct = 20
+    """
+    Allowed margin for error in estimated energy cost for task placement,
+    compared to optimal placment.
+    """
+
+    @classmethod
+    def _getExperimentsConf(cls, *args, **kwargs):
+        return {
+            'wloads' : cls.workloads,
+            'confs' : [energy_aware_conf]
+        }
+
+    def get_task_utils_df(self, experiment):
+        """
+        Get a DataFrame with the *expected* utilization of each task over time
+
+        :param experiment: The :class:Experiment to examine
+        :returns: A Pandas DataFrame with a column for each task, showing how
+                  the utilization of that task varies over time
+        """
+        util_scale = self.te.nrg_model.capacity_scale
+
+        transitions = {}
+        def add_transition(time, task, util):
+            if time not in transitions:
+                transitions[time] = {task: util}
+            else:
+                transitions[time][task] = util
+
+        # First we'll build a dict D {time: {task_name: util}} where D[t][n] is
+        # the expected utilization of task n from time t.
+        for task, params in experiment.wload.params['profile'].iteritems():
+            time = self.get_start_time(experiment) + params['delay']
+            add_transition(time, task, 0)
+            for _ in range(params.get('loops', 1)):
+                for phase in params['phases']:
+                    util = (phase.duty_cycle_pct * util_scale / 100.)
+                    add_transition(time, task, util)
+                    time += phase.duration_s
+            add_transition(time, task, 0)
+
+        index = sorted(transitions.keys())
+        df = pd.DataFrame([transitions[k] for k in index], index=index)
+        return df.fillna(method='ffill')
+
+    def get_task_cpu_df(self, experiment):
+        """
+        Get a DataFrame mapping task names to the CPU they ran on
+
+        Use the sched_switch trace event to find which CPU each task ran
+        on. Does not reflect idleness - tasks not running are shown as running
+        on the last CPU they woke on.
+
+        :param experiment: The :class:Experiment to examine
+        :returns: A Pandas DataFrame with a column for each task, showing the
+                  CPU that the task was "on" at each moment in time
+        """
+        tasks = experiment.wload.tasks.keys()
+        trace = self.get_trace(experiment)
+
+        df = trace.ftrace.sched_switch.data_frame[['next_comm', '__cpu']]
+        df = df[df['next_comm'].isin(tasks)]
+        df = df.pivot(index=df.index, columns='next_comm').fillna(method='ffill')
+        cpu_df = df['__cpu']
+        # Drop consecutive duplicates
+        cpu_df = cpu_df[(cpu_df.shift(+1) != cpu_df).any(axis=1)]
+        return cpu_df
+
+    def _sort_power_df_columns(self, df):
+        """
+        Helper method to re-order the columns of a power DataFrame
+
+        This has no significance for code, but when examining DataFrames by hand
+        they are easier to understand if the columns are in a logical order.
+        """
+        node_cpus = [node.cpus for node in self.te.nrg_model.root.iter_nodes()]
+        return pd.DataFrame(df, columns=[c for c in node_cpus if c in df])
+
+    def get_power_df(self, experiment):
+        """
+        Considering only the task placement, estimate power usage over time
+
+        Examine a trace and use :meth:EnergyModel.estimate_from_cpu_util to get
+        a DataFrame showing the estimated power usage over time. This assumes
+        perfect cpuidle and cpufreq behaviour.
+
+        :param experiment: The :class:Experiment to examine
+        :returns: A Pandas DataFrame with a column node in the energy model
+                  (keyed with a tuple of the CPUs contained by that node) Shows
+                  the estimated power over time.
+        """
+        task_cpu_df = self.get_task_cpu_df(experiment)
+        task_utils_df = self.get_task_utils_df(experiment)
+
+        tasks = experiment.wload.tasks.keys()
+
+        # Create a combined DataFrame with the utilization of a task and the CPU
+        # it was running on at each moment. Looks like:
+        #                       utils                  cpus
+        #          task_wmig0 task_wmig1 task_wmig0 task_wmig1
+        # 2.375056      102.4      102.4        NaN        NaN
+        # 2.375105      102.4      102.4        2.0        NaN
+
+        df = pd.concat([task_utils_df, task_cpu_df],
+                       axis=1, keys=['utils', 'cpus'])
+        df = df.sort_index().fillna(method='ffill')
+        nrg_model = self.executor.te.nrg_model
+
+        # Now make a DataFrame with the estimated power at each moment.
+        def est_power(row):
+            cpu_utils = [0 for cpu in nrg_model.cpus]
+            for task in tasks:
+                cpu = row['cpus'][task]
+                util = row['utils'][task]
+                if not isnan(cpu):
+                    cpu_utils[int(cpu)] += util
+            power = nrg_model.estimate_from_cpu_util(cpu_utils)
+            columns = power.keys()
+            return pd.Series([power[c] for c in columns], index=columns)
+        return self._sort_power_df_columns(df.apply(est_power, axis=1))
+
+    def get_expected_power_df(self, experiment):
+        """
+        Estimate *optimal* power usage over time
+
+        Examine a trace and use :meth:get_optimal_placements and
+        :meth:EnergyModel.estimate_from_cpu_util to get a DataFrame showing the
+        estimated power usage over time under ideal EAS behaviour.
+
+        :param experiment: The :class:Experiment to examine
+        :returns: A Pandas DataFrame with a column each node in the energy model
+                  (keyed with a tuple of the CPUs contained by that node) and a
+                  "power" column with the sum of other columns. Shows the
+                  estimated *optimal* power over time.
+        """
+        task_utils_df = self.get_task_utils_df(experiment)
+
+        nrg_model = self.te.nrg_model
+
+        def exp_power(row):
+            task_utils = row.to_dict()
+            expected_utils = nrg_model.get_optimal_placements(task_utils)
+            power = nrg_model.estimate_from_cpu_util(expected_utils[0])
+            columns = power.keys()
+            return pd.Series([power[c] for c in columns], index=columns)
+        return self._sort_power_df_columns(
+            task_utils_df.apply(exp_power, axis=1))
+
+    def _test_slack(self, experiment, tasks):
+        """
+        Assert that the RTApp workload was given enough performance
+
+        Use :class:PerfAnalysis to find instances where the experiment's RT-App
+        workload wasn't able to complete its activations (i.e. its reported
+        "slack" was negative). Assert that this happened less that
+        ``negative_slack_allowed_pct`` percent of the time.
+
+        :meth:_test_task_placement asserts that estimated energy usage was
+        low. That will pass for runs where too *little* energy was used,
+        compromising performance. This method provides a separate test to
+        counteract that problem.
+        """
+
+        pa = PerfAnalysis(experiment.out_dir)
+        for task in tasks:
+            slack = pa.df(task)["Slack"]
+
+            bad_activations_pct = len(slack[slack < 0]) * 100. / len(slack)
+            if bad_activations_pct > self.negative_slack_allowed_pct:
+                raise AssertionError("task {} missed {}% of activations".format(
+                    task, bad_activations_pct))
+
+    def _test_task_placement(self, experiment, tasks):
+        """
+        Test that task placement was energy-efficient
+
+        Use :meth:get_expected_power_df and :meth:get_power_df to estimate
+        optimal and observed power usage for task placements of the experiment's
+        workload. Assert that the observed power does not exceed the optimal
+        power by more than 20%.
+        """
+        exp_power = self.get_expected_power_df(experiment)
+        est_power = self.get_power_df(experiment)
+
+        exp_energy = area_under_curve(exp_power.sum(axis=1), method='rect')
+        est_energy = area_under_curve(est_power.sum(axis=1), method='rect')
+
+        msg = 'Estimated {} bogo-Joules to run workload, expected {}'.format(
+            est_energy, exp_energy)
+        threshold = exp_energy * (1 + (self.energy_est_threshold_pct / 100.))
+        self.assertLess(est_energy, threshold, msg=msg)
+
+class OneSmallTask(_EnergyModelTest):
+    """
+    Test EAS for a single 20% task over 2 seconds
+    """
+    workloads = {
+        'one_small' : {
+            'type' : 'rt-app',
+            'conf' : {
+                'class' : 'periodic',
+                'params' : {
+                    'duty_cycle_pct': 20,
+                    'duration_s': 2,
+                    'period_ms': 10,
+                },
+                'tasks' : 1,
+                'prefix' : 'many',
+            },
+        },
+    }
+    @experiment_test
+    def test_slack(self, experiment, tasks):
+        self._test_slack(experiment, tasks)
+    @experiment_test
+    def test_task_placement(self, experiment, tasks):
+        self._test_task_placement(experiment, tasks)
+
+class ThreeSmallTasks(_EnergyModelTest):
+    """
+    Test EAS for 3 20% tasks over 2 seconds
+    """
+    workloads = {
+        'three_small' : {
+            'type' : 'rt-app',
+            'conf' : {
+                'class' : 'periodic',
+                'params' : {
+                    'duty_cycle_pct': 20,
+                    'duration_s': 2,
+                    'period_ms': 10,
+                },
+                'tasks' : 3,
+                'prefix' : 'many',
+            },
+        },
+    }
+    @experiment_test
+    def test_slack(self, experiment, tasks):
+        self._test_slack(experiment, tasks)
+    @experiment_test
+    def test_task_placement(self, experiment, tasks):
+        self._test_task_placement(experiment, tasks)
+
+class TwoBigTasks(_EnergyModelTest):
+    """
+    Test EAS for 2 80% tasks over 2 seconds
+    """
+    workloads = {
+        'two_big' : {
+            'type' : 'rt-app',
+            'conf' : {
+                'class' : 'periodic',
+                'params' : {
+                    'duty_cycle_pct': 80,
+                    'duration_s': 2,
+                    'period_ms': 10,
+                },
+                'tasks' : 2,
+                'prefix' : 'many',
+            },
+        },
+    }
+    @experiment_test
+    def test_slack(self, experiment, tasks):
+        self._test_slack(experiment, tasks)
+    @experiment_test
+    def test_task_placement(self, experiment, tasks):
+        self._test_task_placement(experiment, tasks)
+
+class TwoBigThreeSmall(_EnergyModelTest):
+    """
+    Test EAS for 2 70% tasks and 3 10% tasks over 2 seconds
+    """
+    workloads = {
+        'two_big_three_small' : {
+            'type' : 'rt-app',
+            'conf' : {
+                'class' : 'profile',
+                'params' : {
+                    'large' : {
+                        'kind' : 'Periodic',
+                        'params' : {
+                            'duty_cycle_pct': 70,
+                            'duration_s': 2,
+                            'period_ms': WORKLOAD_PERIOD_MS,
+                        },
+                        'tasks' : 2,
+                    },
+                    'small' : {
+                        'kind' : 'Periodic',
+                        'params' : {
+                            'duty_cycle_pct': 10,
+                            'duration_s': 2,
+                            'period_ms': WORKLOAD_PERIOD_MS,
+                        },
+                        'tasks' : 3,
+                    },
+                },
+            },
+        },
+    }
+    @experiment_test
+    def test_slack(self, experiment, tasks):
+        self._test_slack(experiment, tasks)
+    @experiment_test
+    def test_task_placement(self, experiment, tasks):
+        self._test_task_placement(experiment, tasks)
+
+class RampUp(_EnergyModelTest):
+    """
+    Test EAS for a task ramping from 5% up to 70% over 2 seconds
+    """
+    workloads = {
+        "ramp_up" : {
+            "type": "rt-app",
+            "conf" : {
+                "class"  : "profile",
+                "params"  : {
+                    "r5_10-60" : {
+                        "kind"   : "Ramp",
+                        "params" : {
+                            "period_ms" : 16,
+                            "start_pct" :  5,
+                            "end_pct"   : 70,
+                            "delta_pct" :  5,
+                            "time_s"    :  2,
+                         },
+                    },
+                },
+            },
+        },
+    }
+
+    @experiment_test
+    def test_slack(self, experiment, tasks):
+        self._test_slack(experiment, tasks)
+    @experiment_test
+    def test_task_placement(self, experiment, tasks):
+        self._test_task_placement(experiment, tasks)
+
+class RampDown(_EnergyModelTest):
+    """
+    Test EAS for a task ramping from 70% down to 5% over 2 seconds
+    """
+    workloads = {
+        "ramp_down" : {
+            "type": "rt-app",
+            "conf" : {
+                "class"  : "profile",
+                "params"  : {
+                    "r5_10-60" : {
+                        "kind"   : "Ramp",
+                        "params" : {
+                            "period_ms" : 16,
+                            "start_pct" : 70,
+                            "end_pct"   :  5,
+                            "delta_pct" :  5,
+                            "time_s"    :  2,
+                         },
+                    },
+                },
+            },
+        },
+    }
+
+    @experiment_test
+    def test_slack(self, experiment, tasks):
+        self._test_slack(experiment, tasks)
+    @experiment_test
+    def test_task_placement(self, experiment, tasks):
+        self._test_task_placement(experiment, tasks)
+
+class EnergyModelWakeMigration(_EnergyModelTest):
+    """
+    Test EAS for tasks alternating beetween 10% and 50%
+    """
+    workloads = {
+        'em_wake_migration' : {
+            'type' : 'rt-app',
+            'conf' : {
+                'class' : 'profile',
+                'params' : {
+                    'wmig' : {
+                        'kind' : 'Step',
+                        'params' : {
+                            'start_pct': 10,
+                            'end_pct': 50,
+                            'time_s': 2,
+                            'loops': 2
+                        },
+                        # Create one task for each big cpu
+                        'tasks' : 'big',
+                    },
+                },
+            },
+        },
+    }
+    @experiment_test
+    def test_slack(self, experiment, tasks):
+        self._test_slack(experiment, tasks)
+    @experiment_test
+    def test_task_placement(self, experiment, tasks):
+        self._test_task_placement(experiment, tasks)

--- a/tests/lisa/test_energy_model.py
+++ b/tests/lisa/test_energy_model.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2016, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from collections import OrderedDict
+import unittest
+from unittest import TestCase
+
+from energy_model import (EnergyModel, ActiveState, EnergyModelCapacityError,
+                          EnergyModelNode, EnergyModelRoot, PowerDomain)
+
+# Import these just to test that they can be constructed
+from libs.utils.platforms.juno_energy import juno_energy
+from libs.utils.platforms.pixel_energy import pixel_energy
+from libs.utils.platforms.hikey_energy import hikey_energy
+
+""" A very basic test suite for the EnergyModel class."""
+
+# WARNING!
+# Note that the tests below have hard-coded expectations about the result. If
+# you change the numbers in this EM, you'll need to recalculate those hard-coded
+# values (or just refactor these tests)
+
+little_cluster_active_states = OrderedDict([
+    (1000, ActiveState(power=10)),
+    (2000, ActiveState(power=20)),
+])
+
+little_cluster_idle_states = OrderedDict([
+    ('WFI',              5),
+    ('cpu-sleep-0',      5),
+    ('cluster-sleep-0',  1),
+])
+
+little_cpu_active_states = OrderedDict([
+    (1000, ActiveState(capacity=100, power=100)),
+    (1500, ActiveState(capacity=150, power=150)),
+    (2000, ActiveState(capacity=200, power=200)),
+])
+
+little_cpu_idle_states = OrderedDict([
+    ('WFI',              5),
+    ('cpu-sleep-0',      0),
+    ('cluster-sleep-0',  0),
+])
+
+littles=[0, 1]
+def little_cpu_node(cpu):
+    return EnergyModelNode(cpu=cpu,
+                           active_states=little_cpu_active_states,
+                           idle_states=little_cpu_idle_states)
+
+big_cluster_active_states = OrderedDict([
+    (3000, ActiveState(power=30)),
+    (4000, ActiveState(power=40)),
+])
+
+big_cluster_idle_states = OrderedDict([
+    ('WFI',              8),
+    ('cpu-sleep-0',      8),
+    ('cluster-sleep-0',  2),
+])
+
+big_cpu_active_states = OrderedDict([
+    (3000, ActiveState(capacity=300, power=300)),
+    (4000, ActiveState(capacity=400, power=400)),
+])
+
+big_cpu_idle_states = OrderedDict([
+    ('WFI',              9),
+    ('cpu-sleep-0',      0),
+    ('cluster-sleep-0',  0),
+])
+
+bigs=[2, 3]
+
+def big_cpu_node(cpu):
+    return EnergyModelNode(cpu=cpu,
+                           active_states=big_cpu_active_states,
+                           idle_states=big_cpu_idle_states)
+
+em = EnergyModel(
+    root_node=EnergyModelRoot(children=[
+        EnergyModelNode(name='cluster_little',
+                        active_states=little_cluster_active_states,
+                        idle_states=little_cluster_idle_states,
+                        children=[little_cpu_node(0),
+                                  little_cpu_node(1)]),
+        EnergyModelNode(name='cluster_big',
+                        active_states=big_cluster_active_states,
+                        idle_states=big_cluster_idle_states,
+                        children=[big_cpu_node(2),
+                                  big_cpu_node(3)])
+    ]),
+    root_power_domain=PowerDomain(idle_states=[], children=[
+        PowerDomain(
+            idle_states=['cluster-sleep-0'],
+            children=[PowerDomain(idle_states=['WFI', 'cpu-sleep-0'], cpu=c)
+                      for c in littles]),
+        PowerDomain(
+            idle_states=['cluster-sleep-0'],
+            children=[PowerDomain(idle_states=['WFI', 'cpu-sleep-0'], cpu=c)
+                      for c in bigs]),
+        ]),
+    freq_domains=[littles, bigs]
+)
+
+class TestInvalid(TestCase):
+    """Test the sanity checks in EnerygModel setup"""
+    def test_overlapping_freq_doms(self):
+        """Can't build an EM with energy nodes overlapping freq domains"""
+
+        # To make this easy we'll just use a single active state everywhere, and
+        # no idle states
+        active_states={10000: ActiveState(capacity=1024, power=100)}
+
+        def cpu_node(cpu):
+            return EnergyModelNode(cpu=cpu,
+                                   active_states=active_states,
+                                   idle_states=[])
+
+        root_node = EnergyModelRoot(children=[
+            EnergyModelNode(
+                name='cluster1',
+                active_states=active_states,
+                idle_states=[],
+                children=[cpu_node(0), cpu_node(1)])])
+
+        def cpu_pd(cpu):
+            return PowerDomain(idle_states=[], cpu=cpu)
+
+        with self.assertRaises(ValueError):
+            EnergyModel(root_node=root_node,
+                        root_power_domain=PowerDomain(
+                            idle_states=[], children=[cpu_pd(0), cpu_pd(1)]),
+                        freq_domains=[[0], [1]]),
+
+
+class TestOptimalPlacement(TestCase):
+    def assertPlacementListEqual(self, l1, l2):
+        """
+        Assert that a pair of lists of lists contain the same lists in any order
+        """
+        s1 = set([tuple(l) for l in l1])
+        s2 = set([tuple(l) for l in l2])
+        self.assertSetEqual(s1, s2)
+
+    def test_single_small(self):
+        placements = em.get_optimal_placements({'task0': 1})
+        self.assertPlacementListEqual(placements, [[1, 0, 0, 0],
+                                                   [0, 1, 0, 0]])
+
+    def test_single_big(self):
+        placements = em.get_optimal_placements({'task0': 350})
+        self.assertPlacementListEqual(placements, [[0, 0, 350, 0],
+                                                   [0, 0, 0, 350]])
+
+    def test_packing(self):
+        tasks = {'task' + str(i) : 10 for i in range(5)}
+        placements = em.get_optimal_placements(tasks)
+        total_util = sum(tasks.values())
+        self.assertPlacementListEqual(placements, [[total_util, 0, 0, 0],
+                                                   [0, total_util, 0, 0]])
+
+    def test_overutilized_single(self):
+        self.assertRaises(EnergyModelCapacityError,
+                          em.get_optimal_placements, {'task0' : 401})
+
+    def test_overutilized_many(self):
+        total_cap = 400 * 2 + 200 * 2
+        task_size = 200
+        tasks = {'task' + str(i): task_size
+                 for i in range((total_cap / task_size) + 1)}
+        self.assertRaises(EnergyModelCapacityError,
+                          em.get_optimal_placements, tasks)
+
+class TestBiggestCpus(TestCase):
+    def test_biggest_cpus(self):
+        self.assertEqual(em.biggest_cpus, [2, 3])
+
+class TestLittlestCpus(TestCase):
+    def test_littlest_cpus(self):
+        self.assertEqual(em.littlest_cpus, [0, 1])
+
+class TestMaxCap(TestCase):
+    def test_max_cap(self):
+        max_caps = [n.max_capacity for n in em.cpu_nodes]
+        self.assertEqual(max_caps, [200, 200, 400, 400])
+
+class TestEnergyEst(TestCase):
+    def test_all_overutilized(self):
+        big_cpu = 400 * 2
+        little_cpu =  200 * 2
+        big_cluster = 40
+        little_cluster = 20
+
+        total = big_cpu + little_cpu + big_cluster + little_cluster
+
+        power = em.estimate_from_cpu_util([10000] * 4)
+        exp = {
+            (0): { 'active': little_cpu, 'idle': 0},
+            (1): { 'active': little_cpu, 'idle': 0},
+            (2): { 'active': big_cpu, 'idle': 0},
+            (3): { 'active': big_cpu, 'idle': 0},
+            (0, 1): { 'active': little_cluster, 'idle': 0},
+            (2, 3): { 'active': big_cluster, 'idle': 0}
+        }
+        for k, v in power.iteritems():
+            self.assertAlmostEqual(v, power[k])
+
+    def test_all_idle(self):
+        self.assertEqual(sum(em.estimate_from_cpu_util([0, 0, 0, 0]).values()),
+                         0 * 4 # CPU power = 0
+                         + 2   # big cluster power
+                         + 1)  # LITTLE cluster power
+
+    def test_one_little_half_lowest(self):
+        cpu0_util = 100 * 0.5
+        self.assertEqual(
+            sum(em.estimate_from_cpu_util([cpu0_util, 0, 0, 0]).values()),
+                (0.5 * 100)  # CPU0 active power
+                + (0.5 * 5)  # CPU0 idle power
+                + (0.5 * 5)  # LITTLE cluster idle power
+                + (0.5 * 10) # LITTLE cluster active power
+                + 2)         # big cluster power
+
+class TestIdleStates(TestCase):
+    def test_zero_util_deepest(self):
+        self.assertEqual(em.guess_idle_states([0] * 4), ['cluster-sleep-0'] * 4)
+
+    def test_single_cpu_used(self):
+        states = em.guess_idle_states([0, 0, 0, 1])
+        self.assertEqual(states, ['cluster-sleep-0', 'cluster-sleep-0',
+                                  'cpu-sleep-0', 'WFI'])
+
+        states = em.guess_idle_states([0, 1, 0, 0])
+        self.assertEqual(states, ['cpu-sleep-0', 'WFI',
+                                  'cluster-sleep-0', 'cluster-sleep-0',])
+
+    def test_all_cpus_used(self):
+        states = em.guess_idle_states([1, 1, 1, 1])
+        self.assertEqual(states, ['WFI'] * 4)
+
+    def test_one_cpu_per_cluster(self):
+        states = em.guess_idle_states([0, 1, 0, 1])
+        self.assertEqual(states, ['cpu-sleep-0', 'WFI'] * 2)
+
+class TestFreqs(TestCase):
+
+    def test_zero_util_slowest(self):
+        self.assertEqual(em.guess_freqs([0] * 4),
+                         [1000, 1000, 3000, 3000])
+
+    def test_high_util_fastest(self):
+        self.assertEqual(em.guess_freqs([100000] * 4),
+                         [2000, 2000, 4000, 4000])
+
+    def test_freq_domains(self):
+        self.assertEqual(em.guess_freqs([0, 0, 0, 10000]),
+                         [1000, 1000, 4000, 4000])
+
+        self.assertEqual(em.guess_freqs([0, 10000, 0, 10000]),
+                         [2000, 2000, 4000, 4000])
+
+        self.assertEqual(em.guess_freqs([0, 10000, 0, 0]),
+                         [2000, 2000, 3000, 3000])
+
+    def test_middle_freq(self):
+        self.assertEqual(em.guess_freqs([0, 110, 0, 0]),
+                         [1500, 1500, 3000, 3000])
+
+class TestNames(TestCase):
+    """Test that the default names for CPU nodes get set"""
+    def test_names(self):
+        self.assertListEqual([n.name for n in em.cpu_nodes],
+                             ['cpu0', 'cpu1', 'cpu2', 'cpu3'])


### PR DESCRIPTION
See the commit messages for the [first](https://github.com/ARM-software/lisa/commit/399cdfff3c112836408f03346832df52008779d7) and [fourth](https://github.com/ARM-software/lisa/commit/37918fade84d389a6df2183ac02892fe3fef898d) commits for more detail on what this PR aims to introduce. In short, this aims to allow automatically running tests for any given synthetic workload and platform. 

This looks like an enormous PR, and it is... but a lot of the added lines are `.ipynb` noise or boilerplate in the [provided](https://github.com/ARM-software/lisa/commit/399cdfff3c112836408f03346832df52008779d7#diff-6a86319666706547b6bb03baf38e4916) [platform](https://github.com/ARM-software/lisa/commit/399cdfff3c112836408f03346832df52008779d7#diff-ac2a5c8c78e008f3791e81447c911ca6) [descriptions](https://github.com/ARM-software/lisa/commit/399cdfff3c112836408f03346832df52008779d7#diff-b622e9d205b02984946d5cdb1cd96a96). I've also added pretty verbose docstrings which bumps up the line count a lot. 

I've siloed myself a bit on this so please highlight wherever I haven't made the high-level intention clear, It's important that someone can understand what this stuff is trying to do without reading 2k lines of inscrutable bjackman Python :smile: . Hopefully docstrings are a good starting point...