### PR TITLE
android/benchmark: add iterations command line parameter

### DIFF
--- a/libs/utils/android/benchmark.py
+++ b/libs/utils/android/benchmark.py
@@ -62,6 +62,12 @@ class LisaBenchmark(object):
     bm_iterations = 1
     """Override this with the desired number of iterations of the test"""
 
+    bm_iterations_pause = 30
+    """
+    Override this with the desired amount of time (in seconds) to pause
+    for before each iteration
+    """
+
     def benchmarkInit(self):
         """
         Code executed before running the benchmark
@@ -112,6 +118,9 @@ class LisaBenchmark(object):
         parser.add_argument('--iterations', type=int,
                 default=1,
                 help='Number of iterations the same test has to be repeated for (default 1)')
+        parser.add_argument('--iterations-pause', type=int,
+                default=30,
+                help='Amount of time (in seconds) to pause for before each iteration (default 30s)')
 
         # Measurements settings
         parser.add_argument('--iio-channel-map', type=str,
@@ -140,6 +149,8 @@ class LisaBenchmark(object):
             self.bm_collect = self.args.collect
         if self.args.iterations:
             self.bm_iterations = self.args.iterations
+        if self.args.iterations_pause:
+            self.bm_iterations_pause = self.args.iterations_pause
 
         # Override energy meter configuration
         if self.args.iio_channel_map:
@@ -186,6 +197,14 @@ class LisaBenchmark(object):
             return ''
         return self.bm_collect
 
+    def _preRun(self):
+        """
+        Code executed before every iteration of the benchmark
+        """
+        self._log.info('Waiting {}[s] before executing iteration...'\
+                .format(self.bm_iterations_pause))
+        sleep(self.bm_iterations_pause)
+
     def __init__(self):
         """
         Set up logging and trigger running experiments
@@ -217,6 +236,8 @@ class LisaBenchmark(object):
             try:
                 os.makedirs(out_dir)
             except: pass
+
+            self._preRun()
 
             self.wl.run(out_dir=out_dir,
                         collect=self._getBmCollect(),

--- a/libs/utils/android/benchmark.py
+++ b/libs/utils/android/benchmark.py
@@ -100,8 +100,8 @@ class LisaBenchmark(object):
                 default=None,
                 help='Path of the Android boot.img to be used')
         parser.add_argument('--boot-timeout', type=int,
-                default=20,
-                help='Timeout in [s] to wait after a reboot (default 20)')
+                default=60,
+                help='Timeout in [s] to wait after a reboot (default 60)')
 
         # Android settings
         parser.add_argument('--android-device', type=str,

--- a/libs/utils/android/benchmark.py
+++ b/libs/utils/android/benchmark.py
@@ -221,6 +221,8 @@ class LisaBenchmark(object):
         if self.bm_reboot and not self.bm_iterations_reboot:
             self.reboot_target()
 
+        self.iterations_count = 1
+
     def _preRun(self):
         """
         Code executed before every iteration of the benchmark
@@ -230,10 +232,12 @@ class LisaBenchmark(object):
         if self.bm_reboot and self.bm_iterations_reboot:
             rebooted = self.reboot_target()
 
-        if not rebooted:
-            self._log.info('Waiting {}[s] before executing iteration...'\
-                           .format(self.bm_iterations_pause))
+        if not rebooted and self.iterations_count > 1:
+            self._log.info('Waiting {}[s] before executing iteration {}...'\
+                           .format(self.bm_iterations_pause, self.iterations_count))
             sleep(self.bm_iterations_pause)
+
+        self.iterations_count += 1
 
     def __init__(self):
         """

--- a/tests/benchmarks/android_geekbench.py
+++ b/tests/benchmarks/android_geekbench.py
@@ -67,16 +67,9 @@ class GeekbenchTest(LisaBenchmark):
         self.setupWorkload()
         self.setupGovernor()
 
-    def benchmarkFinalize(self):
-        if self.delay_after_s:
-            self._log.info("Waiting %d[s] before to continue...",
-                           self.delay_after_s)
-            sleep(self.delay_after_s)
-
-    def __init__(self, governor, test, delay_after_s=0):
+    def __init__(self, governor, test):
         self.governor = governor
         self.test = test
-        self.delay_after_s = delay_after_s
         super(GeekbenchTest, self).__init__()
 
     def setupWorkload(self):
@@ -163,9 +156,8 @@ tests_completed = 0
 for governor in governors:
     for test in tests:
         tests_remaining -= 1
-        delay_after_s = 30 if tests_remaining else 0
         try:
-            GeekbenchTest(governor, test, delay_after_s)
+            GeekbenchTest(governor, test)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests

--- a/tests/benchmarks/android_geekbench.py
+++ b/tests/benchmarks/android_geekbench.py
@@ -66,8 +66,6 @@ class GeekbenchTest(LisaBenchmark):
     def benchmarkInit(self):
         self.setupWorkload()
         self.setupGovernor()
-        if self.reboot:
-            self.reboot_target()
 
     def benchmarkFinalize(self):
         if self.delay_after_s:
@@ -75,8 +73,7 @@ class GeekbenchTest(LisaBenchmark):
                            self.delay_after_s)
             sleep(self.delay_after_s)
 
