### PR TITLE
libs/utils/energy: Fix error reporting for missing hwmon channel

### DIFF
--- a/libs/utils/energy.py
+++ b/libs/utils/energy.py
@@ -195,11 +195,11 @@ class HWMon(EnergyMeter):
         # Reformat data for output generation
         clusters_nrg = {}
         for channel in self._channels:
-            if channel not in nrg:
+            label = self._channels[channel]
+            if label not in nrg:
                 raise RuntimeError('hwmon channel "{}" not available. '
                                    'Selected channels: {}'.format(
                                        channel, nrg.keys()))
-            label = self._channels[channel]
             nrg_total = nrg[label]['total']
             self._log.debug('Energy [%16s]: %.6f', label, nrg_total)
             clusters_nrg[channel] = nrg_total


### PR DESCRIPTION
For some platforms (e.g., JunoR2) channel labels in the energy report
might differ from channel names, and this raises a runtime error (even
if energy is correctly reported).

Fix it by always use channel labels.

Fixes: a41a48dfabb7 ('libs/utils/energy: Slightly improve error for missing hwmon channel')
Signed-off-by: Juri Lelli <juri.lelli@arm.com>