### PR TITLE
Add feature to set test iteration count from command line

### DIFF
--- a/libs/utils/test.py
+++ b/libs/utils/test.py
@@ -87,6 +87,14 @@ class LisaTest(unittest.TestCase):
         test_env = TestEnv(test_conf=cls._getTestConf())
 
         experiments_conf = cls._getExperimentsConf(test_env)
+
+        if ITERATIONS_FROM_CMDLINE:
+            if 'iterations' in experiments_conf:
+                cls.logger.warning(
+                    "Command line overrides iteration count in "
+                    "{}'s experiments_conf".format(cls.__name__))
+            experiments_conf['iterations'] = ITERATIONS_FROM_CMDLINE
+
         cls.executor = Executor(test_env, experiments_conf)
 
         # Alias tests and workloads configurations
@@ -226,5 +234,21 @@ def experiment_test(wrapped_test, instance, args, kwargs):
 
 # Prevent nosetests from running experiment_test directly as a test case
 experiment_test.__test__ = False
+
+# Allow the user to override the iterations setting from the command
+# line. Nosetests does not support this kind of thing, so we use an
+# evil hack: the lisa-test shell function takes an --iterations
+# argument and exports an environment variable. If the test itself
+# specifies an iterations count, we'll later print a warning and
+# override it. We do this here in the root scope, rather than in
+# runExperiments, so that if the value is invalid we print the error
+# immediately instead of going ahead with target setup etc.
+try:
+    ITERATIONS_FROM_CMDLINE = int(
+        os.getenv('LISA_TEST_ITERATIONS', '0'))
+    if ITERATIONS_FROM_CMDLINE < 0:
+        raise ValueError('Cannot be negative')
+except ValueError as e:
+    raise ValueError("Couldn't read iterations count: {}".format(e))
 
 # vim :set tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -284,18 +284,19 @@ Usage: lisa-test [args] FILE[:CLASS]
   to that tool.
 
   Examples:
-    Run all EAS Acceptance tests:
+    Run all EAS Generic tests:
 
-      lisa-test tests/eas/acceptance.py
+      lisa-test tests/eas/generic.py
 
-    Run ForkMigration test from EAS Acceptance suite:
+    Run RampUp test from EAS Generic suite:
 
-      lisa-test tests/eas/acceptance.py:ForkMigration
+      lisa-test tests/eas/generic.py:RampUp
 
-    Run ForkMigration test from EAS Acceptance suite, generating an XML test
+    Run RampUp test from EAS Generic suite, generating an XML test
     report via nose's XUnit plugin (see nosetests documentation):
 
-      lisa-test --with-xunit --xunit-file=report.xml tests/eas/acceptance.py:ForkMigration
+      lisa-test --with-xunit --xunit-file=report.xml tests/eas/generic.py:RampUp
+
 
 EOF
 }

--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -277,8 +277,12 @@ fi
 
 function _lisa-test-usage {
 cat <<EOF
-Usage: lisa-test [args] FILE[:CLASS]
+Usage: lisa-test [--iterations ITERATIONS] [args] FILE[:CLASS]
   Run automated tests. Tests can be found under the tests/ directory.
+
+  --iterations (or -n) sets the number of iterations to use for
+    each workload/target-conf, for tests that support this usage. 0 means use
+    the test's default iteration count.
 
   This is a wrapper for the 'nosetests' utility, additional arguments are passed
   to that tool.
@@ -297,7 +301,15 @@ Usage: lisa-test [args] FILE[:CLASS]
 
       lisa-test --with-xunit --xunit-file=report.xml tests/eas/generic.py:RampUp
 
+    Run RampUp test from EAS Generic suite, repeating the
+    workload 10 times and reporting how many times the test run
+    passed:
 
+      lisa-test --iterations 10 tests/eas/generic.py:RampUp
+
+    Run EAS Generic suite, repeating each workload 10 times:
+
+      lisa-test --iterations 10 tests/eas/generic.py
 EOF
 }
 
@@ -308,16 +320,36 @@ nosetests -v --nocapture --nologcapture \
 }
 
 function lisa-test {
-CMD=${1:-help}
+local iterations=0 # Means use default - see libs/utils/test.py
+local extra_args=""
+
 echo
-case "x${CMD^^}" in
-"xHELP")
-	_lisa-test-usage
-	;;
-*)
-	_lisa-test $*
-        local retcode=$?
-esac
+while [[ $# -gt 0 ]]; do
+        case "$1" in
+                help|-h|--help)
+                        _lisa-test-usage
+                        return 0
+                        ;;
+                -n|--iterations)
+                        iterations="$2"
+                        shift
+                        ;;
+                *)
+                        # Unrecognised args are passed through to nosetests
+                        extra_args="$extra_args $1"
+                        ;;
+        esac
+        shift
+done
+
+if [ -z "$extra_args" ]; then
+        # No arguments provided, default to "help"
+        _lisa-test-usage
+        return 1
+fi
+
+(export LISA_TEST_ITERATIONS=$iterations; _lisa-test $extra_args)
+local retcode=$?
 echo
 echo
 return $retcode


### PR DESCRIPTION
This is a kludge, but I think doing this properly basically requires
implementing our own Nose test runner, or even our own test-running
framework entire. In the short term we really need this feature.

nosetests doesn't provide a way for the user to pass command-line
arguments to the test. To get around this, this commit adds a
parameter to lisa-test that sets an environment variable, which
LisaTest then reads to set or override the iterations count.

---

This will go pretty nicely with https://github.com/ARM-software/lisa/pull/348 but they are technically independent.