### PR TITLE
cgroups migration test: catch error when migrating task

### DIFF
--- a/tests/eas/load_tracking.py
+++ b/tests/eas/load_tracking.py
@@ -1370,9 +1370,12 @@ class CgroupsMigrationTest(_PELTTaskGroupsTest):
         task = cls.root_group.get_child('t1_2')
         new_taskgroup = cls.root_group.get_child('/tg2')
         task.change_taskgroup(new_taskgroup)
-        tg1_task = cgroups.tasks('/tg1', filter_tname='rt-app',
-                                 filter_tcmdline='t1_1')
-        exclude = next(iter(tg1_task))
+        try:
+            [exclude] = cgroups.tasks('/tg1', filter_tname='rt-app',
+                                      filter_tcmdline='t1_1').keys()
+        except ValueError:
+            raise ValueError('The non-migrated task PID has not been found')
+
         cgroups.move_tasks('/tg1', '/tg2', exclude=exclude)
 
     def test_group_util_aggregation(self):
@@ -1472,9 +1475,12 @@ class NestedCgroupsMigrationTest(_PELTTaskGroupsTest):
         task = cls.root_group.get_child('t2_2')
         new_taskgroup = cls.root_group.get_child('/tg1')
         task.change_taskgroup(new_taskgroup)
-        tg2_task = cgroups.tasks('/tg1/tg2', filter_tname='rt-app',
-                                 filter_tcmdline='t2_1')
-        exclude = next(iter(tg2_task))
+        try:
+            [exclude] = cgroups.tasks('/tg1/tg2', filter_tname='rt-app',
+                                      filter_tcmdline='t2_1').keys()
+        except ValueError:
+            raise ValueError('The non-migrated task PID has not been found')
+
         cgroups.move_tasks('/tg1/tg2', '/tg1', exclude=exclude)
 
     def test_group_util_aggregation(self):


### PR DESCRIPTION
The PID of the task that is not migrated need to be found
by looking into the cgroups file and filtering these information.
If something goes wrong it may happen that the task PID is not
found. In this case an error is raised.

Signed-off-by: Elieva Pignat <Elieva.Pignat@arm.com>
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>