### PR TITLE
libs/utils/energy: Fix df indexing

### DIFF
--- a/libs/utils/energy.py
+++ b/libs/utils/energy.py
@@ -258,7 +258,7 @@ class _DevlibContinuousEnergyMeter(EnergyMeter):
             df = pd.read_csv(f, names=columns)
 
         sample_period = 1. / self._instrument.sample_rate_hz
-        df.index = np.arange(0, sample_period * len(df), step=sample_period)
+        df.index = np.linspace(0, sample_period * len(df), num=len(df))
 
         if df.empty:
             raise RuntimeError('No energy data collected')


### PR DESCRIPTION
numpy.arange() was being used to index the energy-measurements df.
This method has some issues where the 'stop' value may or may not
be included in the returned set, i.e:
arange(0.8, 1.0, 0.1) could return [0.8, 0.9, 1.0]
BUT
arange(0.7, 1.0, 0.1) could return [0.7, 0.8, 0.9]
(not tested for these values but it is the problem being encountered)

This could thus create n indexes for n-1 values, which would cause an
exception.

numpy.linspace() is more predictible than arange(), as the 'stop' value
can explicitly be included or excluded (excluded by default).
This commit introduces linspace().