### PR TITLE
test_series: fix --reboot_timeout parameter

### DIFF
--- a/tools/wltests/test_series
+++ b/tools/wltests/test_series
@@ -264,6 +264,10 @@ while [[ $# -gt 0 ]]; do
 		RESULTS=$2
 		shift
 	;;
+	--reboot_timeout)
+		REBOOT_TIMEOUT=$2
+		shift
+	;;
 	--force)
 		FORCE=1
 	;;


### PR DESCRIPTION
In the current implementation, the --reboot_timeout parameter is
documented for lisa-wltest-series but cannot be used. This is fixed by
this PR.