### PR TITLE
some issues with two examples from the tutorials directory

### DIFF
--- a/ipynb/tutorial/00_LisaInANutshell.ipynb
+++ b/ipynb/tutorial/00_LisaInANutshell.ipynb
@@ -487,7 +487,7 @@
    ],
    "source": [
     "# Enable Energy-Aware scheduler\n",
-    "target.execute(\"echo ENERGY_AWARE > /sys/kernel/debug/sched_features\");\n",
+    "target.execute(\"echo ENERGY_AWARE > /sys/kernel/debug/sched_features\", as_root=True);\n",
     "\n",
     "# Check which sched_feature are enabled\n",
     "sched_features = target.read_value(\"/sys/kernel/debug/sched_features\");\n",

--- a/ipynb/tutorial/UseCaseExamples_SchedTuneAnalysis.ipynb
+++ b/ipynb/tutorial/UseCaseExamples_SchedTuneAnalysis.ipynb
@@ -183,9 +183,10 @@
    ],
    "source": [
     "import json\n",
+    "import os\n",
     "\n",
     "# Load the platform information\n",
-    "with open('../../results/SchedTuneAnalysis/platform.json', 'r') as fh:\n",
+    "with open(os.path.join(res_dir, 'platform.json'), 'r') as fh:\n",
     "    platform = json.load(fh)\n",
     "print \"Platform descriptio collected from the target:\"\n",
     "print json.dumps(platform, indent=4)"

--- a/ipynb/tutorial/UseCaseExamples_SchedTuneAnalysis.ipynb
+++ b/ipynb/tutorial/UseCaseExamples_SchedTuneAnalysis.ipynb
@@ -568,8 +568,8 @@
    "source": [
     "# Get a list of first 5 \"sched_load_avg_events\" events\n",
     "sched_load_avg_events = !(\\\n",
-    "    grep sched_load_avg_task {trace_file.replace('.dat', '.txt')} | \\\n",
-    "    head -n5 \\\n",
+    "    trace-cmd report -q -F sched_load_avg_task {trace_file} | \\\n",
+    "    head -n6 \\\n",
     ")\n",
     " \n",
     "print \"First 5 sched_load_avg events:\"\n",


### PR DESCRIPTION
tutorial/00_LisaInANutshell: should be trying to set ENERGY_AWARE scheduling as root, otherwise permission will be denied (i haven't tested the rest of the file)

tutorial/UseCaseExamples_SchedTuneAnalysis: was not using the path that was set to load the trace file and the ASCII trace file is missing, therefore need to generate it

there are more issues, at least with the latter one.