### PR TITLE
tests/eas/heavy_load: Reduce required active time percent 99->95

### DIFF
--- a/tests/eas/heavy_load.py
+++ b/tests/eas/heavy_load.py
@@ -19,7 +19,7 @@ from test import LisaTest, experiment_test
 
 WORKLOAD_DURATION_S = 5
 
-REQUIRED_CPU_ACTIVE_TIME_PCT = 99
+REQUIRED_CPU_ACTIVE_TIME_PCT = 95
 
 class HeavyLoadTest(LisaTest):
     """


### PR DESCRIPTION
99% is too harsh - kernels with totally acceptable behaviour can fail this
test.