### PR TITLE
skip null size power file

### DIFF
--- a/libs/utils/wa_results_collector.py
+++ b/libs/utils/wa_results_collector.py
@@ -448,6 +448,10 @@ class WaResultsCollector(object):
         # TODO: once WA's reporting of this data has been cleaned up a bit I
         # think we can simplify this.
         for artifact_name, path in artifacts.iteritems():
+            if os.stat(path).st_size == 0:
+                self._log.info(" no data for %s",  path)
+                continue
+
             if artifact_name.startswith('energy_instrument_output'):
                 df = pd.read_csv(path)
 


### PR DESCRIPTION
Sometimes, the power measurement file is null. Just skip it in this case
because panda doesn't correctly handle that case