### PR TITLE
rta.py: fix phase cpus assignment

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -426,7 +426,7 @@ class RTA(Workload):
                 self.rta_profile['tasks'][tid]['phases']\
                     ['p'+str(pid).zfill(6)] = task_phase
 
-                if phase.cpus:
+                if phase.cpus is not None:
                     if isinstance(phase.cpus, str):
                         task_phase['cpus'] = ranges_to_list(phase.cpus)
                     elif isinstance(phase.cpus, list):


### PR DESCRIPTION
Fix: The cpus of the phase of a task was never assigned in the
case where the cpu was given as an int and has the value 0.

Signed-off-by: Elieva Pignat <Elieva.Pignat@arm.com>