### PR TITLE
Load tracking cpu migration improvements

### DIFF
--- a/libs/utils/test.py
+++ b/libs/utils/test.py
@@ -132,12 +132,17 @@ class LisaTest(unittest.TestCase):
         """
 
     @memoized
-    def get_sched_assert(self, experiment, task):
+    def get_sched_assert(self, experiment, task, pid=0):
         """
         Return a SchedAssert over the task provided
         """
-        return SchedAssert(
-            self.get_trace(experiment).ftrace, self.te.topology, execname=task)
+
+        if pid:
+            return SchedAssert(
+                self.get_trace(experiment).ftrace, self.te.topology, pid=pid)
+        else:
+            return SchedAssert(
+                self.get_trace(experiment).ftrace, self.te.topology, execname=task)
 
     @memoized
     def get_multi_assert(self, experiment, task_filter=""):

--- a/tests/eas/load_tracking.py
+++ b/tests/eas/load_tracking.py
@@ -837,6 +837,11 @@ class OneTaskCPUMigrationTest(_CPUMigrationBase):
             Util            Util
     CPU 4:   35%             10%
     CPU 5:   5%              30%
+
+    Conditions
+    ==========
+    The CPU[s] on the which the test is running must be reasonably quiet or the
+    measured util_mean will be skewed by any creeping tasks/kthreads/softirqs.
     """
     @classmethod
     def _getExperimentsConf(cls, test_env):
@@ -903,6 +908,11 @@ class TwoTasksCPUMigrationTest(_CPUMigrationBase):
             Util            Util
     CPU 4:   20%             50%
     CPU 5:   50%             20%
+
+    Conditions
+    ==========
+    The CPU[s] on the which the test is running must be reasonably quiet or the
+    measured util_mean will be skewed by any creeping tasks/kthreads/softirqs.
     """
     @classmethod
     def _getExperimentsConf(cls, test_env):

--- a/tests/eas/load_tracking.py
+++ b/tests/eas/load_tracking.py
@@ -39,6 +39,8 @@ UTIL_SCALE = 1024
 UTIL_AVG_CONVERGENCE_TIME = 0.3
 # Allowed margin between expected and observed util_avg value
 ERROR_MARGIN_PCT = 15
+# Allowed error margin % for migration tests
+MIGRATION_ERROR_MARGIN_PCT = 2
 # PELT half-life value in ms
 HALF_LIFE_MS = 32
 
@@ -555,7 +557,7 @@ class _CPUMigrationBase(LisaTest):
     }
 
     # Allowed error margin
-    allowed_util_margin = UTIL_SCALE * 0.02
+    allowed_util_margin = UTIL_SCALE * (MIGRATION_ERROR_MARGIN_PCT / 100.)
 
     # Dictionary that contains the description of the tasks
     tasks_desc = {}
@@ -946,7 +948,7 @@ class _PELTTaskGroupsTest(LisaTest):
         'modules': ['cpufreq', 'cgroups'],
     }
     # Allowed error margin
-    allowed_util_margin = 0.02
+    allowed_util_margin = (MIGRATION_ERROR_MARGIN_PCT / 100.)
 
     @classmethod
     def runExperiments(cls):


### PR DESCRIPTION
The 2 patches make the {One,Two}Task[s]CPUMigrationTest more stable by reducing some sources of noise that made the tests fail occasionally at some iterations and during one integration test (20180720) fail 100% of the iterations.

I can't root cause why 20180720 integration was worse than others but changes to NFS might have caused more kworker threads to run randomly on the CPUs the test was running on causing utilization to be slightly off. Combined with rounding/quantization errors in calculating util_mean in _get_util_mean() they all were adding up enough to tip the point to a 100% failure rate.

Depending on the next integration test results with these fixes - more investigation might be necessary.