### PR TITLE
android/workload: allow collection of kernel's symbols address

### DIFF
--- a/libs/utils/android/workload.py
+++ b/libs/utils/android/workload.py
@@ -94,11 +94,15 @@ class Workload(object):
             raise ValueError(msg)
         # Start FTrace
         if 'ftrace' in self.collect:
+            # Ensure symbols addresses are exposed via /proc/kallsyms
+            self._target.write_value('/proc/sys/kernel/kptr_restrict', 0)
             self.trace_file = os.path.join(self.out_dir, 'trace.dat')
             self._log.info('FTrace START')
             self._te.ftrace.start()
         # Start Systrace (mutually exclusive with ftrace)
         elif 'systrace' in self.collect:
+            # Ensure symbols addresses are exposed via /proc/kallsyms
+            self._target.write_value('/proc/sys/kernel/kptr_restrict', 0)
             self.trace_file = os.path.join(self.out_dir, 'trace.html')
             # Get the systrace time
             match = re.search(r'systrace_([0-9]+)', self.collect)


### PR DESCRIPTION
Kernel symbols are useful to support debugging of tasks traces and
ftrace allows to inject a backtrack from code via a simple call
to trace_dump_stack(). When the trace is dumped, the backtrace addresses
can be translated to function names via the mapping available in:
   /proc/kallsyms

However, for security reasons, the content of this file reports the
actual addresses only if access has not been "not restricted", which is
the default configuration.

This patch disable such restriction by pocking the provided procfs
configuration file (/proc/sys/kernel/kptr_restrict) every time we start
a tracing using either ftrace or systrace.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>