### PR TITLE
wltest: fix trace-cmd parameters

### DIFF
--- a/tools/wa_user_directory/config.yaml
+++ b/tools/wa_user_directory/config.yaml
@@ -1,7 +1,7 @@
 # Skeleton global config.yaml for WA3
 device: generic_android
 
-trace_cmd:
+trace-cmd:
   buffer_size: 102400
   report: false
 


### PR DESCRIPTION
The correct section name to configure trace-cmd should
have a "-" instead of a "_" so let's fix that.