-    def __init__(self, governor, test, reboot=False, delay_after_s=0):
-        self.reboot = reboot
+    def __init__(self, governor, test, delay_after_s=0):
         self.governor = governor
         self.test = test
         self.delay_after_s = delay_after_s
@@ -161,8 +158,6 @@ tests = [
         'COMPUTE'
 ]
 
-# Reboot device only the first time
-do_reboot = True
 tests_remaining = len(governors) * len(tests)
 tests_completed = 0
 for governor in governors:
@@ -170,12 +165,11 @@ for governor in governors:
         tests_remaining -= 1
         delay_after_s = 30 if tests_remaining else 0
         try:
-            GeekbenchTest(governor, test, do_reboot, delay_after_s)
+            GeekbenchTest(governor, test, delay_after_s)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests
             pass
-        do_reboot = False
 
 # We want to collect data from at least one governor
 assert(tests_completed >= 1)

--- a/tests/benchmarks/android_gmaps.py
+++ b/tests/benchmarks/android_gmaps.py
@@ -67,18 +67,10 @@ class GMapsTest(LisaBenchmark):
         self.setupWorkload()
         self.setupGovernor()
 
-    def benchmarkFinalize(self):
-        if self.delay_after_s:
-            self._log.info("Waiting %d[s] before to continue...",
-                           self.delay_after_s)
-            sleep(self.delay_after_s)
-
-    def __init__(self, governor, location_search, swipe_count,
-                 delay_after_s=0):
+    def __init__(self, governor, location_search, swipe_count):
         self.governor = governor
         self.location_search = location_search
         self.swipe_count = swipe_count
-        self.delay_after_s = delay_after_s
         super(GMapsTest, self).__init__()
 
     def setupWorkload(self):
@@ -169,10 +161,8 @@ tests_completed = 0
 for governor in governors:
     for location in locations:
         tests_remaining -= 1
-        delay_after_s = 30 if tests_remaining else 0
         try:
-            GMapsTest(governor, location, swipe_count,
-                          delay_after_s)
+            GMapsTest(governor, location, swipe_count)
             tests_completed += 1
         except:
             # A test configuration failed, continue with other tests

--- a/tests/benchmarks/android_gmaps.py
+++ b/tests/benchmarks/android_gmaps.py
@@ -66,8 +66,6 @@ class GMapsTest(LisaBenchmark):
     def benchmarkInit(self):
         self.setupWorkload()
         self.setupGovernor()
-        if self.reboot:
-            self.reboot_target()
 
     def benchmarkFinalize(self):
         if self.delay_after_s:
