### PR TITLE
libs/utils/android: Add systrace timeless support

### DIFF
--- a/libs/utils/android/system.py
+++ b/libs/utils/android/system.py
@@ -30,7 +30,7 @@ class System(object):
     """
 
     @staticmethod
-    def systrace_start(target, trace_file, time,
+    def systrace_start(target, trace_file, time=None,
                        events=['gfx', 'view', 'sched', 'freq', 'idle']):
 
         log = logging.getLogger('System')
@@ -46,10 +46,13 @@ class System(object):
                             target.CATAPULT_HOME)
                 return None
 
-        #  Format the command according to the specified time and events
-        systrace_pattern = "{} -e {} -o {} {} -t {}"
+        #  Format the command according to the specified arguments
+        systrace_pattern = "{} -e {} -o {} {}"
         trace_cmd = systrace_pattern.format(systrace_path, target.conf['device'],
-                                            trace_file, " ".join(events), time)
+                                            trace_file, " ".join(events))
+        if time is not None:
+            trace_cmd += " -t {}".format(time)
+
         log.info('SysTrace: %s', trace_cmd)
 
         # Actually spawn systrace

--- a/libs/utils/android/workload.py
+++ b/libs/utils/android/workload.py
@@ -101,12 +101,7 @@ class Workload(object):
             self.trace_file = os.path.join(self.out_dir, 'trace.html')
             # Get the systrace time
             match = re.search(r'systrace_([0-9]+)', self.collect)
-            if match:
-                self._trace_time = match.group(1)
-            else:
-                # TODO: must implement a CTRL+C based systrace stopping
-                self._log.warning("Systrace time NOT defined, tracing for 10[s]")
-                self._trace_time = 10
+            self._trace_time = match.group(1) if match else None
             self._log.info('Systrace START')
             self._systrace_output = System.systrace_start(
                 self._te, self.trace_file, self._trace_time)
@@ -132,6 +127,9 @@ class Workload(object):
             else:
                 self._log.info('Waiting systrace report [%s]...',
                                  self.trace_file)
+                if self._trace_time is None:
+                    # Systrace expects <enter>
+                    self._systrace_output.sendline('')
                 self._systrace_output.wait()
         # Dump a platform description
         self._te.platform_dump(self.out_dir)


### PR DESCRIPTION
Systrace expects either a time argument to know how long it has
to record traces, or an <enter> keystroke to end the tracing.
Added a 'fake' <enter> keystroke so tracing may be started
and stopped without a predefined duration.