### PR TITLE
tests/generic: use 16ms period for all workloads

### DIFF
--- a/tests/eas/generic.py
+++ b/tests/eas/generic.py
@@ -29,7 +29,7 @@ from trace import Trace
 from unittest import SkipTest
 
 
-WORKLOAD_PERIOD_MS =  10
+WORKLOAD_PERIOD_MS =  16
 SET_IS_BIG_LITTLE = True
 SET_INITIAL_TASK_UTIL = True
 
@@ -311,7 +311,7 @@ class OneSmallTask(_EnergyModelTest):
                 'params' : {
                     'duty_cycle_pct': 20,
                     'duration_s': 2,
-                    'period_ms': 10,
+                    'period_ms': WORKLOAD_PERIOD_MS,
                 },
                 'tasks' : 1,
                 'prefix' : 'many',
@@ -337,7 +337,7 @@ class ThreeSmallTasks(_EnergyModelTest):
                 'params' : {
                     'duty_cycle_pct': 20,
                     'duration_s': 2,
-                    'period_ms': 10,
+                    'period_ms': WORKLOAD_PERIOD_MS,
                 },
                 'tasks' : 3,
                 'prefix' : 'many',
@@ -363,7 +363,7 @@ class TwoBigTasks(_EnergyModelTest):
                 'params' : {
                     'duty_cycle_pct': 80,
                     'duration_s': 2,
-                    'period_ms': 10,
+                    'period_ms': WORKLOAD_PERIOD_MS,
                 },
                 'tasks' : 2,
                 'prefix' : 'many',
@@ -429,7 +429,7 @@ class RampUp(_EnergyModelTest):
                     "r5_10-60" : {
                         "kind"   : "Ramp",
                         "params" : {
-                            "period_ms" : 16,
+                            'period_ms': WORKLOAD_PERIOD_MS,
                             "start_pct" :  5,
                             "end_pct"   : 70,
                             "delta_pct" :  5,
@@ -461,7 +461,7 @@ class RampDown(_EnergyModelTest):
                     "r5_10-60" : {
                         "kind"   : "Ramp",
                         "params" : {
-                            "period_ms" : 16,
+                            'period_ms': WORKLOAD_PERIOD_MS,
                             "start_pct" : 70,
                             "end_pct"   :  5,
                             "delta_pct" :  5,
@@ -493,6 +493,7 @@ class EnergyModelWakeMigration(_EnergyModelTest):
                     'wmig' : {
                         'kind' : 'Step',
                         'params' : {
+                            "period_ms" : WORKLOAD_PERIOD_MS,
                             'start_pct': 10,
                             'end_pct': 50,
                             'time_s': 2,


### PR DESCRIPTION
How "big" a periodic task is depends not only from its duty-cycle but
also from the period.
A 20% periodic task, can be considered "small" from the scheduler time
perspective if it's period is around the scheduler latency. However it's
completely different if its period if of 500ms. In this case indeed the
task runs for 100ms at each activation, thus it should better be
considered quite big.

In our synthetics tests, let's fix the period of all the generated
workloads such that how big a task is can be properly defined by just
setting its duty-cycle. We pick 16ms because it's the most interesting
time constant for a standard Android rendering pipeline.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>