@@ -75,9 +73,8 @@ class GMapsTest(LisaBenchmark):
                            self.delay_after_s)
             sleep(self.delay_after_s)
 
-    def __init__(self, governor, location_search, swipe_count, reboot=False,
+    def __init__(self, governor, location_search, swipe_count,
                  delay_after_s=0):
-        self.reboot = reboot
         self.governor = governor
         self.location_search = location_search
         self.swipe_count = swipe_count
@@ -167,8 +164,6 @@ locations = [
     "London British Museum"
 ]
 
-# Reboot device only the first time
-do_reboot = True
 tests_remaining = len(governors) * len(locations)
 tests_completed = 0
 for governor in governors:
@@ -177,12 +172,11 @@ for governor in governors:
         delay_after_s = 30 if tests_remaining else 0
         try:
             GMapsTest(governor, location, swipe_count,
-                          do_reboot, delay_after_s)
+                          delay_after_s)
             tests_completed += 1
         except:
             # A test configuration failed, continue with other tests
             pass
-        do_reboot = False
 
 # We want to collect data from at least one governor
 assert(tests_completed >= 1)

--- a/tests/benchmarks/android_jankbench.py
+++ b/tests/benchmarks/android_jankbench.py
@@ -67,8 +67,6 @@ class JankbenchTest(LisaBenchmark):
     def benchmarkInit(self):
         self.setupWorkload()
         self.setupGovernor()
-        if self.reboot:
-            self.reboot_target()
 
     def benchmarkFinalize(self):
         if self.delay_after_s:
@@ -77,8 +75,7 @@ class JankbenchTest(LisaBenchmark):
             sleep(self.delay_after_s)
 
     def __init__(self, governor, test, iterations,
-                 reboot=False, delay_after_s=0):
-        self.reboot = reboot
+                 delay_after_s=0):
         self.governor = governor
         self.test = test
         self.iterations = iterations
@@ -172,8 +169,6 @@ tests = [
     'edit_text'
 ]
 
-# Reboot device only the first time
-do_reboot = True
 tests_remaining = len(governors) * len(tests)
 tests_completed = 0
 for governor in governors:
@@ -182,12 +177,11 @@ for governor in governors:
         delay_after_s = 30 if tests_remaining else 0
         try:
             JankbenchTest(governor, test, iterations,
-                          do_reboot, delay_after_s)
+                          delay_after_s)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests
             pass
-        do_reboot = False
 
 # We want to collect data from at least one governor
 assert(tests_completed >= 1)

--- a/tests/benchmarks/android_jankbench.py
+++ b/tests/benchmarks/android_jankbench.py
@@ -68,18 +68,10 @@ class JankbenchTest(LisaBenchmark):
         self.setupWorkload()
         self.setupGovernor()
 
-    def benchmarkFinalize(self):
-        if self.delay_after_s:
-            self._log.info("Waiting %d[s] before to continue...",
-                           self.delay_after_s)
-            sleep(self.delay_after_s)
-
-    def __init__(self, governor, test, iterations,
-                 delay_after_s=0):
+    def __init__(self, governor, test, iterations):
         self.governor = governor
         self.test = test
         self.iterations = iterations
-        self.delay_after_s = delay_after_s
         super(JankbenchTest, self).__init__()
 
     def setupWorkload(self):
@@ -174,10 +166,8 @@ tests_completed = 0
 for governor in governors:
     for test in tests:
         tests_remaining -= 1
-        delay_after_s = 30 if tests_remaining else 0
         try:
-            JankbenchTest(governor, test, iterations,
-                          delay_after_s)
+            JankbenchTest(governor, test, iterations)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests

--- a/tests/benchmarks/android_uibench.py
+++ b/tests/benchmarks/android_uibench.py
@@ -67,18 +67,10 @@ class UiBenchTest(LisaBenchmark):
         self.setupWorkload()
         self.setupGovernor()
 
