### PR TITLE
utils/wa_results_collector: Fix typo for log

### DIFF
--- a/libs/utils/wa_results_collector.py
+++ b/libs/utils/wa_results_collector.py
@@ -172,7 +172,7 @@ class WaResultsCollector(object):
 
             # WA3 results dirs contains a __meta directory at the top level.
             if '__meta' not in os.listdir(dir):
-                self.log.warning('Ignoring {}, does not contain __meta directory')
+                self._log.warning('Ignoring {}, does not contain __meta directory')
                 continue
 
             dirs.append(dir)


### PR DESCRIPTION
When run wa_results_collector class, it report the error for log:
AttributeError: 'WaResultsCollector' object has no attribute 'log'

This is caused by the typo "self.log.warning", so fix typo to
"self._log.warning".

Signed-off-by: Leo Yan <leo.yan@linaro.org>