### PR TITLE
wltest: add support for Android 4.4 on Hikey 620

### DIFF
--- a/tools/wltests/platforms/hikey620_android-4.4/build_images
+++ b/tools/wltests/platforms/hikey620_android-4.4/build_images
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname $(realpath -s $0))
+BASE_DIR="$SCRIPT_DIR/../.."
+source "${BASE_DIR}/helpers"
+source "${PLATFORM_PATH}/definitions"
+
+################################################################################
+# Build all images required to test a new kernel
+################################################################################
+
+#./build --image --dtbs --silent; ERROR=$?
+./build --image --silent; ERROR=$?
+[ $ERROR -eq 0 ] || exit $ERROR
+
+./android/create_boot_img.sh; ERROR=$?
+[ $ERROR -eq 0 ] || exit $ERROR
+

--- a/tools/wltests/platforms/hikey620_android-4.4/definitions
+++ b/tools/wltests/platforms/hikey620_android-4.4/definitions
@@ -1,0 +1,38 @@
+
+################################################################################
+# Build definitions for Hikey620
+################################################################################
+
+PLATFORM_NAME="Hikey620_Android"
+
+################################################################################
+# Boot Image Configuration
+################################################################################
+
+KERNEL_IMAGE="${KERNEL_IMAGE:-Image-dtb}"
+KERNEL_CMDLINE="${KERNEL_CMDLINE:-\
+ console=ttyFIQ0\
+ androidboot.console=ttyFIQ0\
+ androidboot.hardware=hikey\
+ firmware_class.path=/system/etc/firmware\
+ efi=noruntime\
+ buildvariant=userdebug\
+}"
+
+RAMDISK_IMAGE="${RAMDISK_IMAGE:-ramdisk.gz}"
+ANDROID_BOOT_IMAGE="${ANDROID_BOOT_IMAGE:-boot.img}"
+ANDROID_IMAGE_BASE="${ANDROID_IMAGE_BASE:-0x0}"
+ANDROID_IMAGE_PAGESIZE="${ANDROID_IMAGE_PAGESIZE:-2048}"
+ANDROID_TAGS_OFFSET="${ANDROID_TAGS_OFFSET:-0x10000100}"
+ANDROID_KERNEL_OFFSET="${ANDROID_KERNEL_OFFSET:-0x10008000}"
+ANDROID_RAMDISK_OFFSET="${ANDROID_RAMDISK_OFFSET:-0x11000000}"
+
+################################################################################
+# Toolchain Configuration
+################################################################################
+
+DEFCONFIG="${DEFCONFIG:-hikey_defconfig}"
+CONFIG_CMD="${CONFIG_CMD:-}"
+ARCH="${ARCH:-arm64}"
+CROSS_COMPILE="${CROSS_COMPILE:-aarch64-linux-android-}"
+

--- a/tools/wltests/platforms/hikey620_android-4.4/flash_images
+++ b/tools/wltests/platforms/hikey620_android-4.4/flash_images
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname $(realpath -s $0))
+BASE_DIR="$SCRIPT_DIR/../.."
+source "${BASE_DIR}/helpers"
+source "${PLATFORM_PATH}/definitions"
+
+################################################################################
+# Build all images required to test a new kernel
+################################################################################
+
+ls *.img >/dev/null; ERROR=$?
+if [ $ERROR -ne 0 ]; then
+	c_error "No images to flash in $PWD"
+	exit $ENOENT
+fi
+
+for IMAGE in $(ls *.img); do
+	PARTITION=${IMAGE%%.img}
+	echo
+	c_info "Flashing [$IMAGE] on [$PARTITION] partition..."
+	$FASTBOOT flash $PARTITION $IMAGE; ERROR=$?
+	[ $ERROR -eq 0 ] || exit $ERROR
+done
+

--- a/tools/wltests/test_series
+++ b/tools/wltests/test_series
@@ -735,7 +735,7 @@ flash_sha1() {
 
 	### Wait for boot to complete
 	[ $DRYRUN -eq 1 ] || \
-	until boot_not_completed || reboot_not_timedout; do
+	until boot_completed || reboot_timedout; do
 		sleep 3; let ELAPSED+=3
 	done
 	echo


### PR DESCRIPTION
Tested using Jankbench with the bootloader provided with the following AOSP factory image: [https://developers.google.com/android/images-preview#hikey](https://developers.google.com/android/images-preview#hikey)
More recent bootloaders require a UEFI-specific boot.img and won't be compatible with this implementation.

Instructions to set-up the board:
 [https://github.com/96boards/documentation/blob/master/ConsumerEdition/HiKey/Installation/LinuxFactoryImage.md](https://github.com/96boards/documentation/blob/master/ConsumerEdition/HiKey/Installation/LinuxFactoryImage.md)

Userspace image (and ramdisk) from the latest linaro AOSP build supporting the 4GB EMMC Hikey620:
[http://builds.96boards.org/snapshots/hikey/linaro/aosp-master/509/](http://builds.96boards.org/snapshots/hikey/linaro/aosp-master/509/)

I wonder where these details should be documented. A README in each platform folder maybe ?