### PR TITLE
Target-side command execution

### DIFF
--- a/libs/utils/android/workloads/gmaps.py
+++ b/libs/utils/android/workloads/gmaps.py
@@ -21,6 +21,7 @@ import logging
 
 from time import sleep
 
+from target_script import TargetScript
 from android import Screen, System
 from android.workload import Workload
 
@@ -90,20 +91,33 @@ class GMaps(Workload):
         # Allow the activity to start
         sleep(1)
 
-        self.tracingStart()
+        script = TargetScript(self._te, "gmaps_swiper.sh")
+        self._log.debug('Accumulating commands')
+
+        for i in range(swipe_count):
+            System.hswipe(script, 20, 80, 100, True)
+            script.append('sleep 1')
+            System.hswipe(script, 20, 80, 100, False)
+            script.append('sleep 1')
+            System.vswipe(script, 40, 60, 100, True)
+            script.append('sleep 1')
+            System.vswipe(script, 40, 60, 100, False)
+            script.append('sleep 1')
+
+        self._log.debug('Accumulation done')
+
+        # Push script to the target
+        script.push()
+
         self._log.info('Opening GMaps to [%s]', loc_url)
         # Let GMaps zoom in on the location
         sleep(2)
 
-        for i in range(swipe_count):
-            System.hswipe(self._target, 20, 80, 100, True)
-            sleep(.5)
-            System.hswipe(self._target, 20, 80, 100, False)
-            sleep(.5)
-            System.vswipe(self._target, 40, 60, 100, True)
-            sleep(.5)
-            System.vswipe(self._target, 40, 60, 100, False)
-            sleep(.5)
+        self.tracingStart()
+
+        self._log.info('Launching target script')
+        script.run()
+        self._log.info('Target script ended')
 
         self.tracingStop()
 

--- a/libs/utils/target_script.py
+++ b/libs/utils/target_script.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2015, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+
+SCRIPT_NAME = 'remote_script.sh'
+
+class TargetScript(object):
+    """
+    This class provides utility to create and run a script
+    directly on a devlib target.
+
+    The execute() method is made to look like Devlib's, so a Target instance can
+    be swapped with an instance of this TargetScript class, and the commands
+    will be accumulated for later use instead of being executed straight away.
+
+    :param env: Reference TestEnv instance. Will be used for some commands
+        that must really be executed instead of accumulated.
+    :type env: TestEnv
+
+    :param script_name: Name of the script that will be pushed on the target,
+        defaults to "remote_script.sh"
+    :type script_name: str
+    """
+
+    _target_attrs = ['screen_resolution', 'android_id', 'abi', 'os_version', 'model']
+
+    def __init__(self, env, script_name=SCRIPT_NAME):
+        self._env = env
+        self._target = env.target
+        self._script_name = script_name
+        self.commands = []
+        
+    # This is made to look like the devlib Target execute()
+    def execute(self, cmd):
+        """
+        Accumulate command for later execution.
+
+        :param cmd: Command that would be run on the target
+        :type cmd: str
+        """
+        self.append(cmd)
+
+    def append(self, cmd):
+        """
+        Append a command to the script.
+
+        :param cmd: Command string to append
+        :type cmd: str
+        """
+        self.commands.append(cmd)
+
+    # Some commands may require some info about the real target.
+    # For instance, System.{h,v}swipe needs to get the value of
+    # screen_resolution to generate a swipe command at a given
+    # screen coordinate percentage.
+    # Thus, if such a property is called on this object,
+    # it will be fetched from the 'real' target object.
+    def __getattr__(self, name):
+        if name in self._target_attrs:
+            return getattr(self._target, name)
+
+        return getattr(super, name)
+            
+    def push(self):
+        """
+        Push a script to the target
+
+        The script is created and stored on the host,
+        and is then sent to the target.
+
+        :param path: Path where the script will be locally created
+        :type path: str
+        :param actions: List of actions(commands) to run
+        :type actions: list(str)
+        """
+
+        actions = ['set -e'] + self.commands + ['set +e']
+        actions = ['#!{} sh'.format(self._target.busybox)] + actions
+        actions = str.join('\n', actions)
+
+        self._remote_path = self._target.path.join(self._target.executables_directory,
+                                                   self._script_name)
+        self._local_path = os.path.join(self._env.res_dir, self._script_name)
+
+        # Create script locally
+        with open(self._local_path, 'w') as script:
+            script.write(actions)
+
+        # Push it on target
+        self._target.push(self._local_path, self._remote_path)
+        self._target.execute('chmod +x {}'.format(self._remote_path))
+
+    def run(self):
+        """
+        Run the previously pushed script
+        """
+
+        if self._target.file_exists(self._remote_path):
+            self._target.execute(self._remote_path)
+        else:
+            raise IOError('Remote script was not found on target device')


### PR DESCRIPTION
This is in response to #329. The example that goes with it is on GMaps, but this uses another PR from devlib (https://github.com/ARM-software/devlib/pull/127), so it cannot be merged yet but is up for comments.

I've looked at the traces on kernelshark, and adbd is running only at the very start & end of the workload, which is a good start.