### PR TITLE
tests/preliminary: Skip SD_SHARE_CAP_STATES test when applicable

### DIFF
--- a/tests/eas/preliminary.py
+++ b/tests/eas/preliminary.py
@@ -250,9 +250,14 @@ class TestSchedDomainFlags(BasicCheckTest):
         """
         Check that some domain exists with SD_SHARE_CAP_STATES set
 
-        EAS silently does nothing if this flag is not set at any level (see
-        use of sd_scs percpu variable in scheduler code).
+        On old kernels (4.14 and before), EAS silently does nothing if this
+        flag is not set at any level (see use of sd_scs percpu variable in
+        scheduler code).
         """
+        if self.target.kernel_version.parts > (4, 14):
+            raise SkipTest('Target kernel version greater than v4.14, '
+                           'SD_SHARE_CAP_STATES not required')
+
         cpu0_flags = []
         for flags in self.iter_cpu_sd_flags(0):
             if flags & self.SD_SHARE_CAP_STATES:


### PR DESCRIPTION
Recent EAS versions (with the simplified EM) do not rely on the
SD_SHARE_CAP_STATES flag to be set anywhere. As a result, the
preliminary test checking its presence fails, although the kernel
configuration is fine.

Fix this by making preliminary.py check the kernel version to skip
the test if it doesn't make sense.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>