### PR TITLE
latency_analysis: Fix task name

### DIFF
--- a/libs/utils/analysis/latency_analysis.py
+++ b/libs/utils/analysis/latency_analysis.py
@@ -775,7 +775,7 @@ class LatencyAnalysis(AnalysisModule):
         else:
             raise ValueError("Task must be either an int or str")
 
-        task_label = "{}: {}".format(task_pid, ', '.join(task_names))
+        task_label = "{}: {}".format(task_pid, task_names)
         return TaskData(task_pid, task_names, task_label)
 
     @memoized


### PR DESCRIPTION
Trace::getTaskByPid() returns task name with 'str' type, if use join()
to apply for the string, it inserts comma between every chars and the
task name is not readable.

So fix this by directly using name string from Trace::getTaskByPid().

Signed-off-by: Leo Yan <leo.yan@linaro.org>