### PR TITLE
add two tasks to skip-freeze list for linux

### DIFF
--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -176,7 +176,7 @@ class Executor():
     """
 
     critical_tasks = {
-        'linux': ['init', 'systemd', 'sh', 'ssh'],
+        'linux': ['init', 'systemd', 'sh', 'ssh', 'rsyslogd', 'jbd2'],
         'android': [
             'sh', 'adbd',
             'usb', 'transport',


### PR DESCRIPTION
Freezing these tasks is causing the kevin chromebook to reboot.