### PR TITLE
TestEnv: fix calibration check again

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -677,6 +677,15 @@ class TestEnv(ShareState):
         return (self.platform, plt_file)
 
     def calibration(self, force=False):
+        """
+        Get rt-app calibration. Run calibration on target if necessary.
+
+        :param force: Always run calibration on target, even if we have not
+                      installed rt-app or have already run calibration.
+        :returns: A dict with calibration results, which can be passed as the
+                  ``calibration`` parameter to :class:`RTA`, or ``None`` if
+                  force=False and we have not installed rt-app.
+        """
 
         if not force and self._calib:
             return self._calib

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -681,14 +681,7 @@ class TestEnv(ShareState):
         if not force and self._calib:
             return self._calib
 
-        required = False
-        if force:
-            required = True
-        if 'rt-app' in self.__tools:
-            required = True
-        elif 'wloads' in self.conf:
-            wloads = self.conf['wloads'].values()
-            required = any(['rt-app' in wl['type'] for wl in wloads])
+        required = force or 'rt-app' in self.__installed_tools
 
         if not required:
             self._log.debug('No RT-App workloads, skipping calibration')


### PR DESCRIPTION
As I noted in my [previous PR](https://github.com/ARM-software/lisa/pull/267), the 'wloads' field doesn't belong in the TestEnv config, it's an Executor thing. So fix that here. This fixes issues where calibration doesn't get run.