### PR TITLE
gfxinfo: Poll framestats in a thread

### DIFF
--- a/libs/utils/android/system.py
+++ b/libs/utils/android/system.py
@@ -268,7 +268,7 @@ class System(object):
         target.execute('dumpsys gfxinfo {} reset'.format(apk_name))
 
     @staticmethod
-    def gfxinfo_get(target, apk_name, out_file):
+    def gfxinfo_get(target, apk_name, out_file, framestats=False):
         """
         Collect frame statistics for the given app.
 
@@ -280,9 +280,14 @@ class System(object):
 
         :param out_file: output file name
         :type out_file: str
+
+        :param framestats: collect framestats and *append* to out_file
+        :type framestats: bool
         """
-        adb_command(target.adb_name,
-                    GET_FRAMESTATS_CMD.format(apk_name, out_file))
+        cmd = GET_FRAMESTATS_CMD.format(apk_name, out_file)
+        if framestats:
+            cmd = cmd.replace('>', 'framestats >>')
+        adb_command(target.adb_name, cmd)
 
     @staticmethod
     def monkey(target, apk_name, event_count=1):


### PR DESCRIPTION
gfxinfo can be executed with an additional 'framestats' parameter that
gives detailed timestamp information for the last 120 frames.
Added a new parameter to expose this functionality.
As this only captures the last 120 frames, to get all frame data across
the workload we need to poll at least every 2 seconds (assuming 60Hz
vsync) and append the data to the same file. New start and stop
functions for doing this have been added to the workload class, similar
to how tracing is currently handled.