### PR TITLE
Fix cpuhp test

### DIFF
--- a/libs/utils/target_script.py
+++ b/libs/utils/target_script.py
@@ -101,7 +101,7 @@ class TargetScript(object):
         # Push it on target
         self._remote_path = self._target.install(self._local_path)
 
-    def run(self, as_root=False, background=False):
+    def run(self, as_root=False, background=False, timeout=None):
         """
         Run the previously pushed script
         """
@@ -112,7 +112,9 @@ class TargetScript(object):
                 self._bg_shell = self._target.background(self._remote_path,
                                                     as_root=self._run_as_root)
             else:
-                self._target.execute(self._remote_path, as_root=self._run_as_root)
+                self._target.execute(self._remote_path,
+                                     as_root=self._run_as_root,
+                                     timeout=timeout)
         else:
             raise IOError('Remote script was not found on target device')
 


### PR DESCRIPTION
The CPU hotplug test is full of useless dependencies which silently talk
to the target (rt-app, freezing userspace, ftrace, ...). When the target
crashes during the hotplug stress, requests sent to the target because
of the above modules can hang indefinitely, or fail miserably. That is
an issue since, in the specific case of the hotplug test, we would like
to classify these crashes as test failures.

Remove all the dependencies by overwritting the runExperiments method of
LisaTest in order to avoid using an Executor. The test spawns a bash
script on the target that plugs CPUs in and out, and does _nothing_ on
the host side during a (configurable) amount of time before checking if
the target is alive.
