### PR TITLE
Fix platform parsing

### DIFF
--- a/libs/utils/analysis/latency_analysis.py
+++ b/libs/utils/analysis/latency_analysis.py
@@ -79,7 +79,7 @@ class LatencyAnalysis(AnalysisModule):
         # we don't care about the status of a task we are replacing
         task_switches_df.prev_state = task_switches_df.apply(
             lambda r : np.nan if r['prev_pid'] != td.pid
-                              else self._taskState(int(r['prev_state'])),
+                              else self._taskState(r['prev_state']),
             axis=1)
 
         # Rename prev_state
@@ -372,6 +372,11 @@ class LatencyAnalysis(AnalysisModule):
 
     @memoized
     def _taskState(self, state):
+        try:
+            state = int(state)
+        except ValueError:
+            # State already converted to symbol
+            return state
 
         # Tasks STATE flags (Linux 4.8)
         TASK_STATES = {

--- a/libs/utils/analysis_module.py
+++ b/libs/utils/analysis_module.py
@@ -29,6 +29,9 @@ class AnalysisModule(object):
     """
 
     def __init__(self, trace):
+
+        self._log = logging.getLogger('Analysis')
+
         self._trace = trace
         self._platform = trace.platform
         self._tasks = trace.tasks
@@ -36,13 +39,31 @@ class AnalysisModule(object):
 
         self._dfg_trace_event = trace._dfg_trace_event
 
-        self._big_cap = self._platform['nrg_model']['big']['cpu']['cap_max']
-        self._little_cap = self._platform['nrg_model']['little']['cpu']['cap_max']
-        self._big_cpus = self._platform['clusters']['big']
-        self._little_cpus = self._platform['clusters']['little']
+        # By default assume SMP system
+        self._big_cap = 1024
+        self._little_cap = 1024
+        nrg_model = self._platform.get('nrg_model', None)
+        if nrg_model:
+            try:
+                self._big_cap = nrg_model['big']['cpu']['cap_max']
+                self._little_cap = nrg_model['little']['cpu']['cap_max']
+            except TypeError:
+                self._log.debug('Failed parsing EM from platform data')
+        else:
+            self._log.debug('Platform data without Energy Model info')
+
+        # By default assume SMP system
+        self._big_cpus = []
+        self._little_cpus = []
+        if 'big' in self._platform['clusters']:
+            self._log.debug('Parsing big.LITTLE system clusters')
+            self._big_cpus = self._platform['clusters']['big']
+            self._little_cpus = self._platform['clusters']['little']
+        else:
+            self._log.debug('Parsing SMP clusters')
+            for cid in self._platform['clusters']:
+                self._big_cpus.append(self._platform['clusters'][cid])
 
         trace._registerDataFrameGetters(self)
-
-        self._log = logging.getLogger('Analysis')
 
 # vim :set tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
We have pretty old issues, like #7, which should address the cleanup of the codebased to remove any hardcoded dependency on bL platforms. This is not such a big refactoring but still these are small fixes for parsing of SMP generated traces which needs to be merged to get new APIs like
   https://github.com/ARM-software/lisa/pull/302
working properly for example using systrace on Pixel phones.