### PR TITLE
TestEnv: Don't error if target's energy model is invalid

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -551,7 +551,7 @@ class TestEnv(ShareState):
             try:
                 self._log.info('Attempting to read energy model from target')
                 self.nrg_model = EnergyModel.from_target(self.target)
-            except (TargetError, RuntimeError) as e:
+            except (TargetError, RuntimeError, ValueError) as e:
                 self._log.error("Couldn't read target energy model: %s", e)
 
     def install_tools(self, tools):


### PR DESCRIPTION
It may happen that a target's EAS energy model is "invalid", e.g. because its
active state power values are not monotonically increasing with frequency (this
is the case with Google Pixel). In this case the EnergyModel construct will
throw a ValueError.

Don't fail to start LISA in that case, just print a warning.