### PR TITLE
utils/analysis: Fix overutilized plotting

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -593,6 +593,10 @@ class Trace(object):
         df['len'] = (df.start - df.start.shift()).fillna(0).shift(-1)
         df.drop('start', axis=1, inplace=True)
 
+        # Fix the last event, which will have a NaN duration
+        # Set duration to trace_end - last_event
+        df.loc[df.index[-1], 'len'] = self.start_time + self.time_range - df.index[-1]
+
         # Build a stat on trace overutilization
         df = self._dfg_trace_event('sched_overutilized')
         self.overutilized_time = df[df.overutilized == 1].len.sum()

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -88,6 +88,9 @@ class Trace(object):
         # The time window used to limit trace parsing to
         self.window = window
 
+        # Whether trace timestamps are normalized or not
+        self.normalize_time = normalize_time
+
         # Dynamically registered TRAPpy events
         self.trappy_cls = {}
 
@@ -126,8 +129,7 @@ class Trace(object):
         self.plots_prefix = plots_prefix
 
         self.__registerTraceEvents(events)
-        self.__parseTrace(data_dir, window, normalize_time,
-                          trace_format)
+        self.__parseTrace(data_dir, window, trace_format)
         self.__computeTimeSpan()
 
         # Minimum and Maximum x_time to use for all plots
@@ -199,7 +201,7 @@ class Trace(object):
         if 'cpu_frequency' in events:
             self.events.append('cpu_frequency_devlib')
 
-    def __parseTrace(self, path, window, normalize_time, trace_format):
+    def __parseTrace(self, path, window, trace_format):
         """
         Internal method in charge of performing the actual parsing of the
         trace.
@@ -209,9 +211,6 @@ class Trace(object):
 
         :param window: time window to consider when parsing the trace
         :type window: tuple(int, int)
-
-        :param normalize_time: normalize trace time stamps
-        :type normalize_time: bool
 
         :param trace_format: format of the trace. Possible values are:
             - FTrace
@@ -232,7 +231,7 @@ class Trace(object):
             raise ValueError("Unknown trace format {}".format(trace_format))
 
         self.ftrace = trace_class(path, scope="custom", events=self.events,
-                                  window=window, normalize_time=normalize_time)
+                                  window=window, normalize_time=self.normalize_time)
 
         # Load Functions profiling data
         has_function_stats = self._loadFunctionsStats(path)
@@ -261,7 +260,7 @@ class Trace(object):
         self._sanitize_CpuFrequency()
 
         # Compute plot window
-        if not normalize_time:
+        if not self.normalize_time:
             start = self.window[0]
             if self.window[1]:
                 duration = min(self.ftrace.get_duration(), self.window[1])

--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -130,16 +130,6 @@ class Trace(object):
 
         self.__registerTraceEvents(events)
         self.__parseTrace(data_dir, window, trace_format)
-        self.__computeTimeSpan()
-
-        # Minimum and Maximum x_time to use for all plots
-        self.x_min = 0
-        self.x_max = self.time_range
-
-        # Reset x axis time range to full scale
-        t_min = self.window[0]
-        t_max = self.window[1]
-        self.setXTimeRange(t_min, t_max)
 
         self.data_frame = TraceData()
         self._registerDataFrameGetters(self)
@@ -173,14 +163,9 @@ class Trace(object):
         :param t_max: upper bound
         :type t_max: int or float
         """
-        if t_min is None:
-            self.x_min = 0
-        else:
-            self.x_min = t_min
-        if t_max is None:
-            self.x_max = self.time_range
-        else:
-            self.x_max = t_max
+        self.x_min = t_min if t_min is not None else self.start_time
+        self.x_max = t_max if t_max is not None else self.start_time + self.time_range
+
         self._log.debug('Set plots time range to (%.6f, %.6f)[s]',
                        self.x_min, self.x_max)
 
@@ -230,8 +215,16 @@ class Trace(object):
         else:
             raise ValueError("Unknown trace format {}".format(trace_format))
 
+        # If using normalized time, we should use
+        # TRAPpy's `abs_window` instead of `window`
+        window_kw = {}
+        if self.normalize_time:
+            window_kw['window'] = window
+        else:
+            window_kw['abs_window'] = window
+
         self.ftrace = trace_class(path, scope="custom", events=self.events,
-                                  window=window, normalize_time=self.normalize_time)
+                                  normalize_time=self.normalize_time, **window_kw)
 
         # Load Functions profiling data
         has_function_stats = self._loadFunctionsStats(path)
@@ -248,8 +241,9 @@ class Trace(object):
         # Index PIDs and Task names
         self.__loadTasksNames()
 
-        # Setup internal data reference to interesting events/dataframes
+        self.__computeTimeSpan()
 
+        # Setup internal data reference to interesting events/dataframes
         self._sanitize_SchedLoadAvgCpu()
         self._sanitize_SchedLoadAvgTask()
         self._sanitize_SchedCpuCapacity()
