### PR TITLE
rta: Disallow invalid composition of delayed tasks

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -606,6 +606,14 @@ class RTATask(object):
         return self._task
 
     def __add__(self, next_phases):
+        if next_phases._task.get('delay', 0):
+            # This won't work, because rt-app's "delay" field is per-task and
+            # not per-phase. We might be able to implement it by adding a
+            # "sleep" event here, but let's not bother unless such a need
+            # arises.
+            raise ValueError("Can't compose rt-app tasks "
+                             "when the second has nonzero 'delay_s'")
+
         self._task['phases'].extend(next_phases._task['phases'])
         return self
 

--- a/tests/lisa/test_wlgen_rtapp.py
+++ b/tests/lisa/test_wlgen_rtapp.py
@@ -216,6 +216,21 @@ class TestRTAComposition(RTABase):
         self.assert_output_file_exists('rt-app-task_ramp-0.log')
         self.assert_can_read_logfile(exp_tasks=['task_ramp'])
 
+    def test_invalid_composition(self):
+        """Test that you can't compose tasks with a delay in the second task"""
+        t1 = Periodic()
+        t2 = Periodic(delay_s=1)
+
+        # Should work fine if delayed task is the first one
+        try:
+            t3 = t2 + t1
+        except Exception as e:
+            raise AssertionError("Couldn't compose tasks: {}".format(e))
+
+        # But not the other way around
+        with self.assertRaises(ValueError):
+            t3 = t1 + t2
+
 
 class TestRTACustom(RTABase):
     def _test_custom_smoke(self, calibration):


### PR DESCRIPTION
This example:

    wl = RTA(te.target, 'mywl', calibration=calib)
    wl.conf('profile',
            params = {'t': Periodic(delay_s=3, duration_s=1) +
                    Periodic(delay_s=2, duration_s=1)).get()})

Should semantically result in

1. 3s delay
2. 1s of periodic behaviour
3. 2s delay
4. 1s of periodic behaviour.

But part 3 (the second delay) will be ignored due to the way we use
the "delay" field.

We could probably fix this using a "sleep" event, but to keep things
simple let's just disallow this type of composition, unless we later
find that we need that feature.