### PR TITLE
env: Add cpuidle to default modules

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -407,7 +407,7 @@ class TestEnv(ShareState):
         # Setup board default if not specified by configuration
         self.nrg_model = None
         platform = None
-        self.__modules = ['cpufreq']
+        self.__modules = ['cpufreq', 'cpuidle']
         if 'board' not in self.conf:
             self.conf['board'] = 'UNKNOWN'
 


### PR DESCRIPTION
We need this for reading the EnergyModel from the target. Ideally we
would just enable that module when we need to read the EnergyModel
but we can't do that at the moment, so just enable it by default