### PR TITLE
tests/eas/generic: Lower ramp tests duration

### DIFF
--- a/tests/eas/generic.py
+++ b/tests/eas/generic.py
@@ -442,7 +442,7 @@ class RampUp(_EnergyModelTest):
                             "start_pct" :  5,
                             "end_pct"   : 70,
                             "delta_pct" :  5,
-                            "time_s"    :  2,
+                            "time_s"    : .5,
                          },
                     },
                 },
@@ -461,7 +461,6 @@ class RampDown(_EnergyModelTest):
     """
     Test EAS for a task ramping from 70% down to 5% over 2 seconds
     """
-
     # The main purpose of this test is to ensure that as it reduces in load, a
     # task is migrated from big to LITTLE CPUs on a big.LITTLE system.
     # This migration naturally happens some time _after_ it could possibly be
@@ -482,7 +481,7 @@ class RampDown(_EnergyModelTest):
                             "start_pct" : 70,
                             "end_pct"   :  5,
                             "delta_pct" :  5,
-                            "time_s"    :  2,
+                            "time_s"    : .5,
                          },
                     },
                 },


### PR DESCRIPTION
Each test in generic.py has a time duration set to 2s. However,
the "time_s" entry for rt-app ramps is the duration of each step,
and not the duration of the whole ramp. As such, each ramp test
lasts 26 seconds instead of 2.

This commit sets the whole duration of each ramp test to 2s.