### PR TITLE
ipynb/examples/android/workloads: Fix Gmaps notebook

### DIFF
--- a/ipynb/examples/android/workloads/Android_Gmaps.ipynb
+++ b/ipynb/examples/android/workloads/Android_Gmaps.ipynb
@@ -385,9 +385,9 @@
    ],
    "source": [
     "# Find exact task name & PID\n",
-    "for name in trace.tasks.keys():\n",
+    "for pid, name in trace.getTasks().iteritems():\n",
     "    if \"GLRunner\" in name:\n",
-    "        glrunner = {\"pid\" : trace.getTaskByName(name)[0], \"name\" : name}\n",
+    "        glrunner = {\"pid\" : pid, \"name\" : name}\n",
     "        \n",
     "        \n",
     "print(\"name=\\\"\" + glrunner[\"name\"] + \"\\\"\" + \" pid=\" + str(glrunner[\"pid\"]))"


### PR DESCRIPTION
Some of Trappy's API has been changed, so this brings the notebook
in line with these changes.