### PR TITLE
Fix some tests broken by recent executor refactoring

### DIFF
--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -451,7 +451,7 @@ class Executor():
                 num_tasks = task.get('tasks', 1)
                 task_idxs = self._wload_task_idxs(wl_idx, num_tasks)
                 for idx in task_idxs:
-                    idx_name = str(idx) if len(task_idxs) > 0 else ""
+                    idx_name = "_{}".format(idx) if len(task_idxs) > 1 else ""
                     task_name_idx = conf['prefix'] + task_name + idx_name
                     params[task_name_idx] = task_ctor(**task['params']).get()
 

--- a/libs/utils/test.py
+++ b/libs/utils/test.py
@@ -51,7 +51,7 @@ class LisaTest(unittest.TestCase):
     """Override this with a dictionary or JSON path to configure the TestEnv"""
 
     experiments_conf = None
-    """Override this with a dictionary to configure the Executor"""
+    """Override this with a dictionary or JSON path to configure the Executor"""
 
     @classmethod
     def _init(cls, *args, **kwargs):

--- a/libs/utils/test.py
+++ b/libs/utils/test.py
@@ -94,6 +94,10 @@ class LisaTest(unittest.TestCase):
         experiments_conf = cls._getExperimentsConf(test_env)
         cls.executor = Executor(test_env, experiments_conf)
 
+        # Alias tests and workloads configurations
+        cls.wloads = cls.executor._experiments_conf["wloads"]
+        cls.confs = cls.executor._experiments_conf["confs"]
+
         # Alias executor objects to make less verbose tests code
         cls.te = cls.executor.te
         cls.target = cls.executor.target

--- a/tests/eas/rfc.py
+++ b/tests/eas/rfc.py
@@ -26,16 +26,15 @@ TESTS_CONF = os.path.join(TESTS_DIRECTORY, "rfc.config")
 class RFC(LisaTest):
     """Tests for the Energy-Aware Scheduler"""
 
+    test_conf = TESTS_CONF
+    experiments_conf = TESTS_CONF
+
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super(RFC, cls)._init(TESTS_CONF, args, kwargs)
 
-    def test_energy_regression(self):
-        """Check that there is not regression on energy"""
-        # TODO
-
-    def test_performance_regression(self):
-        """Check that there is not regression on performance"""
-        # TODO
+    def test_run(self):
+        """A dummy test just to run configured workloads"""
+        pass
 
 # vim :set tabstop=4 shiftwidth=4 expandtab

--- a/tests/sfreq/smoke_test.py
+++ b/tests/sfreq/smoke_test.py
@@ -26,6 +26,9 @@ TESTS_CONF = os.path.join(TESTS_DIRECTORY, "smoke_test.config")
 class SFreq(LisaTest):
     """Tests for SchedFreq framework"""
 
+    test_conf = TESTS_CONF
+    experiments_conf = TESTS_CONF
+
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super(SFreq, cls)._init(TESTS_CONF, *args, **kwargs)

--- a/tests/stune/smoke_test_ramp.py
+++ b/tests/stune/smoke_test_ramp.py
@@ -54,6 +54,8 @@ class STune(LisaTest):
 
     """
 
+    test_conf = TESTS_CONF
+    experiments_conf = TESTS_CONF
 
     @classmethod
     def setUpClass(cls, *args, **kwargs):
@@ -62,19 +64,19 @@ class STune(LisaTest):
     def test_boosted_utilization_signal(self):
         """Tasks in stune groups are boosted"""
 
-        for tc in self.conf["confs"]:
-            test_id = tc["tag"]
+        for tc in self.confs:
+            conf_id = tc["tag"]
 
-            wload_idx = self.conf["wloads"].keys()[0]
+            wload_id = self.wloads.keys()[0]
             run_dir = os.path.join(self.te.res_dir,
-                                   "rtapp:{}:{}".format(test_id, wload_idx),
+                                   "rtapp:{}:{}".format(conf_id, wload_id),
                                    "1")
 
             ftrace_events = ["sched_boost_task"]
             ftrace = trappy.FTrace(run_dir, scope="custom",
                                    events=ftrace_events)
 
-            first_task_params = self.conf["wloads"][wload_idx]["conf"]["params"]
+            first_task_params = self.wloads[wload_id]["conf"]["params"]
             first_task_name = first_task_params.keys()[0]
             rta_task_name = "task_{}".format(first_task_name)
 


### PR DESCRIPTION
Existing SchedTune and SchedFreq tests are now working again with the mods to use the new interfaces required by the executor module.

This fixes also the executor's recent support to spawns moultiple tasks with a single wload spec.