### PR TITLE
wa/config: specify the list of default trace events to collect

### DIFF
--- a/tools/wa_user_directory/config.yaml
+++ b/tools/wa_user_directory/config.yaml
@@ -4,6 +4,28 @@ device: generic_android
 trace-cmd:
   buffer_size: 102400
   report: false
+  events: [
+    "sched_switch",
+    "sched_wakeup",
+    "sched_wakeup_new",
+    "sched_overutilized",
+    "sched_load_avg_cpu",
+    "sched_load_avg_task",
+    "sched_pelt_se",
+    "sched_load_se",
+    "sched_load_cfs_rq",
+    "sched_load_waking_task",
+    "cpu_capacity",
+    "cpu_frequency",
+    "cpu_idle",
+    "sched_tune_config",
+    "sched_tune_tasks_update",
+    "sched_tune_boostgroup_update",
+    "sched_tune_filter",
+    "sched_boost_cpu",
+    "sched_boost_task",
+    "sched_energy_diff"
+  ]
 
 # Disable re-trying things that go wrong
 max_retries: 0


### PR DESCRIPTION
By default, WA's list of events to collect is the following:
        ['sched*', 'irq*', 'power*', 'thermal*']
As a result, the trace files are generally massive. This becomes an
issue when sched-evaluation-full-traced is in use as the result folder
can be > 25GB per kernel, mostly because of the trace files.

To avoid this, let's select by default a list of trace events we care
and drop all the others. This global parameter can be overridden in each
agenda if needed by setting 'trace_events' in the global section.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>