### PR TITLE
rta: Detect task names when using custom wload

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -306,6 +306,11 @@ class RTA(Workload):
         ifile.close()
         ofile.close()
 
+        with open(self.json) as f:
+            conf = json.load(f)
+        for tid in conf['tasks']:
+            self.tasks[tid] = {'pid': -1}
+
         return self.json
 
     def _confProfile(self):


### PR DESCRIPTION
RTA.__postrun uses the `tasks` attribute to find the logfiles to pull from the
target. So when using a custom rt-app configuration, set up this attribute in a
similar way to "profile" workloads.