### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2017, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+sudo: required
+language: python
+install:
+  - pip install --upgrade Cython trappy bart-py devlib psutil wrapt ipython jupyter
+script:
+  - cd $TRAVIS_BUILD_DIR
+  - source init_env && lisa-test tests/lisa/

--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -289,9 +289,11 @@ case "x${CMD^^}" in
 	;;
 *)
 	_lisa-test $*
+        local retcode=$?
 esac
 echo
 echo
+return $retcode
 }
 
 function lisa-report {


### PR DESCRIPTION
This adds a barebones YAML config for Travis and a fix that allows travis to detect failures from `lisa-test`. You can see an example run against my repository here: https://travis-ci.org/bjackman/lisa/builds/201980373 (running the wlgen tests that were recently meged).