-    def benchmarkFinalize(self):
-        if self.delay_after_s:
-            self._log.info("Waiting %d[s] before to continue...",
-                           self.delay_after_s)
-            sleep(self.delay_after_s)
-
-    def __init__(self, governor, test, duration_s,
-                 delay_after_s=0):
+    def __init__(self, governor, test, duration_s):
         self.governor = governor
         self.test = test
         self.duration_s = duration_s
-        self.delay_after_s = delay_after_s
         super(UiBenchTest, self).__init__()
 
     def setupWorkload(self):
@@ -186,10 +178,8 @@ tests_completed = 0
 for governor in governors:
     for test in tests:
         tests_remaining -= 1
-        delay_after_s = 30 if tests_remaining else 0
         try:
-            UiBenchTest(governor, test, duration_s,
-                          delay_after_s)
+            UiBenchTest(governor, test, duration_s)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests

--- a/tests/benchmarks/android_uibench.py
+++ b/tests/benchmarks/android_uibench.py
@@ -66,8 +66,6 @@ class UiBenchTest(LisaBenchmark):
     def benchmarkInit(self):
         self.setupWorkload()
         self.setupGovernor()
-        if self.reboot:
-            self.reboot_target()
 
     def benchmarkFinalize(self):
         if self.delay_after_s:
@@ -75,9 +73,8 @@ class UiBenchTest(LisaBenchmark):
                            self.delay_after_s)
             sleep(self.delay_after_s)
 
-    def __init__(self, governor, test, duration_s, reboot=False,
+    def __init__(self, governor, test, duration_s,
                  delay_after_s=0):
-        self.reboot = reboot
         self.governor = governor
         self.test = test
         self.duration_s = duration_s
@@ -184,8 +181,6 @@ tests = [
     'ActivityTransitionDetails',
 ]
 
-# Reboot device only the first time
-do_reboot = True
 tests_remaining = len(governors) * len(tests)
 tests_completed = 0
 for governor in governors:
@@ -194,12 +189,11 @@ for governor in governors:
         delay_after_s = 30 if tests_remaining else 0
         try:
             UiBenchTest(governor, test, duration_s,
-                          do_reboot, delay_after_s)
+                          delay_after_s)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests
             pass
-        do_reboot = False
 
 # We want to collect data from at least one governor
 assert(tests_completed >= 1)

--- a/tests/benchmarks/android_vellamo.py
+++ b/tests/benchmarks/android_vellamo.py
@@ -66,8 +66,6 @@ class VellamoTest(LisaBenchmark):
     def benchmarkInit(self):
         self.setupWorkload()
         self.setupGovernor()
-        if self.reboot:
-            self.reboot_target()
 
     def benchmarkFinalize(self):
         if self.delay_after_s:
@@ -75,8 +73,7 @@ class VellamoTest(LisaBenchmark):
                            self.delay_after_s)
             sleep(self.delay_after_s)
 
-    def __init__(self, governor, test, reboot=False, delay_after_s=0):
-        self.reboot = reboot
+    def __init__(self, governor, test, delay_after_s=0):
         self.governor = governor
         self.test = test
         self.delay_after_s = delay_after_s
@@ -164,8 +161,6 @@ tests = [
 ]
 
 
-# Reboot device only the first time
-do_reboot = True
 tests_remaining = len(governors) * len(tests)
 tests_completed = 0
 for governor in governors:
@@ -173,12 +168,11 @@ for governor in governors:
         tests_remaining -= 1
         delay_after_s = 30 if tests_remaining else 0
         try:
-            VellamoTest(governor, test, do_reboot, delay_after_s)
+            VellamoTest(governor, test, delay_after_s)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests
             pass
-        do_reboot = False
 
 # We want to collect data from at least one governor
 assert(tests_completed >= 1)

--- a/tests/benchmarks/android_vellamo.py
+++ b/tests/benchmarks/android_vellamo.py
@@ -67,16 +67,9 @@ class VellamoTest(LisaBenchmark):
         self.setupWorkload()
         self.setupGovernor()
 
