### PR TITLE
tests/eas/generic.py: Tweak RampDown energy threshold

### DIFF
--- a/tests/eas/generic.py
+++ b/tests/eas/generic.py
@@ -549,7 +549,15 @@ class RampDown(_EnergyModelTest):
     # This migration naturally happens some time _after_ it could possibly be
     # done, since there must be some hysteresis to avoid a performance cost.
     # Therefore allow a larger energy usage threshold
-    energy_est_threshold_pct = 15
+    #
+    # The number below has been found by trial and error on the platforms
+    # generally used for testing EAS (at the time of writing: Juno r0, Juno r2,
+    # Hikey960 and TC2). It would be better to estimate the amount of energy
+    # 'wasted' in the hysteresis (the overutilized band) and compute a threshold
+    # based on that. But implementing this isn't easy because it's very platform
+    # dependent, so until we have a way to do that easily in test classes, let's
+    # stick with the arbitrary threshold.
+    energy_est_threshold_pct = 18
 
     workloads = {
         "ramp_down" : {


### PR DESCRIPTION
The RampDown test happens to fail on TC2 with a 16% or 17% energy delta,
while the behaviour is clearly correct. This happens because of the
overutilized band. The exact location of that band depends on the
capacity ratio of CPUs of the platform, but the RampDown test
configuration is hardcoded, without taking the platform's topology into
account. As a result, the test is hitting more sensible part of the
power-perf curve on some targets than others, and that is the cause of
the problems observed on TC2.

Fix this by tweaking the threshold at a level that should suit TC2
better. A proper fix would be to compute the threshold depending on the
EM of the target, but this is difficult to do in the current state of
the test framework. The new test framework should handle these scenarios
a lot better, so implementing 'the right thing' should be easier then.
In the meantime, the threshold tweak should workaround the issue just
fine.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>