### PR TITLE
tests/eas/generic: Reduce energy threshold 20%->5%

### DIFF
--- a/tests/eas/generic.py
+++ b/tests/eas/generic.py
@@ -63,7 +63,7 @@ class _EnergyModelTest(LisaTest):
     negative_slack_allowed_pct = 15
     """Percentage of RT-App task activations with negative slack allowed"""
 
-    energy_est_threshold_pct = 20
+    energy_est_threshold_pct = 5
     """
     Allowed margin for error in estimated energy cost for task placement,
     compared to optimal placment.


### PR DESCRIPTION
20% is too forgiving, it lets you get away with keeping small tasks on the big
CPUs on some big.LITLE platforms.