### PR TITLE
generic.py: fix EnergyModelWakeMigration

### DIFF
--- a/tests/eas/generic.py
+++ b/tests/eas/generic.py
@@ -567,7 +567,7 @@ class RampDown(_EnergyModelTest):
 
 class EnergyModelWakeMigration(_EnergyModelTest):
     """
-    Test EAS for tasks alternating beetween 10% and 50%
+    Test EAS for tasks alternating beetween 10% and 70%
     """
     workloads = {
         'em_wake_migration' : {
@@ -580,7 +580,7 @@ class EnergyModelWakeMigration(_EnergyModelTest):
                         'params' : {
                             "period_ms" : WORKLOAD_PERIOD_MS,
                             'start_pct': 10,
-                            'end_pct': 50,
+                            'end_pct': 70,
                             'time_s': 2,
                             'loops': 2
                         },


### PR DESCRIPTION
Change the task utilization so that the optimal placement agrees with
EAS placement. 50% was high enough for EAS to move the task to a big
CPU, but the optimal placement was expecting a little CPU. With 70%,
they both agree that it should be on a big CPU.