### PR TITLE
Change the log output sequence to avoid confusion. 

### DIFF
--- a/libs/utils/energy.py
+++ b/libs/utils/energy.py
@@ -460,8 +460,6 @@ class ACME(EnergyMeter):
             self._iio[ch_id].wait()
             self._iio[ch_id] = None
 
-            self._log.debug('Completed IIOCapture for %s...',
-                            self._str(channel))
 
             # iio-capture return "energy=value", add a simple format check
             if '=' not in out:
@@ -469,6 +467,10 @@ class ACME(EnergyMeter):
                                 self._str(channel))
                 self._log.error('[%s]', out)
                 continue
+	    else:
+		self._log.debug('Completed IIOCapture for %s...',
+		                self._str(channel))
+	        self._log.debug('Normal iio-capture case [%s]', out)
 
             # Build energy counter object
             nrg = {}


### PR DESCRIPTION
Change the log output sequence to avoid confusion.
Only prompt measurement complete log in valid cases.

Signed-off-by: Zhifei Yang <zhifei.yang@arm.com>