### PR TITLE
latency_analysis: add statistics getter method

### DIFF
--- a/libs/utils/analysis/latency_analysis.py
+++ b/libs/utils/analysis/latency_analysis.py
@@ -381,7 +381,6 @@ class LatencyAnalysis(AnalysisModule):
 
         return df, cdf
 
-
     @memoized
     def _dfg_latency_stats_df(self, task, kind='all', threshold_ms=1):
         """
@@ -402,9 +401,6 @@ class LatencyAnalysis(AnalysisModule):
 
         # Get latency events
         df, cdf = self._get_latency_df(task, kind, threshold_ms)
-        self._log.info('Total: %5d latency events', len(df))
-        self._log.info('%.1f %% samples below %d [ms] threshold',
-                       100. * cdf.below, threshold_ms)
 
         # Return statistics
         stats_df = df.describe(percentiles=[0.95, 0.99])
@@ -456,7 +452,6 @@ class LatencyAnalysis(AnalysisModule):
         td = self._getTaskData(task)
         if not td:
             return None
-
 
         # Setup plots
         gs = gridspec.GridSpec(2, 2, height_ratios=[2,1], width_ratios=[1,1])


### PR DESCRIPTION
Right now, the plotLatency method returns a DF with statistics for the
latencies of a specified task. However, sometimes we could be
interested in getting these stats without necessarily plotting all the
data.

Let's move the statistics DF generation into an internal _get_latency_df
method, which can then be used by the plotLatency but also from an
additional DF gatter: _dfg_latency_stats_df.
Thus, this will make available a new:

   trace.data_frame.latency_stats_df()

which just return the overall latency stats for the specified task.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>