### PR TITLE
Analysis/latency: Add task CPU residency utilities

### DIFF
--- a/libs/utils/analysis/latency_analysis.py
+++ b/libs/utils/analysis/latency_analysis.py
@@ -23,6 +23,7 @@ import numpy as np
 import pandas as pd
 import pylab as pl
 import re
+import os
 
 from collections import namedtuple
 from analysis_module import AnalysisModule
@@ -783,6 +784,28 @@ class LatencyAnalysis(AnalysisModule):
         return stats_df.append(pd.DataFrame(
             stats.values(), columns=['running_time'], index=stats.keys()))
 
+    def plotTaskResidency(self, task):
+        """
+        Plot CPU residency of the specified task
+        This will show an overview of how much time that task spent being
+        active on each available CPU, in seconds.
+
+        :param task: the task to report runtimes for
+        :type task: int or str
+        """
+        df = self._dfg_task_residency(task)
+
+        ax = df.plot(kind='bar', figsize=(16, 6))
+        ax.set_title('CPU residency of task {}'.format(task))
+
+        figname = os.path.join(
+            self._trace.plots_dir,
+            '{}task_cpu_residency_{}.png'.format(
+                self._trace.plots_prefix, task
+            )
+        )
+
+        pl.savefig(figname, bbox_inches='tight')
 
 ###############################################################################
 # Utility Methods

--- a/libs/utils/analysis/latency_analysis.py
+++ b/libs/utils/analysis/latency_analysis.py
@@ -146,6 +146,14 @@ class LatencyAnalysis(AnalysisModule):
             - task_latency_df['t_start']
         )
 
+        # Fix the last entry, which will have a NaN state duration
+        # Set duration to trace_end - last_event
+        task_latency_df.loc[task_latency_df.index[-1], 't_delta'] = (
+            self._trace.start_time +
+            self._trace.time_range -
+            task_latency_df.index[-1]
+        )
+
         return task_latency_df
 
 


### PR DESCRIPTION
This can be useful to look at the behaviour of a task (or from another point of view, the behaviour of the scheduler regarding this task) and to have an overview of how much time a task has spent on each CPU.

I'm not entirely too sure about with task states should be considered in the runtime sum - from my understanding, anything but sleeping should be accounted, but I could be wrong on that.