### PR TITLE
env.py,executor.py: Turn warning into info

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -893,7 +893,7 @@ class TestEnv(ShareState):
             return
 
         if not force and 'rtapp-calib' in self.conf:
-            self._log.warning('Using configuration provided RTApp calibration')
+            self._log.info('Using configuration provided RTApp calibration')
             self._calib = {
                     int(key): int(value)
                     for key, value in self.conf['rtapp-calib'].items()

--- a/libs/utils/executor.py
+++ b/libs/utils/executor.py
@@ -674,7 +674,7 @@ class Executor():
 
         # FTRACE: start (if a configuration has been provided)
         if self.te.ftrace and self._target_conf_flag(tc, 'ftrace'):
-            self._log.warning('FTrace events collection enabled')
+            self._log.info('FTrace events collection enabled')
             self.te.ftrace.start()
 
         # ENERGY: start sampling


### PR DESCRIPTION
Turn some log warnings in log info as they are just informative messages
and not a source of misbehavior.