### PR TITLE
utils/ftrace: add a utility function to display a trace

### DIFF
--- a/libs/utils/trace.py
+++ b/libs/utils/trace.py
@@ -26,6 +26,7 @@ import json
 import warnings
 import operator
 import logging
+import webbrowser
 
 from analysis_register import AnalysisRegister
 from collections import namedtuple
@@ -393,6 +394,23 @@ class Trace(object):
                  name
         """
         return self._tasks_by_pid.TaskName.to_dict()
+
+    def show(self):
+        """
+        Open the parsed trace using the most appropriate native viewer.
+
+        The native viewer depends on the specified trace format:
+        - ftrace: open using kernelshark
+        - systrace: open using a browser
+
+        In both cases the native viewer is assumed to be available in the host
+        machine.
+        """
+        if isinstance(self.ftrace, trappy.FTrace):
+            return os.popen("kernelshark {}".format(self.ftrace.trace_path))
+        if isinstance(self.ftrace, trappy.SysTrace):
+            return webbrowser.open(self.ftrace.trace_path)
+        self._log.warning('No trace data available')
 
 
 ###############################################################################


### PR DESCRIPTION
Whenever a trace has been parsed, it could be useful sometimes to still
open it using the most appropriate native viewer.

Let's open ftrace using kernelshark of systraces using the default user
web browser.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>