### PR TITLE
ipynb/wltests: sort energy plot by average instead of 99% percentile

### DIFF
--- a/ipynb/wltests/sched-evaluation-full.ipynb
+++ b/ipynb/wltests/sched-evaluation-full.ipynb
@@ -130,7 +130,7 @@
     "for test in collector.tests(workload='jankbench'):\n",
     "    logging.info(\"Results for: %s\", test)\n",
     "    collector.report(workload='jankbench', metric='device_total_energy',\n",
-    "                     test=\"^{}$\".format(test), sort_on='99%', ascending=True)"
+    "                     test=\"^{}$\".format(test), sort_on='mean', ascending=True)"
    ]
   },
   {
@@ -196,7 +196,7 @@
     "for test in collector.tests(workload='exoplayer'):\n",
     "    logging.info(\"Results for: %s\", test)\n",
     "    collector.report(workload='exoplayer', metric='device_total_energy',\n",
-    "                     test=test, sort_on='99%', ascending=True)"
+    "                     test=test, sort_on='mean', ascending=True)"
    ]
   },
   {
@@ -215,7 +215,7 @@
     "for test in collector.tests(workload='homescreen'):\n",
     "    logging.info(\"Results for: %s\", test)\n",
     "    collector.report(workload='homescreen', metric='device_total_energy',\n",
-    "                     test=test, sort_on='99%', ascending=True)"
+    "                     test=test, sort_on='mean', ascending=True)"
    ]
   },
   {


### PR DESCRIPTION
The energy plots should enable users to quickly see whether their new
feature under test saved energy or not. Although defining "saving
energy" can be tricky, looking at the average value is often a sensible
option to do that, so let's use it by default.