@@ -258,16 +252,6 @@ class Trace(object):
         self._sanitize_SchedEnergyDiff()
         self._sanitize_SchedOverutilized()
         self._sanitize_CpuFrequency()
-
-        # Compute plot window
-        if not self.normalize_time:
-            start = self.window[0]
-            if self.window[1]:
-                duration = min(self.ftrace.get_duration(), self.window[1])
-            else:
-                duration = self.ftrace.get_duration()
-            self.window = (self.ftrace.basetime + start,
-                           self.ftrace.basetime + duration)
 
     def __checkAvailableEvents(self, key=""):
         """
@@ -318,30 +302,12 @@ class Trace(object):
         """
         Compute time axis range, considering all the parsed events.
         """
-        ts = sys.maxint
-        te = 0
-
-        for events in self.available_events:
-            df = self._dfg_trace_event(events)
-            if len(df) == 0:
-                continue
-            if (df.index[0]) < ts:
-                ts = df.index[0]
-            if (df.index[-1]) > te:
-                te = df.index[-1]
-            self.time_range = te - ts
-
+        self.start_time = 0 if self.normalize_time else self.ftrace.basetime
+        self.time_range = self.ftrace.get_duration()
         self._log.debug('Collected events spans a %.3f [s] time interval',
                        self.time_range)
 
-        # Build a stat on trace overutilization
-        if self.hasEvents('sched_overutilized'):
-            df = self._dfg_trace_event('sched_overutilized')
-            self.overutilized_time = df[df.overutilized == 1].len.sum()
-            self.overutilized_prc = 100. * self.overutilized_time / self.time_range
-
-            self._log.debug('Overutilized time: %.6f [s] (%.3f%% of trace time)',
-                           self.overutilized_time, self.overutilized_prc)
+        self.setXTimeRange(self.window[0], self.window[1])
 
     def _scanTasks(self, df, name_key='comm', pid_key='pid'):
         """
@@ -626,6 +592,14 @@ class Trace(object):
         df['start'] = df.index
         df['len'] = (df.start - df.start.shift()).fillna(0).shift(-1)
         df.drop('start', axis=1, inplace=True)
