### PR TITLE
screen: Give time for screen on

### DIFF
--- a/libs/utils/android/screen.py
+++ b/libs/utils/android/screen.py
@@ -17,6 +17,7 @@
 
 import logging
 from system import System
+from time import sleep
 
 class Screen(object):
     """
@@ -150,6 +151,7 @@ class Screen(object):
     @staticmethod
     def unlock(target):
        Screen.set_screen(target, on=True)
+       sleep(1)
        System.menu(target)
        System.home(target)
 


### PR DESCRIPTION
On some devices I see screen on just takes a tad bit longer, and the MENU
keycode that does the screen unlock is sent too soon. Giving a small delay
seems to fix it for me.

Change-Id: I5f4d258e53e2a6766a3bfb5a92cf073cbcceab59
Signed-off-by: Joel Fernandes <joelaf@google.com>