### PR TITLE
tests/eas/generic: Fix broken import

### DIFF
--- a/tests/eas/generic.py
+++ b/tests/eas/generic.py
@@ -26,7 +26,6 @@ from energy_model import EnergyModel, EnergyModelCapacityError
 from perf_analysis import PerfAnalysis
 from test import LisaTest, experiment_test
 from trace import Trace
-from . import _EasTest, energy_aware_conf, WORKLOAD_PERIOD_MS
 from unittest import SkipTest
 
 


### PR DESCRIPTION
tests/eas/__init__.py was removed.

Fixes: 113ce343beab "tests/eas: Un-factorise code that is no longer shared"