-    def benchmarkFinalize(self):
-        if self.delay_after_s:
-            self._log.info("Waiting %d[s] before to continue...",
-                           self.delay_after_s)
-            sleep(self.delay_after_s)
-
-    def __init__(self, governor, test, delay_after_s=0):
+    def __init__(self, governor, test):
         self.governor = governor
         self.test = test
-        self.delay_after_s = delay_after_s
         super(VellamoTest, self).__init__()
 
     def setupWorkload(self):
@@ -166,9 +159,8 @@ tests_completed = 0
 for governor in governors:
     for test in tests:
         tests_remaining -= 1
-        delay_after_s = 30 if tests_remaining else 0
         try:
-            VellamoTest(governor, test, delay_after_s)
+            VellamoTest(governor, test)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests

--- a/tests/benchmarks/android_youtube.py
+++ b/tests/benchmarks/android_youtube.py
@@ -66,8 +66,6 @@ class YouTubeTest(LisaBenchmark):
     def benchmarkInit(self):
         self.setupWorkload()
         self.setupGovernor()
-        if self.reboot:
-            self.reboot_target()
 
     def benchmarkFinalize(self):
         if self.delay_after_s:
@@ -75,9 +73,8 @@ class YouTubeTest(LisaBenchmark):
                            self.delay_after_s)
             sleep(self.delay_after_s)
 
-    def __init__(self, governor, video_url, video_duration_s, reboot=False,
+    def __init__(self, governor, video_url, video_duration_s,
                  delay_after_s=0):
-        self.reboot = reboot
         self.governor = governor
         self.video_url = video_url
         self.video_duration_s = video_duration_s
@@ -166,8 +163,6 @@ video_urls = [
     'https://youtu.be/XSGBVzeBUbk?t=45s',
 ]
 
-# Reboot device only the first time
-do_reboot = True
 tests_remaining = len(governors) * len(video_urls)
 tests_completed = 0
 for governor in governors:
@@ -176,12 +171,11 @@ for governor in governors:
         delay_after_s = 30 if tests_remaining else 0
         try:
             YouTubeTest(governor, url, video_duration_s,
-                          do_reboot, delay_after_s)
+                          delay_after_s)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests
             pass
-        do_reboot = False
 
 # We want to collect data from at least one governor
 assert(tests_completed >= 1)

--- a/tests/benchmarks/android_youtube.py
+++ b/tests/benchmarks/android_youtube.py
@@ -67,18 +67,10 @@ class YouTubeTest(LisaBenchmark):
         self.setupWorkload()
         self.setupGovernor()
 
-    def benchmarkFinalize(self):
-        if self.delay_after_s:
-            self._log.info("Waiting %d[s] before to continue...",
-                           self.delay_after_s)
-            sleep(self.delay_after_s)
-
-    def __init__(self, governor, video_url, video_duration_s,
-                 delay_after_s=0):
+    def __init__(self, governor, video_url, video_duration_s):
         self.governor = governor
         self.video_url = video_url
         self.video_duration_s = video_duration_s
-        self.delay_after_s = delay_after_s
         super(YouTubeTest, self).__init__()
 
     def setupWorkload(self):
@@ -168,10 +160,8 @@ tests_completed = 0
 for governor in governors:
     for url in video_urls:
         tests_remaining -= 1
-        delay_after_s = 30 if tests_remaining else 0
         try:
-            YouTubeTest(governor, url, video_duration_s,
-                          delay_after_s)
+            YouTubeTest(governor, url, video_duration_s)
             tests_completed += 1
         except:
             # A test configuraion failed, continue with other tests


### PR DESCRIPTION
It is usually handy to be able to run the same benchmark multiple times
(e.g., to do statistics on results).

Add a --iterations command line parameter to implement the feature.

Signed-off-by: Juri Lelli <juri.lelli@arm.com>