### PR TITLE
Rework results directory

### DIFF
--- a/ipynb/energy/EnergyModel_ClusterEnergy.ipynb
+++ b/ipynb/energy/EnergyModel_ClusterEnergy.ipynb
@@ -178,7 +178,7 @@
    "source": [
     "# Initialize a test environment using:\n",
     "# the provided target configuration (my_conf)\n",
-    "te = TestEnv(target_conf=my_conf, force_new=True)\n",
+    "te = TestEnv(target_conf=my_conf)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/energy/EnergyModel_SystemEnergy.ipynb
+++ b/ipynb/energy/EnergyModel_SystemEnergy.ipynb
@@ -207,7 +207,7 @@
    "source": [
     "# Initialize a test environment using:\n",
     "# the provided target configuration (my_conf)\n",
-    "te = TestEnv(target_conf=my_conf, force_new=True)\n",
+    "te = TestEnv(target_conf=my_conf)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/examples/devlib/cgroups_example.ipynb
+++ b/ipynb/examples/devlib/cgroups_example.ipynb
@@ -202,7 +202,7 @@
     "    }\n",
     "}\n",
     "\n",
-    "te = TestEnv(my_conf, force_new=True)\n",
+    "te = TestEnv(my_conf)\n",
     "target = te.target\n",
     "\n",
     "# Report target connection\n",

--- a/ipynb/examples/energy_meter/EnergyMeter_ACME.ipynb
+++ b/ipynb/examples/energy_meter/EnergyMeter_ACME.ipynb
@@ -159,7 +159,7 @@
    ],
    "source": [
     "# Initialize a test environment using:\n",
-    "te = TestEnv(my_conf, wipe=False, force_new=True)\n",
+    "te = TestEnv(my_conf, wipe=False)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/examples/energy_meter/EnergyMeter_AEP.ipynb
+++ b/ipynb/examples/energy_meter/EnergyMeter_AEP.ipynb
@@ -158,7 +158,7 @@
    ],
    "source": [
     "# Initialize a test environment using:\n",
-    "te = TestEnv(my_conf, wipe=False, force_new=True)\n",
+    "te = TestEnv(my_conf, wipe=False)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/examples/energy_meter/EnergyMeter_HWMON.ipynb
+++ b/ipynb/examples/energy_meter/EnergyMeter_HWMON.ipynb
@@ -158,7 +158,7 @@
    ],
    "source": [
     "# Initialize a test environment using:\n",
-    "te = TestEnv(my_conf, wipe=False, force_new=True)\n",
+    "te = TestEnv(my_conf, wipe=False)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/examples/energy_meter/EnergyMeter_Monsoon.ipynb
+++ b/ipynb/examples/energy_meter/EnergyMeter_Monsoon.ipynb
@@ -191,7 +191,7 @@
    ],
    "source": [
     "# Initialize a test environment using:\n",
-    "te = TestEnv(my_conf, wipe=False, force_new=True)\n",
+    "te = TestEnv(my_conf, wipe=False)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/examples/trace_analysis/TraceAnalysis_FunctionsProfiling.ipynb
+++ b/ipynb/examples/trace_analysis/TraceAnalysis_FunctionsProfiling.ipynb
@@ -169,7 +169,7 @@
    ],
    "source": [
     "# Initialize a test environment using:\n",
-    "te = TestEnv(my_conf, wipe=False, force_new=True)\n",
+    "te = TestEnv(my_conf, wipe=False)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/examples/trace_analysis/TraceAnalysis_IdleStates.ipynb
+++ b/ipynb/examples/trace_analysis/TraceAnalysis_IdleStates.ipynb
@@ -191,7 +191,7 @@
    ],
    "source": [
     "# Initialize a test environment\n",
-    "te = TestEnv(my_conf, wipe=False, force_new=True)\n",
+    "te = TestEnv(my_conf, wipe=False)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/examples/trace_analysis/TraceAnalysis_TasksLatencies.ipynb
+++ b/ipynb/examples/trace_analysis/TraceAnalysis_TasksLatencies.ipynb
@@ -197,7 +197,7 @@
    ],
    "source": [
     "# Initialize a test environment using:\n",
-    "te = TestEnv(my_conf, wipe=False, force_new=True)\n",
+    "te = TestEnv(my_conf, wipe=False)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/releases/ReleaseNotes_v16.10.ipynb
+++ b/ipynb/releases/ReleaseNotes_v16.10.ipynb
@@ -255,7 +255,7 @@
    "source": [
     "from env import TestEnv\n",
     "\n",
-    "te = TestEnv(my_conf, force_new=True)\n",
+    "te = TestEnv(my_conf)\n",
     "target = te.target"
    ]
   },
@@ -532,7 +532,7 @@
    "source": [
     "from env import TestEnv\n",
     "\n",
-    "te = TestEnv(my_conf, force_new=True)"
+    "te = TestEnv(my_conf)"
    ]
   },
   {
@@ -766,7 +766,7 @@
    "source": [
     "from env import TestEnv\n",
     "\n",
-    "te = TestEnv(my_conf, force_new=True)\n",
+    "te = TestEnv(my_conf)\n",
     "target = te.target"
    ]
   },
