### PR TITLE
trace: Drop NaNs from CPU active signal in getClusterActiveSignal

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -847,6 +847,10 @@ class Trace(object):
             )
 
         active.fillna(method='ffill', inplace=True)
+        # There might be NaNs in the signal where we got data from some CPUs
+        # before others. That will break the .astype(int) below, so drop rows
+        # with NaN in them.
+        active.dropna(inplace=True)
 
         # Cluster active is the OR between the actives on each CPU
         # belonging to that specific cluster


### PR DESCRIPTION
Some CPUs' active signals may begin earlier than others. In that
case, despite the fillna, we may still have NaNs, which break the
reduce() call. Therefore just drop rows with NaNs.