### PR TITLE
libs/utils/energy: Add 'power' kind for default VExpress hwmon config

### DIFF
--- a/libs/utils/energy.py
+++ b/libs/utils/energy.py
@@ -195,6 +195,10 @@ class HWMon(EnergyMeter):
         # Reformat data for output generation
         clusters_nrg = {}
         for channel in self._channels:
+            if channel not in nrg:
+                raise RuntimeError('hwmon channel "{}" not available. '
+                                   'Selected channels: {}'.format(
+                                       channel, nrg.keys()))
             label = self._channels[channel]
             nrg_total = nrg[label]['total']
             self._log.debug('Energy [%16s]: %.6f', label, nrg_total)


### PR DESCRIPTION
It seems like some hwmon instances use 'power' instead of 'energy'. It looks like we can just enable both.

I'm not merging this unilaterally because there's a lot of hwmon-related code between LISA and devlib that I don't understand. It would also be fantastic if at least one other person could test this as it seems likely I'm breaking something for somebody.

BTW, at some point we really need to improve the way the hwmon stuff reports errors. This error was reported as a `KeyError` in `HwMon.report`. I spent a little time to try and make it a bit more helpful but there's really a lot of complexity and it seems like this complexity is necessary.