### PR TITLE
tests/stune/smoke_test_ramp: Add negative boost test for schedtune

### DIFF
--- a/tests/stune/smoke_test_ramp.config
+++ b/tests/stune/smoke_test_ramp.config
@@ -29,6 +29,51 @@
     /* Set of platform configurations to test */
     "confs" : [
         {
+            "tag" : "boost-15",
+            "flags" : "ftrace",
+            "sched_features" : "ENERGY_AWARE",
+            "cpufreq" : { "governor" : "sched" },
+	    "cgroups" : {
+                "conf" : {
+                    "schedtune" : {
+                        "/"      : {"boost" :  0 },
+                        "/stune" : {"boost" : -15 },
+                    }
+                },
+                "default" : "/stune",
+            }
+        },
+        {
+            "tag" : "boost-30",
+            "flags" : "ftrace",
+            "sched_features" : "ENERGY_AWARE",
+            "cpufreq" : { "governor" : "sched" },
+	    "cgroups" : {
+                "conf" : {
+                    "schedtune" : {
+                        "/"      : {"boost" :  0 },
+                        "/stune" : {"boost" : -30 },
+                    }
+                },
+                "default" : "/stune",
+            }
+        },
+        {
+            "tag" : "boost-60",
+            "flags" : "ftrace",
+            "sched_features" : "ENERGY_AWARE",
+            "cpufreq" : { "governor" : "sched" },
+	    "cgroups" : {
+                "conf" : {
+                    "schedtune" : {
+                        "/"      : {"boost" :  0 },
+                        "/stune" : {"boost" : -60 },
+                    }
+                },
+                "default" : "/stune",
+            }
+        },
+        {
             "tag" : "noboost",
             "flags" : "ftrace",
             "sched_features" : "ENERGY_AWARE",


### PR DESCRIPTION
Negative boosting is used to reduce the performance of a task
by running it at a lower frequency. It is supported in the kernel
and hence adding this patch for validation.

Signed-off-by: Divya Lingaiah <divya.lingaiah@intel.com>