### PR TITLE
executor: Don't except `init` from freezing on Android

### DIFF
--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -171,7 +171,7 @@ class Executor():
     critical_tasks = {
         'linux': ['init', 'systemd', 'sh', 'ssh'],
         'android': [
-            'sh', 'adbd', 'init',
+            'sh', 'adbd',
             'usb', 'transport',
             # We don't actually need this task but on Google Pixel it apparently
             # cannot be frozen, so the cgroup state gets stuck in FREEZING if we


### PR DESCRIPTION
Freezing init doesn't seem to break anything. Also scenarios have been observed
where Android's init eats CPU while the rest of the system is frozen. Maybe
it's spin-waiting on a lock or mailbox for a frozen process.