### PR TITLE
utils/trace: drop spurious wakeup/idle events

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -30,7 +30,7 @@ import logging
 from analysis_register import AnalysisRegister
 from collections import namedtuple
 from devlib.utils.misc import memoized
-from trappy.utils import listify
+from trappy.utils import listify, handle_duplicate_index
 
 
 NON_IDLE_STATE = -1
@@ -848,7 +848,9 @@ class Trace(object):
             entry_0 = pd.Series(cpu_active.iloc[0] ^ 1, index=[start_time])
             cpu_active = pd.concat([entry_0, cpu_active])
 
-        return cpu_active
+        # Fix sequences of wakeup/sleep events reported with the same index
+        return handle_duplicate_index(cpu_active)
+
 
     @memoized
     def getClusterActiveSignal(self, cluster):


### PR DESCRIPTION
In some traces it can happen that a CPU wakeup is immediately followed by a CPU idle event (or the other way around) which have the exact same timestamp. Such a condition means that the wakeup time (or sleep time) is essentially null and thus it can be discarded.

Nevertheless, such a condition generates an exception when we try to re-index the active signal, e.g. in HeavyLoadTest::test_tasks_spread.

This fixes these issues by ensuring that the cpu_active time series does not have spurious wakeup/idle events. The number of (eventually) dropper events is reported in output for logging purposes.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>