### PR TITLE
Factor out dependency installation script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,34 +16,12 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
     set -e
 
-    sudo apt-get update
-    sudo apt-get install -y autoconf automake build-essential expect git \
-        libfreetype6-dev libpng12-dev libtool nmap openjdk-7-jdk \
-        openjdk-7-jre pkg-config python-all-dev python-matplotlib \
-        python-nose python-numpy python-pip python-zmq sshpass trace-cmd \
-        tree wget
-    pip install Cython
-    sudo pip install ipython[notebook] pandas psutil wrapt
-    sudo apt-get remove -y w3m
-
     if [ ! -e /home/vagrant/lisa ]; then
        ln -s /vagrant /home/vagrant/lisa
     fi
 
     cd /home/vagrant/lisa
-    ANDROID_SDK_URL="https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz"
-    if [ ! -e ./tools/android-sdk-linux ]; then
-        echo "Downloading Android SDK [$ANDROID_SDK_URL]..."
-        wget -qO- $ANDROID_SDK_URL | tar xz -C tools
-        expect -c '
-            set timeout -1;
-            spawn ./tools/android-sdk-linux/tools/android update sdk --no-ui
-            expect {
-                "Do you accept the license" { exp_send "y\r" ; exp_continue }
-                eof
-            }
-        '
-    fi
+    ./install_base_ubuntu.sh --install-android-sdk
 
     chown vagrant.vagrant /home/vagrant/lisa
     echo cd /home/vagrant/lisa >> /home/vagrant/.bashrc

--- a/install_base_ubuntu.sh
+++ b/install_base_ubuntu.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Script to install the depenencies for LISA on an Ubuntu-like system.
+
+# This is intended to be used for setting up containers and virtual machines to
+# run LISA (e.g. for CI infrastructure or for Vagrant installation). However for
+# the brave, it could be used to set up LISA directly on a real machine.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+usage() {
+    echo Usage: "$0" [--install-android-sdk]
+}
+
+set -eu
+
+install_android_sdk=n
+
+for arg in "$@"; do
+    if [ "$arg" == "--install-android-sdk" ]; then
+        install_android_sdk=y
+    else
+        echo "Unrecognised argument: $arg"
+        usage
+        exit 1
+    fi
+done
+
+apt-get update
+
+apt-get -y remove ipython ipython-notebook
+
+apt-get -y install build-essential autoconf automake libtool pkg-config \
+    trace-cmd sshpass kernelshark nmap net-tools tree python-matplotlib \
+    python-numpy libfreetype6-dev libpng12-dev python-nose python-pip \
+    python-dev iputils-ping git wget expect
+
+# Upgrade pip so we can use wheel packages instead of compiling stuff, this is
+# much faster.
+pip install --upgrade pip
+
+# Incantation to fix broken pip packages
+/usr/local/bin/pip install --upgrade packaging appdirs
+
+/usr/local/bin/pip install --upgrade Cython trappy bart-py devlib psutil wrapt ipython jupyter
+
+if [ "$install_android_sdk" == y ]; then
+    apt-get -y install openjdk-7-jre openjdk-7-jdk
+    ANDROID_SDK_URL="https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz"
+    mkdir -p "$SCRIPT_DIR"/tools
+    if [ ! -e "$SCRIPT_DIR"/tools/android-sdk-linux ]; then
+        echo "Downloading Android SDK [$ANDROID_SDK_URL]..."
+        wget -qO- $ANDROID_SDK_URL | tar xz -C $SCRIPT_DIR/tools/
+        expect -c "
+            set timeout -1;
+            spawn $SCRIPT_DIR/tools/android-sdk-linux/tools/android update sdk --no-ui
+            expect {
+                \"Do you accept the license\" { exp_send \"y\r\" ; exp_continue }
+                eof
+            }
+        "
+    fi
+fi


### PR DESCRIPTION
This provides an installation script that can be used to set up VMs and containers on Ubuntu-like systems. Then modifies the Vagrantfile to use that script.

I've kept this as 3 commits so that I can keep track of the changes from the script I was given by another team, but I'm happy to squash before merging.