### PR TITLE
config.yaml: add csv and status as default result processors

### DIFF
--- a/tools/wa_user_directory/config.yaml
+++ b/tools/wa_user_directory/config.yaml
@@ -11,3 +11,6 @@ max_retries: 0
 # If any of the workloads fail during the initialization phase, don't bail out
 # on the rest of the run
 bail_on_init_failure: false
+
+# Default result processors
+result_processors: ['csv', 'status']


### PR DESCRIPTION
These might or might not be set as default by workload-automation.
Make sure they're selected by making them default in the LISA
config.

Signed-off-by: Ionela Voinescu <ionela.voinescu@arm.com>