@@ -1662,7 +1662,7 @@
    "source": [
     "from env import TestEnv\n",
     "\n",
-    "te = TestEnv(my_conf, force_new=True)\n",
+    "te = TestEnv(my_conf)\n",
     "target = te.target"
    ]
   },

--- a/ipynb/releases/ReleaseNotes_v16.12.ipynb
+++ b/ipynb/releases/ReleaseNotes_v16.12.ipynb
@@ -493,7 +493,7 @@
     "        'platform'     : 'android',\n",
     "        'board'        : 'pixel',\n",
     "        'ANDROID_HOME' : '/home/patbel01/Code/lisa/tools/android-sdk-linux/'\n",
-    "    }, force_new=True)\n",
+    "    })\n",
     "target = te.target"
    ]
   },

--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -187,7 +187,7 @@ class TestEnv(ShareState):
     _initialized = False
 
     def __init__(self, target_conf=None, test_conf=None, wipe=True,
-                 force_new=False):
+                 force_new=True):
         super(TestEnv, self).__init__()
 
         if self._initialized and not force_new:
@@ -313,13 +313,13 @@ class TestEnv(ShareState):
         self._init()
 
         # Initialize FTrace events collection
-        self._init_ftrace(True)
+        self._init_ftrace()
 
         # Initialize RT-App calibration values
         self.calibration()
 
         # Initialize energy probe instrument
-        self._init_energy(True)
+        self._init_energy()
 
         self._log.info('Set results folder to:')
         self._log.info('   %s', self.res_dir)
@@ -349,7 +349,7 @@ class TestEnv(ShareState):
         conf.load()
         return conf.json
 
-    def _init(self, force = False):
+    def _init(self, force=True):
 
         # Initialize target
         self._init_target(force)
@@ -385,7 +385,7 @@ class TestEnv(ShareState):
         self._init_platform()
 
 
-    def _init_target(self, force = False):
+    def _init_target(self, force=True):
 
         if not force and self.target is not None:
             return self.target
@@ -711,7 +711,7 @@ class TestEnv(ShareState):
     def ftrace_conf(self, conf):
         self._init_ftrace(True, conf)
 
-    def _init_ftrace(self, force=False, conf=None):
+    def _init_ftrace(self, force=True, conf=None):
 
         if not force and self.ftrace is not None:
             return self.ftrace
@@ -748,7 +748,7 @@ class TestEnv(ShareState):
 
         return self.ftrace
 
