### PR TITLE
[RFC] Allow specifying wload objects directly in the executor's experiments_conf

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -764,7 +764,7 @@ class TestEnv(ShareState):
                   force=False and we have not installed rt-app.
         """
 
-        if not force:
+        if not force and 'rt-app' not in self.__installed_tools:
             if not self._calib and 'rtapp-calib' in self.conf:
                 self._log.warning('Using configuration provided RTApp calibration')
                 self._calib = {
@@ -772,12 +772,6 @@ class TestEnv(ShareState):
                     for key, value in self.conf['rtapp-calib'].items()
                 }
             return self._calib
-
-        required = force or 'rt-app' in self.__installed_tools
-
-        if not required:
-            self._log.debug('No RT-App workloads, skipping calibration')
-            return
 
         self._log.info('Calibrating RTApp...')
         self._calib = RTA.calibrate(self.target)

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -520,7 +520,8 @@ class TestEnv(ShareState):
             self.target = devlib.LocalLinuxTarget(
                     platform = platform,
                     load_default_modules = False,
-                    modules = self.__modules)
+                    modules = self.__modules,
+                    connection_settings = {'unrooted': True})
         else:
             raise ValueError('Config error: not supported [platform] type {}'\
                     .format(platform_type))

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -764,7 +764,13 @@ class TestEnv(ShareState):
                   force=False and we have not installed rt-app.
         """
 
-        if not force and self._calib:
+        if not force:
+            if not self._calib and 'rtapp-calib' in self.conf:
+                self._log.warning('Using configuration provided RTApp calibration')
+                self._calib = {
+                    int(key): int(value)
+                    for key, value in self.conf['rtapp-calib'].items()
+                }
             return self._calib
 
         required = force or 'rt-app' in self.__installed_tools
@@ -773,15 +779,8 @@ class TestEnv(ShareState):
             self._log.debug('No RT-App workloads, skipping calibration')
             return
 
