### PR TITLE
CPU Migration test: fix parallelism issue

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -222,8 +222,6 @@ class RTA(Workload):
 
         rtapp_conf = self.params['custom']
 
-        self._log.info('Loading custom configuration:')
-        self._log.info('   %s', rtapp_conf)
         self.json = '{0:s}_{1:02d}.json'.format(self.name, self.exc_id)
         ofile = open(self.json, 'w')
 
@@ -252,6 +250,8 @@ class RTA(Workload):
                                  "a filename or an embedded dictionary")
         else:
             # We assume we are being passed a filename instead of a dict
+            self._log.info('Loading custom configuration:')
+            self._log.info('   %s', rtapp_conf)
             ifile = open(rtapp_conf, 'r')
 
         for line in ifile:


### PR DESCRIPTION
The file that contains the description of the tasks was written before
the test are launched and read back after the tests run to control the
that the result of the test are coherent.
The problem is when the test is run for several platforms in parallel
the file containing the json description may have been overwritten by
another platform test and may not contain the description of the test anymore.

To avoid the problem of sharing this file, the tasks descritpion is saved in
a variable in the test class and the file containing the json is no more read.

Signed-off-by: Elieva Pignat <Elieva.Pignat@arm.com>