-    def _init_energy(self, force):
+    def _init_energy(self, force=True):
 
         # Initialize energy probe to board default
         self.emeter = EnergyMeter.getInstance(self.target, self.conf, force,

--- a/libs/utils/test.py
+++ b/libs/utils/test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import copy
 import os
 import unittest
 import logging
@@ -63,7 +64,15 @@ class LisaTest(unittest.TestCase):
     def _getTestConf(cls):
         if cls.test_conf is None:
             raise NotImplementedError("Override `test_conf` attribute")
-        return cls.test_conf
+        # Shallow copy of the test conf so we can update its results_dir
+        # without modifying it for all classes that may share the same test_conf
+        # object (through their base class for example).
+        test_conf = copy.copy(cls.test_conf)
+        # Using a qualified name avoids clashes if the same class name is used
+        # by different modules.
+        test_name = cls.__module__ + '.' + cls.__name__
+        test_conf.setdefault('results_dir', test_name)
+        return test_conf
 
     @classmethod
     def _getExperimentsConf(cls, test_env):

--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -393,6 +393,9 @@ fi
 # Execute in a sub-shell
 (
   export LISA_TEST_ITERATIONS LISA_TARGET_CONF LISA_RESULTS_DIR
+  # Allow all TestEnv to share the same target to avoid reinitialization between
+  # tests
+  export LISA_TARGET_SINGLETON=1
   _lisa-test "${extra_args[@]}"
 )
 local retcode=$?

--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -296,8 +296,7 @@ cat <<EOF
 Usage: lisa-test [OPTIONS] [args] FILE[:CLASS]
 
   Run automated tests. Tests can be found under the tests/ directory.
-  Only one python file can be specified at a time, otherwise the results might
-  not be valid.
+  A "results.xml" xUnit file can be found in the results base directory.
 
   Valid OPTIONS are:
 
@@ -307,7 +306,8 @@ Usage: lisa-test [OPTIONS] [args] FILE[:CLASS]
 
   --target-conf (or -t) sets an alternative target.config file.
 
-  --results-dir (or -o) sets the output directory of the tests.
+  --results-base (or -o) sets the output directory for the tests started by this
+    command. Defaults to a timestamp-named folder.
 
   This is a wrapper for the 'nosetests' utility, additional arguments are passed
   to that tool.
@@ -321,11 +321,6 @@ Usage: lisa-test [OPTIONS] [args] FILE[:CLASS]
 
       lisa-test tests/eas/generic.py:RampUp
 
-    Run RampUp test from EAS Generic suite, generating an XML test
-    report via nose's XUnit plugin (see nosetests documentation):
-
-      lisa-test --with-xunit --xunit-file=report.xml tests/eas/generic.py:RampUp
-
     Run RampUp test from EAS Generic suite, repeating the
     workload 10 times and reporting how many times the test run
     passed:
@@ -335,26 +330,24 @@ Usage: lisa-test [OPTIONS] [args] FILE[:CLASS]
     Run EAS Generic suite, repeating each workload 10 times:
 
       lisa-test --iterations 10 tests/eas/generic.py
+
+    Run EAS Generic suite, with the results stored under results/myrun:
+
+      lisa-test --results-base results/myrun tests/eas/generic.py
 EOF
 }
 
 function _lisa-test {
-if [ -n "$LISA_RESULTS_DIR" ]; then
-  mkdir -p "$LISA_RESULTS_DIR"
-  # There is no sensible place to store results.xml when the directory is not
-  # set explicitely, as the Python scripts decide where to put the results..
-  # Using results_latest symlink is not an option as it would race if using the
-  # same tree to run multiple tests on different boards at the same time.
-  local xunit_options=(--with-xunit --xunit-file="$LISA_RESULTS_DIR/results.xml")
-fi
+mkdir -p "$LISA_RESULTS_BASE" &&
 nosetests -v --nocapture --nologcapture    \
           --logging-config=logging.conf    \
-          "${xunit_options[@]}"            \
+          --with-xunit --xunit-file="$LISA_RESULTS_BASE/results.xml"    \
           "$@"
 }
 
 function lisa-test {
 local extra_args=()
+local LISA_RESULTS_BASE=${LISA_RESULTS_BASE:-$LISA_HOME/results/$(date '+%Y%m%d_%H%M%S')}
 
 echo
 while [[ $# -gt 0 ]]; do
@@ -372,8 +365,8 @@ while [[ $# -gt 0 ]]; do
                         LISA_TARGET_CONF="$2"
                         shift
                         ;;
-                -o|--results-dir)
-                        LISA_RESULTS_DIR="$2"
+                -o|--results-base)
+                        LISA_RESULTS_BASE="$2"
                         shift
                         ;;
                 *)
@@ -390,9 +383,13 @@ if [ -z "${extra_args[*]}" ]; then
         return 1
 fi
 
+# Make sure an absolute path is used so relative paths will not be relocated
+# under $LISA_HOME/results/
+LISA_RESULTS_BASE=$(readlink -f "$LISA_RESULTS_BASE")
+
 # Execute in a sub-shell
 (
-  export LISA_TEST_ITERATIONS LISA_TARGET_CONF LISA_RESULTS_DIR
+  export LISA_TEST_ITERATIONS LISA_TARGET_CONF LISA_RESULTS_BASE
   # Allow all TestEnv to share the same target to avoid reinitialization between
   # tests
   export LISA_TARGET_SINGLETON=1

--- a/tests/eas/preliminary.py
+++ b/tests/eas/preliminary.py
@@ -49,17 +49,17 @@ All required config options are set, sched governor is present.
 
 """
 
-TEST_CONF = {
-    'modules': ['cpufreq'],
-    'tools': [
-        'sysbench',
-    ]
-}
-
 class BasicCheckTest(LisaTest):
+    test_conf = {
+        'modules': ['cpufreq'],
+        'tools': [
+            'sysbench',
+        ]
+    }
+
     @classmethod
     def setUpClass(cls):
-        cls.env = TestEnv(test_conf=TEST_CONF)
+        cls.env = TestEnv(test_conf=cls._getTestConf())
         cls.target = cls.env.target
 
 class TestSchedGovernor(BasicCheckTest):

--- a/tests/lisa/test_executor.py
+++ b/tests/lisa/test_executor.py
@@ -44,8 +44,7 @@ class SetUpTarget(TestCase):
                 'ftrace': {
                     'events': []
                 }
-            },
-            force_new=True)
+            })
 
 class TestMagicSmoke(SetUpTarget):
     def test_files_created(self):

--- a/tests/lisa/test_executor.py
+++ b/tests/lisa/test_executor.py
@@ -40,6 +40,7 @@ class SetUpTarget(TestCase):
             test_conf={
                 # Don't load cpufreq, it won't work when platform=host
                 'exclude_modules': ['cpufreq'],
+                'results_dir': self.__module__ + '.' + self.__class__.__name__,
                 # Empty list of events to avoid getting the default ones
                 'ftrace': {
                     'events': []


### PR DESCRIPTION
The current behavior relies on TestEnv being initialized once per lisa-test command. This will create a results_dir directory that will be used by all tests. The default argument wipe=True does not wipe this folder since it is ignored after the first TestEnv is created. Unfortunately, this has a number of downsides: TestEnv are sharing a results_dir that is supposed to be private. It makes it harder to map files to the test they belong to. The shared state in TestEnv also means the trace events are initialized once per lisa-test command, so the first test in alphabetical order will get its required events but it will be a gamble for the following tests.

The fix consists in limiting the shared state to the target attribute and closely related attributes. The rest of TestEnv is now initialized properly for every test, including a new results directory base on the name of the test. The base folder containing all the tests' results directory can be specified with -o lisa-test option.

close #316 