### PR TITLE
Fix calibration

### DIFF
--- a/libs/wlgen/wlgen/rta.py
+++ b/libs/wlgen/wlgen/rta.py
@@ -60,6 +60,10 @@ class Phase(object):
         self.cpus = cpus
         self.barrier_after = barrier_after
 
+class RTACalibrationError(Exception):
+    """Exception raised when the calibration fails"""
+    pass
+
 class RTA(Workload):
     """
     Class for creating RT-App workloads
@@ -168,14 +172,16 @@ class RTA(Workload):
                                  for key in pload) + "}")
 
         # Sanity check calibration values for big.LITTLE systems
-        if 'bl' in target.modules:
-            bcpu = target.bl.bigs_online[0]
-            lcpu = target.bl.littles_online[0]
-            if pload[bcpu] > pload[lcpu]:
-                log.warning('Calibration values reports big cores less '
-                            'capable than LITTLE cores')
-                raise RuntimeError('Calibration failed: try again or file a bug')
-            bigs_speedup = ((float(pload[lcpu]) / pload[bcpu]) - 1) * 100
+        if target.big_core:
+            bcpu = [i for i, t in enumerate(target.core_names) if t == target.big_core]
+            lcpu = [i for i, t in enumerate(target.core_names) if t == target.little_core]
+            for l in lcpu:
+                for b in bcpu:
+                    if pload[b] > pload[l]:
+                        raise RTACalibrationError(
+                            'Calibration values reports big cores less capable than LITTLE cores')
+
+            bigs_speedup = ((float(pload[lcpu[0]]) / pload[bcpu[0]]) - 1) * 100
             log.info('big cores are ~%.0f%% more capable than LITTLE cores',
                      bigs_speedup)
 

--- a/tests/lisa/test_wlgen_rtapp.py
+++ b/tests/lisa/test_wlgen_rtapp.py
@@ -73,8 +73,7 @@ class TestRTAProfile(RTABase):
             run_dir=self.target_run_dir
         )
 
-        with open(rtapp.json) as f:
-            conf = json.load(f, object_pairs_hook=OrderedDict)
+        conf = rtapp.rta_profile
 
         # Check that the configuration looks like we expect it to
         phases = conf['tasks']['my_task']['phases'].values()
@@ -270,8 +269,7 @@ class TestRTACustom(RTABase):
         rtapp.conf(kind='custom', params=json_path, duration=5,
                    run_dir=self.target_run_dir)
 
-        with open(rtapp.json) as f:
-            conf = json.load(f)
+        conf = rtapp.rta_profile
 
         # Convert k to str because the json loader gives us unicode strings
         tasks = set([str(k) for k in conf['tasks'].keys()])
@@ -315,8 +313,7 @@ class TestRTACalibrationConf(RTABase):
             run_dir=self.target_run_dir
         )
 
-        with open(rtapp.json) as f:
-            return json.load(f)['global']['calibration']
+        return rtapp.rta_profile['global']['calibration']
 
     def test_calibration_conf_pload(self):
         """Test that the smallest pload value is used, if provided"""


### PR DESCRIPTION
RTA calibration process is relying on pushing an rt-app configuration file to the target. Since that file used to always have the same name, it created a race condition if more than one LISA instance was running on the same LISA source tree.

Fix that by using a proper temporary file instead of relying on a deterministically-created one.

Thanks to @Elieva for discovering that and creating the first draft of this PR.