### PR TITLE
Save & restore cpufreq governor tunables for RTA calibration

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -99,13 +99,10 @@ class RTA(Workload):
         log = logging.getLogger('RTApp')
 
         # Save previous governors
-        cpus = target.list_online_cpus()
         old_governors = {}
-
-        for cpu in cpus:
-            domain = tuple(target.cpufreq.get_domain_cpus(cpu))
-            if domain not in old_governors:
-                old_governors[domain] = target.cpufreq.get_governor(cpu)
+        for domain in target.cpufreq.iter_domains():
+            cpu = domain[0]
+            old_governors[cpu] = target.cpufreq.get_governor(cpu)
 
         target.cpufreq.set_all_governors('performance')
 
@@ -145,8 +142,8 @@ class RTA(Workload):
         #   Setting a governor for a cpu will set it for all cpus in the same
         #   clock domain, so only restoring the governor of one cpu per domain
         #   is enough to restore all of the previous governors
-        for domain, governor in old_governors.iteritems():
-            target.cpufreq.set_governor(domain[0], governor)
+        for cpu, governor in old_governors.iteritems():
+            target.cpufreq.set_governor(cpu, governor)
 
         log.info('Target RT-App calibration:')
         log.info("{" + ", ".join('"%r": %r' % (key, pload[key])


### PR DESCRIPTION
Governor tunables are reset to default when switching governors.

This is particularly relevant when using the Executor, which calls
te.calibration() after _setup_cpufreq. If the calibration has not
been done yet, that will result in setting the performance governor
then restoring the previous governor. However if _setup_cpufreq set
up any tunables they are not currently restored. This commit fixes
that.

----

While I'm touching this code, I've also updated it to use the `iter_domains` method I added to devlib.