### PR TITLE
Update wa agendas to fix several breakges

### DIFF
--- a/tools/wltests/agendas/example-exoplayer-simple.yaml
+++ b/tools/wltests/agendas/example-exoplayer-simple.yaml
@@ -7,3 +7,5 @@
 workloads:
   - name: exoplayer
     iterations: 3
+    workload_parameters:
+      version: 2.4

--- a/tools/wltests/agendas/example-rich.yaml
+++ b/tools/wltests/agendas/example-rich.yaml
@@ -53,10 +53,13 @@ workloads:
   - name: exoplayer
     id: exoplayer_30s
     workload_parameters:
+      version: 2.4
       duration: 30
 
   - name: pcmark
     id: pcmark
+    runtime_parameters:
+      airplane_mode: false
 
   - name: geekbench
     id: geekbench
@@ -69,31 +72,31 @@ workloads:
     # easier to read/parse
     id: jb_list_view
     classifiers:
-      test: jb_list_view
+      test_ids: jb_list_view
     # workload_parameters are the real parameters that influence what gets run
     workload_parameters:
-      test: list_view
+      test_ids: list_view
   - name: jankbench
     id: jb_image_list_view
     classifiers:
-      test: jb_image_list_view
+      test_ids: jb_image_list_view
     workload_parameters:
-      test: image_list_view
+      test_ids: image_list_view
   - name: jankbench
     id: jb_shadow_grid
     classifiers:
-      test: jb_shadow_grid
+      test_ids: jb_shadow_grid
     workload_parameters:
-      test: shadow_grid
+      test_ids: shadow_grid
   - name: jankbench
     id: jb_low_hitrate_text
     classifiers:
-      test: jb_low_hitrate_text
+      test_ids: jb_low_hitrate_text
     workload_parameters:
-      test: low_hitrate_text
+      test_ids: low_hitrate_text
   - name: jankbench
     id: jb_edit_text
     classifiers:
-      test: jb_edit_text
+      test_ids: jb_edit_text
     workload_parameters:
-      test: edit_text
+      test_ids: edit_text

--- a/tools/wltests/agendas/sched-evaluation-full-traced.yaml
+++ b/tools/wltests/agendas/sched-evaluation-full-traced.yaml
@@ -57,6 +57,7 @@ workloads:
     classifiers:
        tag: mov_720p_30s
     workload_parameters:
+      version: 2.4
       format: "mov_720p"
       duration: 30
       landscape: True
@@ -67,6 +68,7 @@ workloads:
     classifiers:
        tag: ogg_128kbps_30s
     workload_parameters:
+      version: 2.4
       format: "ogg_128kbps"
       duration: 30
 
@@ -78,6 +80,8 @@ workloads:
     classifiers:
        tag: single
     iterations: 10
+    runtime_parameters:
+      airplane_mode: false
 
 ################################################################################
 # Geekbench
@@ -98,7 +102,7 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: list_view
+      test_ids: list_view
     iterations: 30
 
   - name: jankbench
@@ -106,7 +110,7 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: image_list_view
+      test_ids: image_list_view
     iterations: 30
 
   - name: jankbench
@@ -114,7 +118,7 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: shadow_grid
+      test_ids: shadow_grid
     iterations: 30
 
   - name: jankbench
@@ -122,7 +126,7 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: low_hitrate_text
+      test_ids: low_hitrate_text
     iterations: 30
 
   - name: jankbench
@@ -130,5 +134,5 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: edit_text
+      test_ids: edit_text
     iterations: 30

--- a/tools/wltests/agendas/sched-evaluation-full.yaml
+++ b/tools/wltests/agendas/sched-evaluation-full.yaml
@@ -80,6 +80,8 @@ workloads:
     classifiers:
        tag: single
     iterations: 10
+    runtime_parameters:
+      airplane_mode: false
 
 ################################################################################
 # Geekbench

--- a/tools/wltests/agendas/sched-evaluation-small.yaml
+++ b/tools/wltests/agendas/sched-evaluation-small.yaml
@@ -57,6 +57,7 @@ workloads:
     classifiers:
        tag: mov_720p_3s
     workload_parameters:
+      version: 2.4
       format: "mov_720p"
       duration: 3
       landscape: True
@@ -67,6 +68,7 @@ workloads:
     classifiers:
        tag: ogg_128kbps_3s
     workload_parameters:
+      version: 2.4
       format: "ogg_128kbps"
       duration: 3
 
@@ -78,6 +80,8 @@ workloads:
     classifiers:
        tag: iter_5
     iterations: 5
+    runtime_parameters:
+      airplane_mode: false
 
 ################################################################################
 # Geekbench
@@ -98,7 +102,7 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: list_view
+      test_ids: list_view
     iterations: 3
 
   - name: jankbench
@@ -106,7 +110,7 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: image_list_view
+      test_ids: image_list_view
     iterations: 3
 
   - name: jankbench
@@ -114,7 +118,7 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: shadow_grid
+      test_ids: shadow_grid
     iterations: 3
 
   - name: jankbench
@@ -122,7 +126,7 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: low_hitrate_text
+      test_ids: low_hitrate_text
     iterations: 3
 
   - name: jankbench
@@ -130,5 +134,5 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: edit_text
+      test_ids: edit_text
     iterations: 3


### PR DESCRIPTION
1. pcmark needs internet access, so disable airplane mode
2. use v2.4 of exoplayer inline with sched-evaluation-full.yaml
3. s/test/test_ids/ in jankbench attributes

Signed-off-by: Qais Yousef <qais.yousef@arm.com>