### PR TITLE
utils/energy.py: call superclass init with res_dir

### DIFF
--- a/libs/utils/energy.py
+++ b/libs/utils/energy.py
@@ -313,7 +313,7 @@ class ACME(EnergyMeter):
     """
 
     def __init__(self, target, conf, res_dir):
-        super(ACME, self).__init__(target)
+        super(ACME, self).__init__(target, res_dir)
 
         # Assume iio-capture is available in PATH
         iioc = conf.get('conf', {


### PR DESCRIPTION
For the ACME energy probe the init funtion call of the superclass
did not specify the results directory so the sample file would go
by default to /tmp/, where it might be overwritten if two tests are
ran at the same time, where the channels used have the same channel
descriptors.

For safety, pass the res_dir to the init call and have the output
file stored there before being moved to the specified output folder.

Signed-off-by: Ionela Voinescu <ionela.voinescu@arm.com>