### PR TITLE
trace: Fix plotting when no data dir specified

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -115,7 +115,7 @@ class Trace(object):
 
         # Folder containing trace
         if not os.path.isdir(data_dir):
-            self.data_dir = os.path.dirname(data_dir)
+            self.data_dir = os.path.dirname(data_dir) or '.'
         else:
             self.data_dir = data_dir
 


### PR DESCRIPTION
If the `data_dir` argument is a singe path element (e.g. just 'trace.dat') then
os.path.dirname(data_dir) is ''. When we later attempt to save a plot to a
subdirectory we end up adding '/<filename>.png' to this empty string, which
means we attempt to save a file to the root directory and get a permissions
error.

Fix this by just explicitly preventing self.data_dir from being empty.