### PR TITLE
uibench: test_name suffix broke Transition tests

### DIFF
--- a/ipynb/examples/android/benchmarks/Android_UiBench.ipynb
+++ b/ipynb/examples/android/benchmarks/Android_UiBench.ipynb
@@ -112,7 +112,7 @@
     "    systrace_output = System.systrace_start(te, trace_file, 15)\n",
     "    \n",
     "    # UiBench\n",
-    "    db_file, nrg_report = wload.run(te.res_dir, 'TrivialAnimation', duration_s=10, collect='systrace')\n",
+    "    db_file, nrg_report = wload.run(te.res_dir, 'TrivialAnimationActivity', duration_s=10, collect='systrace')\n",
     "\n",
     "    if systrace_output:\n",
     "        logging.info('Waiting systrace report [%s]...', trace_file)\n",

--- a/ipynb/examples/android/workloads/Android_Workloads.ipynb
+++ b/ipynb/examples/android/workloads/Android_Workloads.ipynb
@@ -431,7 +431,7 @@
     "# Params:\n",
     "# - test_name:  The name of the test to start\n",
     "# - duration:   playback time in [s]\n",
-    "    'UiBench 1 TrivialAnimation 10',\n",
+    "    'UiBench 1 TrivialAnimationActivity 10',\n",
     "\n",
     "# RT-App workload:\n",
     "# Params:\n",

--- a/libs/utils/android/workloads/uibench.py
+++ b/libs/utils/android/workloads/uibench.py
@@ -34,21 +34,21 @@ class UiBench(Workload):
 
     # Supported activities list, obtained via:
     # adb shell dumpsys package | grep -i uibench | grep Activity
-    test_BitmapUpload = 'BitmapUpload'
-    test_DialogList = 'DialogList'
-    test_EditTextType = 'EditTextType'
-    test_FullscreenOverdraw = 'FullscreenOverdraw'
-    test_GlTextureView = 'GlTextureView'
-    test_InflatingList = 'InflatingList'
-    test_Invalidate = 'Invalidate'
-    test_ShadowGrid = 'ShadowGrid'
-    test_TextCacheHighHitrate = 'TextCacheHighHitrate'
-    test_TextCacheLowHitrate = 'TextCacheLowHitrate'
-    test_Transition = 'Transition'
-    test_TransitionDetails = 'TransitionDetails'
-    test_TrivialAnimation = 'TrivialAnimation'
-    test_TrivialList = 'TrivialList'
-    test_TrivialRecyclerView = 'TrivialRecyclerView'
+    test_BitmapUpload = 'BitmapUploadActivity'
+    test_DialogList = 'DialogListActivity'
+    test_EditTextType = 'EditTextTypeActivity'
+    test_FullscreenOverdraw = 'FullscreenOverdrawActivity'
+    test_GlTextureView = 'GlTextureViewActivity'
+    test_InflatingList = 'InflatingListActivity'
+    test_Invalidate = 'InvalidateActivity'
+    test_ShadowGrid = 'ShadowGridActivity'
+    test_TextCacheHighHitrate = 'TextCacheHighHitrateActivity'
+    test_TextCacheLowHitrate = 'TextCacheLowHitrateActivity'
+    test_Transition = 'ActivityTransition'
+    test_TransitionDetails = 'ActivityTransitionDetails'
+    test_TrivialAnimation = 'TrivialAnimationActivity'
+    test_TrivialList = 'TrivialListActivity'
+    test_TrivialRecyclerView = 'TrivialRecyclerViewActivity'
 
     def __init__(self, test_env):
         super(UiBench, self).__init__(test_env)
@@ -79,7 +79,7 @@ class UiBench(Workload):
         :type collect: list(str)
         """
 
-        activity = '.' + test_name + 'Activity'
+        activity = '.' + test_name
 
         # Keep track of mandatory parameters
         self.out_dir = out_dir

--- a/tests/benchmarks/android_uibench.py
+++ b/tests/benchmarks/android_uibench.py
@@ -162,21 +162,26 @@ governors = [
 ]
 
 tests = [
-    'TrivialAnimation',
-    'BitmapUpload',
-    'DialogList',
-    'EditTextType',
-    'FullscreenOverdraw',
-    'GlTextureView',
-    'InflatingList',
-    'Invalidate',
-    'ShadowGrid',
-    'TextCacheHighHitrate',
-    'TextCacheLowHitrate',
-    'Transition',
-    'TransitionDetails',
-    'TrivialList',
-    'TrivialRecyclerView',
+# General
+    'DialogListActivity',
+    'FullscreenOverdrawActivity',
+    'GlTextureViewActivity',
+    'InvalidateActivity',
+    'TrivialAnimationActivity',
+    'TrivialListActivity',
+    'TrivialRecyclerViewActivity',
+# Inflation
+    'InflatingListActivity',
+# Rendering
+    'BitmapUploadActivity',
+    'ShadowGridActivity',
+# Text
+    'EditTextTypeActivity',
+    'TextCacheHighHitrateActivity',
+    'TextCacheLowHitrateActivity',
+# Transitions
+    'ActivityTransition',
+    'ActivityTransitionDetails',
 ]
 
 # Reboot device only the first time


### PR DESCRIPTION
test_name had a forced suffix of 'Activity' with the assumption that all
test names would have this appended at the end in the app. This is not
true for two activities; ActivityTransition and
ActivityTransitionDetails.
As such, the suffix has been removed and the user now must specify the
full name of the test name. In addition, the default list of tests have
been updated to reflect this.