### PR TITLE
error message in lisa_shell is not very instructive, /sbin/ifconfig might not be installed

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -188,9 +188,19 @@ function _lisa-ipython-usage {
 
 function _lisa-ipython-start {
 # Get IP address for the specified interface
-IPADDR=$(/sbin/ifconfig $NETIF 2>/dev/null  | \
-    awk '/inet / {print $2}' | \
-    sed 's/addr://')
+IPADDR=
+
+if [ -x /sbin/ifconfig ]; then
+    IPADDR=$(/sbin/ifconfig $NETIF 2>/dev/null  | \
+        awk '/inet / {print $2}' | \
+        sed 's/addr://')
+fi
+
+if [ "x$IPADDR" == "x" -a -x /sbin/ip ]; then
+    IPADDR=$(/sbin/ip a show dev $NETIF 2>/dev/null | \
+        awk '/inet / { gsub("/.*", ""); print $2; }')
+fi
+
 if [ "x$IPADDR" == "x" ]; then
     echo
     echo "could not determine IP address of $NETIF"

--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -193,7 +193,7 @@ IPADDR=$(/sbin/ifconfig $NETIF 2>/dev/null  | \
     sed 's/addr://')
 if [ "x$IPADDR" == "x" ]; then
     echo
-    echo "$NETIF is not a valid network interface"
+    echo "could not determine IP address of $NETIF"
     echo
     echo "Usage: $0 <NETIF>"
     echo " NETIF - The network interface to start the server on"


### PR DESCRIPTION
modern linux systems don't have /sbin/ifconfig installed by default (but /sbin/ip, instead)