### PR TITLE
shell: allow disabling colors

### DIFF
--- a/src/shell/lisa_colors
+++ b/src/shell/lisa_colors
@@ -32,7 +32,7 @@
 # cyan    36 46
 # white   37 47
 
-if [[ -t 1 ]]; then
+if [[ -t 1 && $- = *"i"* ]]; then
     LISASHELL_WHITE="\033[1;37m"
     LISASHELL_LGRAY="\033[37m"
     LISASHELL_GRAY="\033[1;30m"

--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -46,7 +46,10 @@ fi
 # Only clear the screen if stdout is a terminal, to avoid ASCII escape
 # characters to be sent to a log file for example.
 function clear {
-test -t 1 && command clear
+    case "$-" in
+        *i*) test -t 1 && command clear ;;
+        *) ;;
+    esac
 }
 
 ################################################################################


### PR DESCRIPTION
When LISA_SHELL_DISABLE_COLORS environment variable is set to some
value, LISA shell won't use colours. This feature is useful when using
LISA in automated environment where shell colours are not supported.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>