### PR TITLE
Bug: Fails to install tool file path without ABI prefix #445

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -639,7 +639,7 @@ class TestEnv(ShareState):
             if not os.path.isfile(binary):
                 binary = '{}/tools/{}/{}'\
                          .format(basepath, self.target.abi, tool)
-                tools_to_install.append(binary)
+            tools_to_install.append(binary)
 
         for tool_to_install in tools_to_install:
             self.target.install(tool_to_install)


### PR DESCRIPTION
Bug: Fails to install tool file path without ABI prefix
Solution: Append the tool file path with ABI prefix to tools_to_install list.

Signed-off-by: Zhifei Yang <zhifei.yang@arm.com>