### PR TITLE
wlgen/rta: Fix calibration value string replacement

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -305,6 +305,12 @@ class RTA(Workload):
         self.json = '{0:s}_{1:02d}.json'.format(self.name, self.exc_id)
         ofile = open(self.json, 'w')
         ifile = open(rtapp_conf, 'r')
+
+        # Calibration can either be a string like "CPU1" or an integer, if the
+        # former we need to quote it.
+        if type(calibration) != int:
+            calibration = '"{}"'.format(calibration)
+
         replacements = {
             '__DURATION__' : str(self.duration),
             '__PVALUE__'   : str(calibration),

--- a/tests/lisa/test_wlgen_rtapp.py
+++ b/tests/lisa/test_wlgen_rtapp.py
@@ -210,7 +210,7 @@ class TestRTAComposition(RTABase):
 
 
 class TestRTACustom(RTABase):
-    def test_custom_smoke(self):
+    def _test_custom_smoke(self, calibration):
         """
         Test RTA custom workload
 
@@ -221,7 +221,7 @@ class TestRTACustom(RTABase):
 
         json_path = os.path.join(os.getenv('LISA_HOME'),
                                  'assets', 'mp3-short.json')
-        rtapp = RTA(self.target, name='test', calibration=self.calibration)
+        rtapp = RTA(self.target, name='test', calibration=calibration)
 
         # Configure this RTApp instance to:
         rtapp.conf(kind='custom', params=json_path, duration=5,
@@ -249,3 +249,11 @@ class TestRTACustom(RTABase):
 
             self.assert_output_file_exists('output.log')
             self.assert_output_file_exists('test_00.json')
+
+    def test_custom_smoke_calib(self):
+        """Test RTA custom workload (providing calibration)"""
+        self._test_custom_smoke(self.calibration)
+
+    def test_custom_smoke_no_calib(self):
+        """Test RTA custom workload (providing no calibration)"""
+        self._test_custom_smoke(None)


### PR DESCRIPTION
Currently, under the assumption that the calibration is an int, we don't quote
it. However it may be a string like "CPU0" in which case we _do_ need to quote it.

Also add a test for this case.