### PR TITLE
libs/utils/energy: fix initialization of ACME

### DIFF
--- a/libs/utils/energy.py
+++ b/libs/utils/energy.py
@@ -321,7 +321,7 @@ class ACME(EnergyMeter):
         self._channels = conf.get('channel_map', {
             'CH0': '0'
         })
-        self._iio = [None] * len(self._channels)
+        self._iio = {}
 
         self._log.info('ACME configuration:')
         self._log.info('    binary: %s', self._iiocapturebin)


### PR DESCRIPTION
ACME energy meter supports multiple channels and initialization
of such channels uses a map that associates a channel id with a
human understandable name.
The current code translate this information to a fixed length array
and this causes a problem if devices ids are not contiguous or if not
all devices are in use, e.g.

 "channel_map" : {
            "Device1" : 1, # iio:device1
 }

Keep the map association as is by using a dictionary instead of an array.