### PR TITLE
Add peripheral clock name info to the platform descriptor.

### DIFF
--- a/libs/utils/analysis/frequency_analysis.py
+++ b/libs/utils/analysis/frequency_analysis.py
@@ -163,7 +163,7 @@ class FrequencyAnalysis(AnalysisModule):
 # Plotting Methods
 ###############################################################################
 
-    def plotPeripheralClock(self, title='Peripheral Frequency', clk='unknown'):
+    def plotPeripheralClock(self, clk, title='Peripheral Frequency'):
         """
         Produce graph plotting the frequency of a particular peripheral clock
 
@@ -190,11 +190,11 @@ class FrequencyAnalysis(AnalysisModule):
         pd.set_option('display.expand_frame_repr', False)
 
         if not enable_df.empty:
-          enable_df = enable_df[enable_df.clk_name == clk]
-          enable_df['clock_setting'] = 1;
+            enable_df = enable_df[enable_df.clk_name == clk]
+            enable_df['clock_setting'] = 1;
         if not disable_df.empty:
-          disable_df = disable_df[disable_df.clk_name == clk]
-          disable_df['clock_setting'] = 0;
+            disable_df = disable_df[disable_df.clk_name == clk]
+            disable_df['clock_setting'] = 0;
 
         freq = pd.concat([rate_df, enable_df, disable_df])
         freq.sort_index(inplace=True)
@@ -230,12 +230,12 @@ class FrequencyAnalysis(AnalysisModule):
                 freq.loc[index, 'frequency'] = 0
                 last_state = row.state
 
-        gs = gridspec.GridSpec(5,1)
-        freq_axis = plt.subplot(gs[:4, 0])
-        state_axis = plt.subplot(gs[4:, 0])
-        plt.suptitle(title, y=.97, fontsize=16, horizontalalignment='center')
 
-        gs.update(hspace=1.7)
+        fig = plt.figure(figsize=(16,8))
+        gs = gridspec.GridSpec(2, 1, height_ratios=[8, 1])
+        freq_axis = plt.subplot(gs[0])
+        state_axis = plt.subplot(gs[1])
+        plt.suptitle(title, y=.97, fontsize=16, horizontalalignment='center')
 
         #plot frequency information
         freq_axis.set_title("Clock frequency for " + clk)

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -761,6 +761,18 @@ class TestEnv(ShareState):
             return None
         return board.json['nrg_model']
 
+    def _load_peripherals(self, board):
+        peripherals_path = os.path.join(basepath,
+                'libs/utils/platforms', board.lower() + '.json')
+        self._log.debug('Trying to load peripheral config from %s', peripherals_path)
+        if not os.path.exists(peripherals_path):
+            return None
+        board = JsonConf(peripherals_path)
+        board.load()
+        if 'peripherals' not in board.json:
+            return None
+        return board.json['peripherals']
+
     def _load_board(self, board):
         board_path = os.path.join(basepath,
                 'libs/utils/platforms', board.lower() + '.json')
@@ -815,6 +827,13 @@ class TestEnv(ShareState):
         }
         self.platform['abi'] = self.target.abi
         self.platform['os'] = self.target.os
+
+        if 'peripherals' in self.conf:
+            self.platform['peripherals'] = self.conf['peripherals']
+        else:
+            peripheral_conf = self._load_peripherals(self.conf['board'])
+            if peripheral_conf is not None:
+                self.platform['peripherals'] = peripheral_conf
 
         self._log.debug('Platform descriptor initialized\n%s', self.platform)
         # self.platform_dump('./')

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -761,7 +761,7 @@ class TestEnv(ShareState):
 
     def _load_board(self, board):
         board = self._load_board_file(board)
-        if 'board' not in board.json:
+        if board is not None and 'board' not in board.json:
             return None
         return board.json['board']
 
@@ -788,7 +788,7 @@ class TestEnv(ShareState):
             self.platform['nrg_model'] = self.conf['nrg_model']
         # Try to load the default energy model (if available)
         # We shouldn't have an 'nrg_model' key if there is no energy model data
-        elif 'nrg_model' in board.json:
+        elif board is not None and 'nrg_model' in board.json:
             self.platform['nrg_model'] = board.json['nrg_model']
 
         # Adding topology information
@@ -808,7 +808,7 @@ class TestEnv(ShareState):
 
         if 'peripherals' in self.conf:
             self.platform['peripherals'] = self.conf['peripherals']
-        elif 'peripherals' in board.json:
+        elif board is not None and 'peripherals' in board.json:
             self.platform['peripherals'] = board.json['peripherals']
 
         self._log.debug('Platform descriptor initialized\n%s', self.platform)

--- a/libs/utils/platforms/pixel.json
+++ b/libs/utils/platforms/pixel.json
@@ -25,5 +25,11 @@
                 "nrg_max" :  96
             }
         }
+    },
+    "peripherals": {
+        "bus": "bimc_clk",
+        "display": "mdp_clk_src",
+        "gpu": "gpucc_gfx3d_clk",
+        "video": "video_core_clk_src"
     }
 }


### PR DESCRIPTION
This allows for users to designate clocks-of-interest for their run,
and also allows tools like tools/plot.py to produce charts for
peripheral clock info.

Change-Id: Iafc6515ecebdb17bb3bf519ea924aa294f8f1da2