### PR TITLE
utils/analysis_module: Initialize _big/little_cpus even w/o nrg_model

### DIFF
--- a/libs/utils/analysis_module.py
+++ b/libs/utils/analysis_module.py
@@ -53,6 +53,10 @@ class AnalysisModule(object):
 
         if self._trace.has_big_little:
             self._little_cap = self._platform['nrg_model']['little']['cpu']['cap_max']
+
+        if ('clusters' in self._platform and
+            'big' in self._platform['clusters'] and
+            'little' in self._platform['clusters']):
             self._big_cpus = self._platform['clusters']['big']
             self._little_cpus = self._platform['clusters']['little']
 


### PR DESCRIPTION
This makes stuff like plotClusterFrequencies work even if no nrg_model
is available, all that is required here is a list of big and small cpus.

Signed-off-by: Leonard Crestez <leonard.crestez@nxp.com>