### PR TITLE
env: Fix check for rt-app calibration requirement

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -687,6 +687,7 @@ class TestEnv(ShareState):
         if 'rt-app' in self.__tools:
             required = True
         elif 'wloads' in self.conf:
+            wloads = self.conf['wloads'].values()
             required = any(['rt-app' in wl['type'] for wl in wloads])
 
         if not required:


### PR DESCRIPTION
Seems I failed to test my previous commit that changed this code.

By the way, 'wloads' doesn't go in the target config any more so this is sort of redundant, but I'm not going to fix that here.