### PR TITLE
submodules: add LISA wiki as a subproject

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "libs/bart"]
 	path = libs/bart
 	url = https://github.com/ARM-Software/bart.git
+[submodule "wiki"]
+	path = wiki
+	url = https://github.com/ARM-Software/lisa.wiki.git


### PR DESCRIPTION
The Github Wiki is not easily accessible to users willing to contribute by
adding documentation or fixing typos. Let's pull in the wiki as a local
subproject so that it should be more easily accessible to users willing to
contribute.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>