### PR TITLE
frequency_analysis: Fix calculating avg_freq

### DIFF
--- a/libs/utils/analysis/frequency_analysis.py
+++ b/libs/utils/analysis/frequency_analysis.py
@@ -263,7 +263,7 @@ class FrequencyAnalysis(AnalysisModule):
             avg_freq = 0
             if len(_df) > 1:
                 timespan = _df.index[-1] - _df.index[0]
-                avg_freq = area_under_curve(_df['frequency']) / timespan
+                avg_freq = area_under_curve(_df['frequency'], method='rect') / timespan
 
             # Store DF for plotting
             freq[cpu_id] = {


### PR DESCRIPTION
By default, area_under_curve uses method='trapz' which implicitly
does a linear interpolation of the data. This is not desirable for
cpu_frequency, which changes ~instantly and stays constant until the
next data point.