### PR TITLE
lisa_shell: Use jupyter command if ipython command doesn't exist

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -210,9 +210,14 @@ echo -e "\t${PYTHONPATH//:/\\n\\t}"
 cd $PYDIR
 echo
 echo -n 'Notebook server task: '
-nohup ipython notebook --ip=$IPADDR --port=$PORT \
-                       --NotebookApp.token=$TOKEN \
-                       >$LOGFILE 2>&1 &
+if which ipython >/dev/null; then
+    local cmd=ipython
+else
+    local cmd=jupyter
+fi
+nohup $cmd notebook --ip=$IPADDR --port=$PORT \
+                    --NotebookApp.token=$TOKEN \
+                    >$LOGFILE 2>&1 &
 echo $! >$PIDFILE
 echo $URL >$URLFILE
 cd - >/dev/null


### PR DESCRIPTION
Newer versions don't have an ipython command any more.