### PR TITLE
Convenience names for platform data

### DIFF
--- a/libs/utils/platforms/__init__.py
+++ b/libs/utils/platforms/__init__.py
@@ -1,0 +1,12 @@
+import json
+import os
+from conf import JsonConf
+
+# Add identifiers for each of the platforms we have JSON descriptors for
+this_dir = os.path.dirname(__file__)
+for file_name in os.listdir(this_dir):
+    name, ext = os.path.splitext(file_name)
+    if ext == '.json':
+        platform = JsonConf(os.path.join(this_dir, file_name)).load()
+        identifier = name.replace('-', '_')
+        globals()[identifier] = platform

--- a/libs/utils/platforms/juno.json
+++ b/libs/utils/platforms/juno.json
@@ -1,5 +1,16 @@
 {
-    // JUNO Energy Model
+    "abi": "arm64",
+    "clusters": {
+        "big": [1, 2],
+        "little": [0, 3, 4, 5]},
+    "cpus_count": 6,
+    "freqs": {
+        "big": [450000, 625000, 800000, 950000, 1100000],
+        "little": [450000, 575000, 700000, 775000, 850000]
+    },
+    "topology": [
+        [0, 3, 4, 5], [1, 2]
+    ],
     "nrg_model" : {
         "little" : {
             "cpu" : {


### PR DESCRIPTION
This lets you parse traces, using platform data, without having to connect to a target.

```
from trace import Trace
from libs.utils.platforms import juno # I don't have a juno board here, but I know my trace was collected from one

trace = Trace(juno, 'trace.dat', ['sched_switch'])
```