### PR TITLE
Fix some of the issues of preliminary.py

### DIFF
--- a/tests/eas/preliminary.py
+++ b/tests/eas/preliminary.py
@@ -181,8 +181,10 @@ class TestWorkThroughput(BasicCheckTest):
 class TestEnergyModelPresent(BasicCheckTest):
     def test_energy_model_present(self):
         """Test that we can see the energy model in sysctl"""
-        if not self.target.file_exists(
-                '/proc/sys/kernel/sched_domain/cpu0/domain0/group0/energy/'):
+        em_path = '/proc/sys/kernel/sched_domain/cpu0/domain0/group0/energy/'
+        sem_path = '/sys/devices/system/cpu/energy_model'
+        if not (self.target.file_exists(em_path) or
+                self.target.file_exists(sem_path)):
             raise AssertionError(
                 'No energy model visible in procfs. Possible causes: \n'
                 '- Kernel built without (CONFIG_SCHED_DEBUG && CONFIG_SYSCTL)\n'

--- a/tests/eas/preliminary.py
+++ b/tests/eas/preliminary.py
@@ -323,3 +323,14 @@ class TestSchedDomainFlags(BasicCheckTest):
         finally:
             self.write_cpu_caps(old_caps)
             self._test_asym_cpucapacity(old_caps, old_caps_asym)
+
+    def test_sched_feat(self):
+        """
+        Check that ENERGY_AWARE is set if it is present.
+        """
+        path = '/sys/kernel/debug/sched_features'
+        sf = self.target.read_value(path)
+        if 'ENERGY_AWARE' not in sf:
+            raise SkipTest('ENERGY_AWARE sched feature not present')
+        if 'NO_ENERGY_AWARE' in sf:
+            raise AssertionError('ENERGY_AWARE sched feature is not set')


### PR DESCRIPTION
This adds a check on the ENERGY_AWARE sched_feat being set (if present) in preliminary.py, and also introduces some support for the simplified EM.

Preliminary.py might have other issues (related to flags for example), but they might be more complex to solve, and might require more discussion. This PR is already helpful as-is in the meantime (I think) so that's why I posted it separetly.