### PR TITLE
Check for kernel SHA1 to match also signed tags'

### DIFF
--- a/tools/wltests/test_series
+++ b/tools/wltests/test_series
@@ -791,7 +791,15 @@ match_sha1() {
 	CURRENT=$($ADB shell 'uname -r' | awk -F "-g" '{print $NF}')
 	[[ $COMMIT_SHA1 =~ $CURRENT* ]] && return $OK
 
-	return $OK
+	# It may happen that a tag pointing to a given commit has
+	# a different SHA1 (signed tag), so check if this this is
+        # the case.
+	TAG_NAME=$(git -C $KERNEL_SRC describe --exact-match $COMMIT_SHA1 2>/dev/null) || return $EAGAIN
+	TAG_SHA1=$(git -C $KERNEL_SRC show-ref --hash $TAG_NAME)
+	c_info "   CommitID of local repo corresponds to tag: $TAG_NAME"
+	[[ $TAG_SHA1 =~ $CURRENT* ]] && return $OK
+
+	return $EAGAIN
 }
 
 build_sha1() {

--- a/tools/wltests/test_series
+++ b/tools/wltests/test_series
@@ -786,10 +786,10 @@ match_sha1() {
 	COMMIT_SHA1=$1
 
 	c_info "Current kernel: "
-	CURRENT=$($ADB shell 'uname -a')
-	c_info "   $CURRENT"
+	c_info "   $($ADB shell 'uname -a')"
 
-	[[ $CURRENT = *$COMMIT_SHA1* ]] || return $EAGAIN
+	CURRENT=$($ADB shell 'uname -r' | awk -F "-g" '{print $NF}')
+	[[ $COMMIT_SHA1 =~ $CURRENT* ]] && return $OK
 
 	return $OK
 }


### PR DESCRIPTION
Since a signed tag has a SHA1 that differs from the one associated with
the commit to which it is referring, this was causing false negatives
when verifying the correspondence between the current kernel version of
the device and of the local repository.

This patch, when there is no correspondence between the current SHA1 of
the repository and the kernel of the device, verifies if there is a tag
pointing to the same SHA1 and performs the comparison with it.

It also inverts the substirng checking: it checks if the SHA1 of the
kernel is contained in the SHA1 of the repo, since this last should be
longer.
In order to do this, the following steps are followed:
- take the kernel release (uname -a), e.g.
  "4.4.88-g0e6b355-00003-g36e8d7f";
- take the last element, considering '-' as separator, e.g. "g36e8d7f";
- remove the first character, e.g. "36e8d7f";
- check if this SHA1 is contained in the SHA1 of the current repository.