### PR TITLE
events: target config can specified additional events

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -720,6 +720,10 @@ class TestEnv(ShareState):
         events = FTRACE_EVENTS_DEFAULT
         if 'events' in ftrace:
             events = ftrace['events']
+        if 'debug_events' in self.conf:
+            # Need to convert from unicode object to str
+            dbg_events = [s.encode('utf-8') for s in self.conf['debug_events']]
+            events = list(set(events).union(dbg_events))
 
         functions = None
         if 'functions' in ftrace:


### PR DESCRIPTION
The target config file can specified additionnal events that will be
registered during the tests with the label 'debug_events'.
These events will be added to the list of events needed by the test
and can be used afterward to help debugging if needed.

Signed-off-by: Elieva Pignat <Elieva.Pignat@arm.com>