### PR TITLE
Bug: RTA property delay_s will case kernel segmentation fault #449

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -411,8 +411,7 @@ class RTA(Workload):
 
             if 'delay' in task.keys():
                 if task['delay'] > 0:
-                    task_conf['phases']['p000000'] = {}
-                    task_conf['phases']['p000000']['delay'] = int(task['delay'] * 1e6)
+                    task_conf['delay'] = int(task['delay'] * 1e6)
                     self._log.info(' | start delay: %.6f [s]',
                             task['delay'])
 


### PR DESCRIPTION
BUG: RTA workload property delay_s will cause kernel userspace rt-app segmentation fault.
Configure the correct RTA settings to meet the RT-APP requirement ( up to commit=a9a0c6c )

Signed-off-by: Zhifei Yang <zhifei.yang@arm.com>