### PR TITLE
env: Add cpufreq to default modules

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -407,7 +407,7 @@ class TestEnv(ShareState):
         # Setup board default if not specified by configuration
         self.nrg_model = None
         platform = None
-        self.__modules = []
+        self.__modules = ['cpufreq']
         if 'board' not in self.conf:
             self.conf['board'] = 'UNKNOWN'
 
@@ -450,7 +450,8 @@ class TestEnv(ShareState):
                     core_clusters = self._get_clusters(core_names),
                     big_core=board.get('big_core', None)
                 )
-                self.__modules=board.get('modules', [])
+                if 'modules' in board:
+                    self.__modules = board['modules']
 
         ########################################################################
         # Modules configuration


### PR DESCRIPTION
We need the cpufreq module to configure rt-app. We don't currently
have an easy way to detect in advance that we need to do this
calibration, so for now just add cpufreq as a default module. This is
already done for all the known boards, this commit just makes it a
default for unkonwn boards too.