### PR TITLE
LisaTest: Improve running tests with multiple iterations

### DIFF
--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -166,6 +166,9 @@ class Executor():
             Number of iterations for each workload/conf combination. Default
             is 1.
     :type experiments_conf: dict
+
+    :ivar experiments: After calling `meth`:run:, the list of
+                       :class:`Experiment` s that were run
     """
 
     critical_tasks = {

--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -169,6 +169,10 @@ class Executor():
 
     :ivar experiments: After calling `meth`:run:, the list of
                        :class:`Experiment` s that were run
+
+    :ivar iterations: The number of iterations run for each wload/conf pair
+                       (i.e. ``experiments_conf['iterations']``.
+
     """
 
     critical_tasks = {
@@ -218,9 +222,9 @@ class Executor():
         self.te = test_env
         self.target = self.te.target
 
-        self._iterations = self._experiments_conf.get('iterations', 1)
+        self.iterations = self._experiments_conf.get('iterations', 1)
         # Compute total number of experiments
-        self._exp_count = self._iterations \
+        self._exp_count = self.iterations \
                 * len(self._experiments_conf['wloads']) \
                 * len(self._experiments_conf['confs'])
 
@@ -236,7 +240,7 @@ class Executor():
 
         self._log.info('   %3d workloads (%d iterations each)',
                        len(self._experiments_conf['wloads']),
-                       self._iterations)
+                       self.iterations)
         wload_confs = ', '.join(self._experiments_conf['wloads'])
         self._log.info('      %s', wload_confs)
 
@@ -264,7 +268,7 @@ class Executor():
             for wl_idx in self._experiments_conf['wloads']:
                 # TEST: configuration
                 wload, test_dir = self._wload_init(tc, wl_idx)
-                for itr_idx in range(1, self._iterations + 1):
+                for itr_idx in range(1, self.iterations + 1):
                     exp = Experiment(
                         wload_name=wl_idx,
                         wload=wload,
@@ -666,7 +670,7 @@ class Executor():
         self._print_title('Experiment {}/{}, [{}:{}] {}/{}'\
                 .format(exp_idx, self._exp_count,
                         tc_idx, experiment.wload_name,
-                        experiment.iteration, self._iterations))
+                        experiment.iteration, self.iterations))
 
         # Setup local results folder
         self._log.debug('out_dir set to [%s]', experiment.out_dir)

--- a/libs/utils/test.py
+++ b/libs/utils/test.py
@@ -81,9 +81,9 @@ class LisaTest(unittest.TestCase):
         """
         Set up logging and trigger running experiments
         """
-        cls.logger = logging.getLogger('LisaTest')
+        cls._log = logging.getLogger('LisaTest')
 
-        cls.logger.info('Setup tests execution engine...')
+        cls._log.info('Setup tests execution engine...')
         test_env = TestEnv(test_conf=cls._getTestConf())
 
         experiments_conf = cls._getExperimentsConf(test_env)
@@ -100,7 +100,7 @@ class LisaTest(unittest.TestCase):
         # Execute pre-experiments code defined by the test
         cls._experimentsInit()
 
-        cls.logger.info('Experiments execution...')
+        cls._log.info('Experiments execution...')
         cls.executor.run()
 
         cls.experiments = cls.executor.experiments


### PR DESCRIPTION
Currently when you run a LisaTest with experiments_conf['iterations']!=0, the
test assertions are made for every experiment and the test is failed as soon as
any experiment produces a failure. Only the first failure encountered is
displayed.

With this patch all the results for each wload/conf pair are aggregated.

The problem is only solved across iterations: if multiple wloads or confs fail,
only the first wload/conf pair that was found to have failed will be
displayed.