+
+        # Build a stat on trace overutilization
+        df = self._dfg_trace_event('sched_overutilized')
+        self.overutilized_time = df[df.overutilized == 1].len.sum()
+        self.overutilized_prc = 100. * self.overutilized_time / self.time_range
+
+        self._log.debug('Overutilized time: %.6f [s] (%.3f%% of trace time)',
+                        self.overutilized_time, self.overutilized_prc)
 
     def _chunker(self, seq, size):
         """

--- a/tests/lisa/test_trace.py
+++ b/tests/lisa/test_trace.py
@@ -27,6 +27,7 @@ class TestTrace(TestCase):
     traces_dir = os.path.join(os.path.dirname(__file__), 'traces')
     events = [
         'sched_switch',
+        'sched_overutilized'
     ]
 
     def __init__(self, *args, **kwargs):
@@ -103,3 +104,19 @@ class TestTrace(TestCase):
         )
 
         self.assertAlmostEqual(trace.time_range, expected_duration, places=6)
+
+    def test_overutilized_time(self):
+        """
+        TestTrace: overutilized_time is the total time spent while system was overutilized
+        """
+        events = [
+            76.402065,
+            80.402065,
+            82.001337
+        ]
+
+        trace_end = self.trace.ftrace.basetime + self.trace.ftrace.get_duration()
+        # Last event should be extended to the trace's end
+        expected_time = (events[1] - events[0]) + (trace_end - events[2])
+
+        self.assertAlmostEqual(self.trace.overutilized_time, expected_time, places=6)

--- a/tests/lisa/test_trace.py
+++ b/tests/lisa/test_trace.py
@@ -78,3 +78,28 @@ class TestTrace(TestCase):
         self.assertEqual(trace.getTaskByName('father'), [1234])
 
         os.remove(self.test_trace)
+
+    def test_time_range(self):
+        """
+        TestTrace: time_range is the duration of the trace
+        """
+        expected_duration = 6.676497
+
+        trace = Trace(self.platform, self.trace_path,
+                      self.events, normalize_time=False
+        )
+
+        self.assertAlmostEqual(trace.time_range, expected_duration, places=6)
+
+    def test_time_range_window(self):
+        """
+        TestTrace: time_range is the duration of the trace in the given window
+        """
+        expected_duration = 4.0
+
+        trace = Trace(self.platform, self.trace_path,
+                      self.events, normalize_time=False,
+                      window=(76.402065, 80.402065)
+        )
+
+        self.assertAlmostEqual(trace.time_range, expected_duration, places=6)

--- a/tests/lisa/test_trace.py
+++ b/tests/lisa/test_trace.py
@@ -37,8 +37,8 @@ class TestTrace(TestCase):
         with open(os.path.join(self.traces_dir, 'platform.json')) as f:
             self.platform = json.load(f)
 
-        trace_path = os.path.join(self.traces_dir, 'trace.txt')
-        self.trace = Trace(self.platform, trace_path, self.events)
+        self.trace_path = os.path.join(self.traces_dir, 'trace.txt')
+        self.trace = Trace(self.platform, self.trace_path, self.events)
 
     def test_getTaskByName(self):
         """TestTrace: getTaskByName() returns the list of PIDs for all tasks with the specified name"""

--- a/tests/lisa/traces/trace.txt
+++ b/tests/lisa/traces/trace.txt
@@ -494,6 +494,7 @@ cpus=6
           <idle>-0     [002]    76.402047: sched_wakeup:          comm=rcu_preempt pid=8 prio=120 success=1 target_cpu=2
           <idle>-0     [002]    76.402053: sched_switch:          prev_comm=swapper/2 prev_pid=0 prev_prio=120 prev_state=0 next_comm=rcu_preempt next_pid=8 next_prio=120
      rcu_preempt-8     [002]    76.402060: sched_switch:          prev_comm=rcu_preempt prev_pid=8 prev_prio=120 prev_state=1 next_comm=swapper/2 next_pid=0 next_prio=120
+          <idle>-0     [001]    76.402065: sched_overutilized:    overutilized=1
           <idle>-0     [002]    76.521978: sched_wakeup:          comm=sshd pid=1639 prio=120 success=1 target_cpu=2
           <idle>-0     [002]    76.521983: sched_switch:          prev_comm=swapper/2 prev_pid=0 prev_prio=120 prev_state=0 next_comm=sshd next_pid=1639 next_prio=120
             sshd-1639  [002]    76.522040: sched_wakeup:          comm=kworker/u12:1 pid=46 prio=120 success=1 target_cpu=2
@@ -1751,6 +1752,7 @@ cpus=6
           <idle>-0     [005]    80.390135: sched_switch:          prev_comm=swapper/5 prev_pid=0 prev_prio=120 prev_state=0 next_comm=watchdog/5 next_pid=39 next_prio=0
       watchdog/5-39    [005]    80.390145: sched_switch:          prev_comm=watchdog/5 prev_pid=39 prev_prio=0 prev_state=1 next_comm=swapper/5 next_pid=0 next_prio=120
             ramp-1706  [004]    80.393096: sched_switch:          prev_comm=ramp prev_pid=1706 prev_prio=120 prev_state=1 next_comm=swapper/4 next_pid=0 next_prio=120
+          <idle>-0     [001]    80.402065: sched_overutilized:    overutilized=0	  
           <idle>-0     [002]    80.406317: sched_wakeup:          comm=ramp pid=1706 prio=120 success=1 target_cpu=2
           <idle>-0     [002]    80.406334: sched_switch:          prev_comm=swapper/2 prev_pid=0 prev_prio=120 prev_state=0 next_comm=ramp next_pid=1706 next_prio=120
             ramp-1706  [002]    80.410068: sched_wakeup:          comm=kworker/2:1 pid=479 prio=120 success=1 target_cpu=2
@@ -2058,6 +2060,7 @@ cpus=6
           <idle>-0     [001]    81.958070: sched_switch:          prev_comm=swapper/1 prev_pid=0 prev_prio=120 prev_state=0 next_comm=jbd2/sda2-8 next_pid=1383 next_prio=120
      jbd2/sda2-8-1383  [001]    81.958077: sched_switch:          prev_comm=jbd2/sda2-8 prev_pid=1383 prev_prio=120 prev_state=2 next_comm=kworker/1:0 next_pid=18 next_prio=120
      kworker/1:0-18    [001]    81.958087: sched_switch:          prev_comm=kworker/1:0 prev_pid=18 prev_prio=120 prev_state=1 next_comm=swapper/1 next_pid=0 next_prio=120
+          <idle>-0     [001]    82.001337: sched_overutilized:    overutilized=1
           <idle>-0     [000]    82.192002: sched_wakeup:          comm=usb-storage pid=1343 prio=120 success=1 target_cpu=0
           <idle>-0     [000]    82.192013: sched_switch:          prev_comm=swapper/0 prev_pid=0 prev_prio=120 prev_state=0 next_comm=usb-storage next_pid=1343 next_prio=120
      usb-storage-1343  [000]    82.192053: sched_switch:          prev_comm=usb-storage prev_pid=1343 prev_prio=120 prev_state=1 next_comm=swapper/0 next_pid=0 next_prio=120


### PR DESCRIPTION
The last event's duration will always be set to NaN, because the time
delta is computed as (next_event time - cur_event time). Since the
plotOverutilized() method uses the time deltas to render the
overutilized flag, this can break things: if the last status event
reports overutilized=1, it won't be rendered (see https://github.com/ARM-software/lisa/issues/433).

This fixes that by 'manually' setting the duration of the last event.