-        if not force and 'rtapp-calib' in self.conf:
-            self._log.warning('Using configuration provided RTApp calibration')
-            self._calib = {
-                    int(key): int(value)
-                    for key, value in self.conf['rtapp-calib'].items()
-                }
-        else:
-            self._log.info('Calibrating RTApp...')
-            self._calib = RTA.calibrate(self.target)
+        self._log.info('Calibrating RTApp...')
+        self._calib = RTA.calibrate(self.target)
 
         self._log.info('Using RT-App calibration values:')
         self._log.info('   %s',

--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -188,6 +188,7 @@ class Executor():
         # Initialize globals
         self._default_cgroup = None
         self._cgroup = None
+        self._old_selinux_mode = None
 
         # Setup logging
         self._log = logging.getLogger('Executor')
@@ -328,26 +329,30 @@ class Executor():
         self._log.debug('Setup RT-App run folder [%s]...', self.te.run_dir)
         self.target.execute('[ -d {0} ] || mkdir {0}'\
                 .format(self.te.run_dir))
-        self.target.execute(
+
+        if self.target.is_rooted:
+            self.target.execute(
                 'grep schedtest /proc/mounts || '\
                 '  mount -t tmpfs -o size=1024m {} {}'\
                 .format('schedtest', self.te.run_dir),
                 as_root=True)
-        # tmpfs mounts have an SELinux context with "tmpfs" as the type (while
-        # other files we create have "shell_data_file"). That prevents non-root
-        # users from creating files in tmpfs mounts. For now, just put SELinux
-        # in permissive mode to get around that.
-        try:
-            # First, save the old SELinux mode
-            self._old_selinux_mode = self.target.execute('getenforce')
-            self._log.warning('Setting target SELinux in permissive mode')
-            self.target.execute('setenforce 0', as_root=True)
-        except TargetError:
-            # Probably the target doesn't have SELinux, or there are no
-            # contexts set up. No problem.
-            self._log.warning("Couldn't set SELinux in permissive mode. "
-                                "This is probably fine.")
-            self._old_selinux_mode = None
+
+            # tmpfs mounts have an SELinux context with "tmpfs" as the type
+            # (while other files we create have "shell_data_file"). That
+            # prevents non-root users from creating files in tmpfs mounts. For
+            # now, just put SELinux in permissive mode to get around that.
+            try:
+                # First, save the old SELinux mode
+                self._old_selinux_mode = self.target.execute('getenforce')
+            except TargetError:
+                # Probably the target doesn't have SELinux. No problem.
+                pass
+            else:
+
+                self._log.warning('Setting target SELinux in permissive mode')
+                self.target.execute('setenforce 0', as_root=True)
+        else:
+            self._log.warning('Not mounting tempfs because no root')
 
     def _setup_cpufreq(self, tc):
         if 'cpufreq' not in tc:

--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -243,10 +243,6 @@ class Executor():
         self._log.info('Results will be collected under:')
         self._log.info('      %s', self.te.res_dir)
 
-        if any(wl['type'] == 'rt-app'
-               for wl in self._experiments_conf['wloads'].values()):
-            self._log.info('rt-app workloads found, installing tool on target')
-            self.te.install_tools(['rt-app'])
 
     def run(self):
         self._print_section('Experiments execution')
@@ -641,7 +637,12 @@ class Executor():
 
         # Configure the test workload
         wlspec = self._experiments_conf['wloads'][wl_idx]
-        wload = self._wload_conf(wl_idx, wlspec)
+        if type(wlspec) == dict:
+            wload = self._wload_conf(wl_idx, wlspec)
+        else:
+            wload = wlspec
+
+        self.te.install_tools([wload.executor])
 
         # Keep track of platform configuration
         test_dir = '{}/{}:{}:{}'\

--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -50,7 +50,8 @@ class RTA(Workload):
     def __init__(self,
                  target,
                  name,
-                 calibration=None):
+                 calibration=None,
+                 *args, **kwargs):
         """
         :param target: Devlib target to run workload on.
         :param name: Human-readable name for the workload.
@@ -67,8 +68,6 @@ class RTA(Workload):
         # TODO: Assume rt-app is pre-installed on target
         # self.target.setup('rt-app')
 
-        super(RTA, self).__init__(target, name)
-
         # rt-app executor
         self.wtype = 'rtapp'
         self.executor = 'rt-app'
@@ -80,6 +79,8 @@ class RTA(Workload):
         self.rta_cmd  = None
         self.rta_conf = None
         self.test_label = None
+
+        super(RTA, self).__init__(target, name, *args, **kwargs)
 
         # Setup RTA callbacks
         self.setCallback('postrun', self.__postrun)

--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -385,6 +385,9 @@ class RTA(Workload):
         for tid in sorted(self.params['profile'].keys()):
             task = self.params['profile'][tid]
 
+            if isinstance(task, RTATask):
+                task = task.get()
+
             # Initialize task configuration
             task_conf = {}
 

--- a/libs/wlgen/wlgen/workload.py
+++ b/libs/wlgen/wlgen/workload.py
@@ -41,7 +41,13 @@ class Workload(object):
 
     def __init__(self,
                  target,
-                 name):
+                 name,
+                 profile=None,
+                 custom_conf=None,
+                 *args, **kwargs):
+
+        if custom_conf and profile_conf:
+            raise ValueError('Provide only one of custom_conf and profile_conf')
 
         # Target device confguration
         self.target = target
@@ -95,6 +101,11 @@ class Workload(object):
         self._log = logging.getLogger('Workload')
 
         self._log.info('Setup new workload %s', self.name)
+
+        if profile:
+            self.conf('profile', profile, *args, **kwargs)
+        elif custom_conf:
+            self.conf('custom', custom_conf, *args, **kwargs)
 
     def __callback(self, step, **kwords):
         if step not in self.steps.keys():

--- a/tests/lisa/test_executor.py
+++ b/tests/lisa/test_executor.py
@@ -22,6 +22,7 @@ from unittest import TestCase
 
 from env import TestEnv
 from executor import Executor
+from wlgen import RTA, Periodic
 
 class SetUpTarget(TestCase):
     @classmethod
@@ -67,6 +68,42 @@ class TestMagicSmoke(SetUpTarget):
                     },
                 },
             },
+        }
+
+        executor = Executor(self.te, experiments_conf)
+        executor.run()
+
+        self.assertTrue(
+            os.path.isdir(results_dir),
+            'Expected to find a directory at {}'.format(results_dir))
+
+        result_1_dir = os.path.join(results_dir, '1')
+        self.assertTrue(
+            os.path.isdir(result_1_dir),
+            'Expected to find a directory at {}'.format(result_1_dir))
+
+class TestDirectObject(SetUpTarget):
+    """Test that Executor can be configured directly using Workload objects"""
+    def test_files_created(self):
+        """Test that we can run experiments and get output files"""
+        conf_name = 'myconf'
+        wl_name = 'mywl'
+
+        results_dir = os.path.join(self.te.LISA_HOME, 'results', self.res_dir,
+                                   'rtapp:{}:{}'.format(conf_name, wl_name))
+        if os.path.isdir(results_dir):
+            shutil.rmtree(results_dir)
+
+        wload = RTA(self.te.target, wl_name)
+        wload.conf('profile', {'mytask': Periodic().get()})
+
+        experiments_conf = {
+            'confs': [{
+                'tag': conf_name
+            }],
+            "wloads" : {
+                wl_name : wload
+            }
         }
 
         executor = Executor(self.te, experiments_conf)

--- a/tests/lisa/test_executor.py
+++ b/tests/lisa/test_executor.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2017, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+import shutil
+import os
+from unittest import TestCase
+
+from env import TestEnv
+from executor import Executor
+
+class SetUpTarget(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._log = logging.getLogger('TestExecutor')
+
+    def setUp(self):
+        self.res_dir='test_{}'.format(self.__class__.__name__)
+        self.te = TestEnv(
+            target_conf={'platform': 'host'},
+            test_conf={'results_dir': self.res_dir},
+            force_new=True)
+
+class TestMagicSmoke(SetUpTarget):
+    def test_files_created(self):
+        """Test that we can run experiments and get output files"""
+        conf_name = 'myconf'
+        wl_name = 'mywl'
+
+        results_dir = os.path.join(self.te.LISA_HOME, 'results', self.res_dir,
+                                   'rtapp:{}:{}'.format(conf_name, wl_name))
+        if os.path.isdir(results_dir):
+            shutil.rmtree(results_dir)
+
+        experiments_conf = {
+            'confs': [{
+                'tag': conf_name
+            }],
+            "wloads" : {
+                wl_name : {
+                    "type" : "rt-app",
+                    "conf" : {
+                        "class" : "profile",
+                        "params" : {
+                            "mytask" : {
+                                "kind" : "Periodic",
+                                "params" : {
+                                    "duty_cycle_pct": 10,
+                                    "duration_s": 0.2,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        executor = Executor(self.te, experiments_conf)
+        executor.run()
+
+        self.assertTrue(
+            os.path.isdir(results_dir),
+            'Expected to find a directory at {}'.format(results_dir))
+
+        result_1_dir = os.path.join(results_dir, '1')
+        self.assertTrue(
+            os.path.isdir(result_1_dir),
+            'Expected to find a directory at {}'.format(result_1_dir))


### PR DESCRIPTION
This is basically to allow you to use the Executor without having to use the dictionary grammar to specify the synthetic workloads you want to use.

That basically means instead of:

```
        experiments_conf = {
            'confs': [{
                'tag': "my_conf"
            }],
            "wloads" : {
                "my_wload" : {
                    "type" : "rt-app",
                    "conf" : {
                        "class" : "profile",
                        "params" : {
                            "my_task" : {
                                "kind" : "Periodic",
                                "params" : {
                                    <task params>
                                },
                            },
                        },
                    },
                },
            },
        }
```

You can have something like:

```
        wload = RTA(target, "my_wload")
        wload.conf('profile', {'my_task': Periodic(<task params>).get()})

        experiments_conf = {
            'confs': [{
                'tag': "my_conf",
            }],
            "wloads" : {
                "my_wload" : wload
            }
        }
```

I've marked this "RFC" because a) I haven't done documentation and b) The API is still a bit awkward. For example note that you "name" the workload twice (i.e. the string "my_wload" appears  twice in my example). I think the ideal usage would be like this:

```
        experiments_conf = {
            'confs': [{
                'tag': conf_name
            }],
            "wloads" : [
                RTA(target, wl_name, profile={'mytask': Periodic()})
            ]
        }
```

But there's quite a few more changes needed to achieve that.