### PR TITLE
init_env: do not replace the running shell. instead start a new one, …

### DIFF
--- a/init_env
+++ b/init_env
@@ -19,7 +19,7 @@
 # LISA Shell: Initialization
 grep "bash" /proc/$$/cmdline &>/dev/null
 if [ $? -eq 0 ]; then
-	source ./src/shell/lisa_shell
+	bash --rcfile <(echo 'source ./src/shell/lisa_shell')
 else
 	echo "WARNING: Current shell is not a BASH"
 	# Check if a bash shell is available


### PR DESCRIPTION
…so that on exiting lisa, we go back to the shell.