### PR TITLE
trace: Fix plotting when normalize_time=False

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -314,7 +314,7 @@ class Trace(object):
         self._log.debug('Collected events spans a %.3f [s] time interval',
                        self.time_range)
 
-        self.setXTimeRange(self.window[0], self.window[1])
+        self.setXTimeRange(max(self.start_time, self.window[0]), self.window[1])
 
     def _scanTasks(self, df, name_key='comm', pid_key='pid'):
         """


### PR DESCRIPTION
This fixes an oversight of 3dead2f2b36c589aae2d2f56a573bcac0bc3b8bc:
since we now use absolute windows with normalize_time=False, we must use start_time along with the given window to determine the x time range.