### PR TITLE
tests/eas/generic: Remove unused skip_on_smp flag

### DIFF
--- a/tests/eas/generic.py
+++ b/tests/eas/generic.py
@@ -64,9 +64,6 @@ class _EnergyModelTest(LisaTest):
         },
     }
 
-    # Set to true to run a test only on heterogeneous systems
-    skip_on_smp = False
-
     negative_slack_allowed_pct = 15
     """Percentage of RT-App task activations with negative slack allowed"""
 
@@ -82,9 +79,6 @@ class _EnergyModelTest(LisaTest):
 
     @classmethod
     def _getExperimentsConf(cls, *args, **kwargs):
-        if cls.skip_on_smp and not test_env.nrg_model.is_heterogeneous:
-            raise SkipTest('Test not required on symmetric systems')
-
         return {
             'wloads' : cls.workloads,
             'confs' : [energy_aware_conf]


### PR DESCRIPTION
None of the tests are big.LITTLe specific any more, they can all usefully be run
on any target, so remove this flag.

Also note that the `and not test_env.nrg_model.is_heterogeneous:` is broken
because `test_env` is not defined here, as..

Reported-by: Valentin Schneider <Valentin.Schneider@arm.com>
Fixes: 113ce343beab "tests/eas: Un-factorise code that is no longer shared"