### PR TITLE
trace: Handle new field format for sched_energy_diff

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -610,6 +610,8 @@ class Trace(object):
         """
         If a energy model is provided, some signals are added to the
         sched_energy_diff trace event data frame.
+
+        Also convert between existing field name formats for sched_energy_diff
         """
         if not self.hasEvents('sched_energy_diff') \
            or 'nrg_model' not in self.platform:
@@ -629,6 +631,10 @@ class Trace(object):
             "Maximum estimated system energy: {0:d}".format(power_max))
 
         df = self._dfg_trace_event('sched_energy_diff')
+
+        translations = {'nrg_d': 'nrg_diff', 'utl_d': 'usage_delta'}
+        df.rename(columns=translations, inplace=True)
+
         df['nrg_diff_pct'] = SCHED_LOAD_SCALE * df.nrg_diff / power_max
 
         # Tag columns by usage_delta


### PR DESCRIPTION
There is a new format for the sched_energy_diff trace event in EAS code in the
Android common kernel:

https://android.googlesource.com/kernel/common/+/6aab3e4a9266fb661638e37ad4745573aff6de5c%5E%21/

Add support for parsing this format in Trace, by translating equivalent field
names and making unmatched fields optional.

-----

I have only done the bare minimum to allow me to use LISA to parse traces from kernels containing these events. I haven't checked that the result of this method makes any sense, neither with the existing events nor the new.