### PR TITLE
env: Freeze all systemd-* cmd except PID 1

### DIFF
--- a/libs/utils/env.py
+++ b/libs/utils/env.py
@@ -160,7 +160,9 @@ class TestEnv(ShareState):
     critical_tasks = {
         'linux': [
             'init',
-            'systemd',
+            # We want to freeze everything except PID 1, we don't want to let
+            # sysmted-journald or systemd-timesyncd running.
+            'systemd[^-]',
             'dbus',
             'sh',
             'ssh',


### PR DESCRIPTION
Since all commands part of the systemd package are named
systemd-<something>, we need a more refined pattern in order to properly
freeze systemd-journald process for example.