### PR TITLE
Add estimation of energy from trace

### DIFF
--- a/libs/utils/energy_model.py
+++ b/libs/utils/energy_model.py
@@ -566,7 +566,6 @@ class EnergyModel(object):
             # For now we assume topology nodes with energy models do not overlap
             # with frequency domains
             freq = freqs[cpus[0]]
-            assert all(freqs[c] == freq for c in cpus[1:])
 
             # The active time of a node is estimated as the max of the active
             # times of its children.


### PR DESCRIPTION
This allows using the data in the EAS energy model to estimate the
power usage of the system at any given moment. The hope is that this
can be used as a weak proxy for power performance on systems where
measuring real power consumption is not possible.

CC: @joelaf

---

This is another PR that looks huge but it's pretty much all docstrings, comments, and test..

I had some performance issues, and rather than doing any 'real' optimisation I just memoized away the slow code. That got me to 20s for a 78Mb trace on my slow laptop (2nd gen i5), so let's see if that's fast enough. If not I can optimise it. Unfortunately there isn't really a single critical component that's slowing it down (I've profiled it), the whole module is just full of slow code.