### PR TITLE
utils/executor: Don't freeze 'dbus' on Linux targets

### DIFF
--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -176,7 +176,15 @@ class Executor():
     """
 
     critical_tasks = {
-        'linux': ['init', 'systemd', 'sh', 'ssh', 'rsyslogd', 'jbd2'],
+        'linux': [
+            'init',
+            'systemd',
+            'dbus',
+            'sh',
+            'ssh',
+            'rsyslogd',
+            'jbd2'
+        ],
         'android': [
             'sh', 'adbd',
             'usb', 'transport',


### PR DESCRIPTION
Freezing this process wouldn't cause any critical crash, but it would
make the tests last much longer than needed (e.g. 1 minute for a
5 seconds rt-app task).