### PR TITLE
Env cleanup

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -92,8 +92,8 @@ class TestEnv(ShareState):
         if self._initialized and not force_new:
             return
 
-        self.conf = None
-        self.test_conf = None
+        self.conf = {}
+        self.test_conf = {}
         self.res_dir = None
         self.target = None
         self.ftrace = None

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -171,9 +171,9 @@ class TestEnv(ShareState):
 
         # Initialize ftrace events
         # test configuration override target one
-        if self.test_conf and 'ftrace' in self.test_conf:
+        if 'ftrace' in self.test_conf:
             self.conf['ftrace'] = self.test_conf['ftrace']
-        if 'ftrace' in self.conf and self.conf['ftrace']:
+        if self.conf.get('ftrace'):
             self.__tools.append('trace-cmd')
 
         # Add tools dependencies

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -94,7 +94,6 @@ class TestEnv(ShareState):
 
         self.conf = {}
         self.test_conf = {}
-        self.res_dir = None
         self.target = None
         self.ftrace = None
         self.workdir = WORKING_DIR_DEFAULT
@@ -199,17 +198,17 @@ class TestEnv(ShareState):
         self.calibration()
 
         # Initialize local results folder
-        # test configuration override target one
-        if self.test_conf and 'results_dir' in self.test_conf:
-            self.res_dir = self.test_conf['results_dir']
-        if not self.res_dir and 'results_dir' in self.conf:
-            self.res_dir = self.conf['results_dir']
+        # test configuration overrides target one
+        self.res_dir = (self.test_conf.get('results_dir') or
+                        self.conf.get('results_dir'))
+
         if self.res_dir and not os.path.isabs(self.res_dir):
-                self.res_dir = os.path.join(basepath, 'results', self.res_dir)
+            self.res_dir = os.path.join(basepath, 'results', self.res_dir)
         else:
             self.res_dir = os.path.join(basepath, OUT_PREFIX)
             self.res_dir = datetime.datetime.now()\
                             .strftime(self.res_dir + '/%Y%m%d_%H%M%S')
+
         if wipe and os.path.exists(self.res_dir):
             self._log.warning('Wipe previous contents of the results folder:')
             self._log.warning('   %s', self.res_dir)

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -395,29 +395,18 @@ class TestEnv(ShareState):
         # Modules configuration
         ########################################################################
 
-        # Refine modules list based on target.conf options
-        if 'modules' in self.conf:
-            self.__modules = list(set(
-                self.__modules + self.conf['modules']
-            ))
+        modules = set(self.__modules)
+
+        # Refine modules list based on target.conf
+        modules.update(self.conf.get('modules', []))
         # Merge tests specific modules
-        if self.test_conf and 'modules' in self.test_conf and \
-           self.test_conf['modules']:
-            self.__modules = list(set(
-                self.__modules + self.test_conf['modules']
-            ))
+        modules.update(self.test_conf.get('modules', []))
 
-        # Initialize modules to exclude on the target
-        if 'exclude_modules' in self.conf:
-            for module in self.conf['exclude_modules']:
-                if module in self.__modules:
-                    self.__modules.remove(module)
-        # Remove tests specific modules
-        if self.test_conf and 'exclude_modules' in self.test_conf:
-            for module in self.test_conf['exclude_modules']:
-                if module in self.__modules:
-                    self.__modules.remove(module)
+        remove_modules = set(self.conf.get('exclude_modules', []) +
+                             self.test_conf.get('exclude_modules', []))
+        modules.difference_update(remove_modules)
 
+        self.__modules = list(modules)
         self._log.info('Devlib modules to load: %s', self.__modules)
 
         ########################################################################


### PR DESCRIPTION
Some cleanups and simplifications for TestEnv.

Generally:

- Simplify a load of conditionals by 
  - Removing the unnecessary case where `conf`/`test_conf` is `None`
  - Using `d.get('foo')` instead of `if 'foo' in d and...`
- Use set operations to simplify stuff

I think this also has a sneaky bugfix for installing rt-app dependencies via `install_tools` but I haven't replicated that presumed bug.
