### PR TITLE
uibench: Set the duration when using systrace

### DIFF
--- a/libs/utils/android/workloads/uibench.py
+++ b/libs/utils/android/workloads/uibench.py
@@ -84,6 +84,11 @@ class UiBench(Workload):
         # Keep track of mandatory parameters
         self.out_dir = out_dir
         self.collect = collect
+        # For systrace collection, the duration is expected to be part of `collect` parameter
+        # This is because systrace capturing currently doesnt support CTRL+C stopping
+        # so tracingStop() call just waits instead.
+        if collect == 'systrace':
+            self.collect = 'systrace_' + str(duration_s)
 
         # Press Back button to be sure we run the video from the start
         System.menu(self._target)


### PR DESCRIPTION
uibench by default collects with systrace but the duration_s parameter
is not used correctly. This is because of a limitation that we cannot
CTRL+C stop systrace captures so the workload class expects duration to
be appended to the collect parameter. This fixes uibench workload to
correctly parse the collect parameter to include the given duration_s
parameter.