### PR TITLE
test_series: fix checkout with ambiguous sha1

### DIFF
--- a/tools/wltests/test_series
+++ b/tools/wltests/test_series
@@ -616,7 +616,7 @@ reboot_fastboot() {
 ################################################################################
 
 name_sha1() {
-	COMMIT_SHA1=${1:0:7}
+	COMMIT_SHA1=${1%% *}
 	MINLEN=12345
 
 	# In case the specified SHA1 has not a name, let's use the SHA1


### PR DESCRIPTION
The current implementation of test_series checks out a kernel based on
the first 7 characters of its sha1. However, this truncation creates an
ambiguity whenever 7 characters aren't enough to identify a unique kernel.
In this case, an error is raised.

This commit fixes this behaviour by removing the hardcoded truncature
and cutting the sha1 to be checked out up to the first space found in
the series file.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>