### PR TITLE
wltests: Fix flashing for hikeys 960/620

### DIFF
--- a/tools/wltests/platforms/hikey620_android-4.4/flash_images
+++ b/tools/wltests/platforms/hikey620_android-4.4/flash_images
@@ -5,7 +5,7 @@ BASE_DIR="$SCRIPT_DIR/../.."
 source "${BASE_DIR}/helpers"
 source "${PLATFORM_PATH}/definitions"
 
-MODE=${$1:-FASTBOOT}
+MODE=${1:-FASTBOOT}
 [ $MODE == FASTBOOT ] || exit $OK
 
 ################################################################################
@@ -25,4 +25,3 @@ for IMAGE in $(ls *.img); do
 	$FASTBOOT flash $PARTITION $IMAGE; ERROR=$?
 	[ $ERROR -eq 0 ] || exit $ERROR
 done
-

--- a/tools/wltests/platforms/hikey960_android-4.4/flash_images
+++ b/tools/wltests/platforms/hikey960_android-4.4/flash_images
@@ -5,7 +5,7 @@ BASE_DIR="$SCRIPT_DIR/../.."
 source "${BASE_DIR}/helpers"
 source "${PLATFORM_PATH}/definitions"
 
-MODE=${$1:-FASTBOOT}
+MODE=${1:-FASTBOOT}
 [ $MODE == FASTBOOT ] || exit $OK
 
 ################################################################################
@@ -25,4 +25,3 @@ for IMAGE in $(ls *.img); do
 	$FASTBOOT flash $PARTITION $IMAGE; ERROR=$?
 	[ $ERROR -eq 0 ] || exit $ERROR
 done
-


### PR DESCRIPTION
A typo was introduced in d32f7592544190beb11bbbaacf5fa67834fc5ff6, which
would prevent the flashing from happening, but the rest of wltest would
still run. As such we'd end up comparing the exact same kernels.