### PR TITLE
Add feature to extract EnergyModel from target data

### DIFF
--- a/libs/utils/platforms/hikey_energy.py
+++ b/libs/utils/platforms/hikey_energy.py
@@ -35,7 +35,7 @@ cluster_idle_states = OrderedDict([
 
 cpu_active_states = OrderedDict([
     ( 208000,  ActiveState(capacity=178,  power=69)),
-    ( 432000,  ActiveState(capacity=369,  power=125)),
+    ( 432000,  ActiveState(capacity=369,  power=124)),
     ( 729000,  ActiveState(capacity=622,  power=224)),
     ( 960000,  ActiveState(capacity=819,  power=367)),
     (1200000, ActiveState(capacity=1024, power=670))

--- a/libs/utils/platforms/juno_energy.py
+++ b/libs/utils/platforms/juno_energy.py
@@ -74,7 +74,7 @@ a57_cpu_active_states = OrderedDict([
     (625000,  ActiveState(capacity=579,   power=251)),
     (800000,  ActiveState(capacity=744,   power=359)),
     (950000,  ActiveState(capacity=883,   power=479)),
-    (1100000, ActiveState(capacity=1024,  power=616)),
+    (1100000, ActiveState(capacity=1023,  power=616)),
 ])
 
 a57_cpu_idle_states = OrderedDict([

--- a/libs/utils/platforms/juno_energy.py
+++ b/libs/utils/platforms/juno_energy.py
@@ -94,15 +94,15 @@ juno_energy = EnergyModel(
     root_node=EnergyModelRoot(
         children=[
             EnergyModelNode(
-                name="cluster_a57",
-                active_states=a57_cluster_active_states,
-                idle_states=a57_cluster_idle_states,
-                children=[a57_cpu_node(c) for c in a57s]),
-            EnergyModelNode(
                 name="cluster_a53",
                 active_states=a53_cluster_active_states,
                 idle_states=a53_cluster_idle_states,
-                children=[a53_cpu_node(c) for c in a53s])]),
+                children=[a53_cpu_node(c) for c in a53s]),
+            EnergyModelNode(
+                name="cluster_a57",
+                active_states=a57_cluster_active_states,
+                idle_states=a57_cluster_idle_states,
+                children=[a57_cpu_node(c) for c in a57s])]),
     root_power_domain=PowerDomain(idle_states=[], children=[
         PowerDomain(
             idle_states=["cluster-sleep-0"],

--- a/tests/eas/generic.py
+++ b/tests/eas/generic.py
@@ -22,10 +22,12 @@ import pandas as pd
 
 from bart.common.Utils import area_under_curve
 
-from energy_model import EnergyModelCapacityError
+from energy_model import EnergyModel, EnergyModelCapacityError
 from perf_analysis import PerfAnalysis
 from test import LisaTest, experiment_test
 from trace import Trace
+from . import _EasTest, energy_aware_conf, WORKLOAD_PERIOD_MS
+from unittest import SkipTest
 
 energy_aware_conf = {
     "tag" : "energy_aware",
@@ -78,7 +80,16 @@ class _EnergyModelTest(LisaTest):
         super(_EnergyModelTest, cls).runExperiments(*args, **kwargs)
 
     @classmethod
-    def _getExperimentsConf(cls, *args, **kwargs):
+    def _getExperimentsConf(cls, test_env):
+        if not test_env.nrg_model:
+            try:
+                test_env.nrg_model = EnergyModel.from_target(test_env.target)
+            except Exception as e:
+                raise SkipTest(
+                    'This test requires an EnergyModel for the platform. '
+                    'Either provide one manually or ensure it can be read '
+                    'from the filesystem: {}'.format(e))
+
         return {
             'wloads' : cls.workloads,
             'confs' : [energy_aware_conf]


### PR DESCRIPTION
This parses data out of procfs and sysfs. This data is currently only available in product-codeline EAS (i.e. AOSP common kernel). 

Unfortunately I'm adding 200 lines here without any new tests, because this code depends on having a target, and a localhost target isn't going to have the required data in sysfs. This is a hard thing to test as even mocking the filesystem poses non-trivial problems due to the way the code uses globs. Perhaps the best solution to this is testing with an emulated target using ARM Fast Models or similar.

----
The reason for the tweaks to the Hikey and Juno data are so that I could validate this code by reading the Hikey and Juno models and checking that the result matched the hard-coded one.