### PR TITLE
Add 'userspace-freezing' support to the capacity_capping test

### DIFF
--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -168,21 +168,6 @@ class Executor():
     :type experiments_conf: dict
     """
 
-    critical_tasks = {
-        'linux': ['init', 'systemd', 'sh', 'ssh'],
-        'android': [
-            'sh', 'adbd',
-            'usb', 'transport',
-            # We don't actually need this task but on Google Pixel it apparently
-            # cannot be frozen, so the cgroup state gets stuck in FREEZING if we
-            # try to freeze it.
-            'thermal-engine'
-        ]
-    }
-    """
-    Dictionary mapping OS name to list of task names that we can't afford to
-    freeze when using freeeze_userspace.
-    """
 
     def __init__(self, test_env, experiments_conf):
         # Initialize globals
@@ -672,7 +657,7 @@ class Executor():
         # Freeze all userspace tasks that we don't need for running tests
         need_thaw = False
         if self._target_conf_flag(tc, 'freeze_userspace'):
-            need_thaw = self._freeze_userspace()
+            need_thaw = self.te.freeze_userspace()
 
         # FTRACE: start (if a configuration has been provided)
         if self.te.ftrace and self._target_conf_flag(tc, 'ftrace'):
@@ -708,30 +693,9 @@ class Executor():
 
         # Unfreeze the tasks we froze
         if need_thaw:
-            self._thaw_userspace()
+            self.te.thaw_userspace()
 
         self._print_footer()
-
-    def _freeze_userspace(self):
-        if 'cgroups' not in self.target.modules:
-            raise RuntimeError(
-                'Failed to freeze userspace. Ensure "cgroups" module is listed '
-                'among modules in target/test configuration')
-        controllers = [s.name for s in self.target.cgroups.list_subsystems()]
-        if 'freezer' not in controllers:
-            self._log.warning('No freezer cgroup controller on target. '
-                              'Not freezing userspace')
-            return False
-
-        exclude = self.critical_tasks[self.te.target.os]
-        self._log.info('Freezing all tasks except: %s', ','.join(exclude))
-        self.te.target.cgroups.freeze(exclude)
-        return True
-
-
-    def _thaw_userspace(self):
-        self._log.info('Un-freezing userspace tasks')
-        self.te.target.cgroups.freeze(thaw=True)
 
 ################################################################################
 # Utility Functions

--- a/tests/eas/capacity_capping.config
+++ b/tests/eas/capacity_capping.config
@@ -5,11 +5,12 @@
     "MIGRATION_WINDOW": 0.75,
     "EXPECTED_BUSY_TIME_PCT": 99,
     "TEST_CONF": {
-        "modules": ["bl", "cpufreq"],
+        "modules": ["bl", "cpufreq", "cgroups" ],
         "tools": ["rt-app"],
         "ftrace" : {
              "events" : ["sched_switch"],
              "buffsize" : 10240
-        }
+        },
+        "flags" : [ "ftrace" ]
     }
 }

--- a/tests/eas/capacity_capping.py
+++ b/tests/eas/capacity_capping.py
@@ -83,6 +83,7 @@ class CapacityCappingTest(unittest.TestCase):
 
     """
 
+
     @classmethod
     def setUpClass(cls):
         cls.params = {}
@@ -126,6 +127,7 @@ class CapacityCappingTest(unittest.TestCase):
         wload.conf(kind="profile", params=cls.params)
         phase_duration = WORKLOAD_DURATION_S / 3.
 
+        cls.env.freeze_userspace()
         cls.env.ftrace.start()
 
         wload.run(out_dir=cls.env.res_dir, background=True)
@@ -150,6 +152,7 @@ class CapacityCappingTest(unittest.TestCase):
 
         cls.env.ftrace.stop()
         cls.env.ftrace.get_trace(cls.trace_file)
+        cls.env.thaw_userspace()
 
     def check_residencies(self, cpus, cpus_name, window, phase_description):
         """Helper function to check the residencies of all busy threads on a


### PR DESCRIPTION
Running capacity_capping on a busy android system is an almost guaranteed failure, since it's actually quite reasonable to leave things running on very low OPPs if all the other cpus are already busy. However, if we freeze the userspace then we can be sure that the system is in a state where it should have the expected behaviour.

The test is not based on the executor class, so I took a few liberties rather than rewrite it using the new test classes.
I reused the 'executor' label for the log entries so that the default logging.conf was able to display them.
I took the implementation of freeze/thaw from executor, along with the task list.

Hope it's acceptable.