### PR TITLE
subodules: Update devlib to latest master

### DIFF
--- a/libs/utils/energy_model.py
+++ b/libs/utils/energy_model.py
@@ -861,7 +861,7 @@ class EnergyModel(object):
         remaining_cpus = set(cpus)
         while remaining_cpus:
             cpu = next(iter(remaining_cpus))
-            dom = target.cpufreq.get_domain_cpus(cpu)
+            dom = target.cpufreq.get_related_cpus(cpu)
             freq_domains.append(dom)
             remaining_cpus = remaining_cpus.difference(dom)
 

--- a/tests/eas/preliminary.py
+++ b/tests/eas/preliminary.py
@@ -204,7 +204,7 @@ class TestSchedutilTunables(BasicCheckTest):
 
         while cpus:
             cpu = iter(cpus).next()
-            domain = tuple(self.target.cpufreq.get_domain_cpus(cpu))
+            domain = tuple(self.target.cpufreq.get_related_cpus(cpu))
 
             tunables = self.target.cpufreq.get_governor_tunables(cpu)
             for name, value in tunables.iteritems():


### PR DESCRIPTION
The cpufreq.get_domain_cpus method has been renamed to
get_related_cpus. Update to master to bring in that change and update
LISA's usage of the renamed function.