### PR TITLE
Add test for CPU invariant load tracking

### DIFF
--- a/libs/utils/energy_model.py
+++ b/libs/utils/energy_model.py
@@ -349,6 +349,23 @@ class EnergyModel(object):
         states = self.cpu_nodes[0].active_states
         return any(c.active_states != states for c in self.cpu_nodes[1:])
 
+    @property
+    @memoized
+    def cpu_groups(self):
+        """
+        List of lists of CPUs who share the same active state values
+        """
+        groups = []
+        for node in self.cpu_nodes:
+            for group in groups:
+                group_states = self.cpu_nodes[group[0]].active_states
+                if node.active_states == group_states:
+                    group.append(node.cpu)
+                    break
+            else:
+                groups.append([node.cpu])
+        return groups
+
     def _guess_idle_states(self, cpus_active):
         def find_deepest(pd):
             if not any(cpus_active[c] for c in pd.cpus):

--- a/libs/utils/energy_model.py
+++ b/libs/utils/energy_model.py
@@ -378,6 +378,17 @@ class EnergyModel(object):
 
         return [find_deepest(pd) for pd in self.cpu_pds]
 
+    def get_cpu_capacity(self, cpu, freq=None):
+        """Convenience method to get the capacity of a CPU at a given frequency
+
+        :param cpu: CPU to get capacity for
+        :param freq: Frequency to get the CPU capacity at. Default is max
+                     capacity.
+        """
+        if freq is None:
+            return self.cpu_nodes[cpu].max_capacity
+        return self.cpu_nodes[cpu].active_states[freq].capacity
+
     def guess_idle_states(self, cpus_active):
         """Pessimistically guess the idle states that each CPU may enter
 

--- a/libs/utils/energy_model.py
+++ b/libs/utils/energy_model.py
@@ -50,6 +50,7 @@ class _CpuTree(object):
             raise ValueError('Provide exactly one of: cpu or children')
 
         self.parent = None
+        self.cpu = cpu
 
         if cpu is not None:
             self.cpus = (cpu,)
@@ -113,6 +114,8 @@ class EnergyModelNode(_CpuTree):
                  have a default name of "cpuN" where N is the cpu number.
 
     :ivar cpus: CPUs contained in this node. Includes those of child nodes.
+    :ivar cpu: For convenience, this holds the single CPU contained by leaf
+               nodes. ``None`` for non-leaf nodes.
     """
     def __init__(self, active_states, idle_states,
                  cpu=None, children=None, name=None):

--- a/tests/eas/load_tracking.py
+++ b/tests/eas/load_tracking.py
@@ -71,18 +71,10 @@ class FreqInvarianceTest(LisaTest):
     def setUpClass(cls, *args, **kwargs):
         super(FreqInvarianceTest, cls).runExperiments(*args, **kwargs)
 
-    @memoized
-    @classmethod
-    def _get_cpu(cls, target):
-        # Run on a 'big' CPU, or any CPU if not big.LITTLE
-        if hasattr(target, 'bl'):
-            return target.bl.bigs[0]
-        else:
-            return 0
-
     @classmethod
     def _getExperimentsConf(cls, test_env):
-        cpu = cls._get_cpu(test_env.target)
+        # Run on one of the CPUs with highest capacity
+        cpu = test_env.nrg_model.biggest_cpus[0]
 
         # 10% periodic RTApp workload:
         wloads = {

--- a/tests/lisa/test_energy_model.py
+++ b/tests/lisa/test_energy_model.py
@@ -292,3 +292,13 @@ class TestCpuGroups(TestCase):
     """Test the cpu_groups property"""
     def test_cpu_groups(self):
         self.assertListEqual(em.cpu_groups, [[0, 1], [2, 3]])
+
+class TestGetCpuCapacity(TestCase):
+    """Test the get_cpu_capacity method"""
+    def test_get_cpu_capacity(self):
+        for node in em.root.iter_leaves():
+            [cpu] = node.cpus
+            self.assertEqual(em.get_cpu_capacity(cpu), node.max_capacity)
+            for freq, active_state in node.active_states.iteritems():
+                self.assertEqual(em.get_cpu_capacity(cpu, freq),
+                                 active_state.capacity)

--- a/tests/lisa/test_energy_model.py
+++ b/tests/lisa/test_energy_model.py
@@ -287,3 +287,8 @@ class TestNames(TestCase):
     def test_names(self):
         self.assertListEqual([n.name for n in em.cpu_nodes],
                              ['cpu0', 'cpu1', 'cpu2', 'cpu3'])
+
+class TestCpuGroups(TestCase):
+    """Test the cpu_groups property"""
+    def test_cpu_groups(self):
+        self.assertListEqual(em.cpu_groups, [[0, 1], [2, 3]])


### PR DESCRIPTION
- Adds some handy members to the `EnergyModel` class
- Make the existing load_tracking test code more generic
- Add a test that runs a workload on each different type of CPU in the system and checks that the utilisation signal from the scheduler is scaled according to each CPU's capacity.