### PR TITLE
wa_results_collector.py: fix test_ids being None

### DIFF
--- a/libs/utils/wa_results_collector.py
+++ b/libs/utils/wa_results_collector.py
@@ -289,23 +289,20 @@ class WaResultsCollector(object):
             # of the full key=value pairs.
             classifiers = job['classifiers'] or {}
 
+            test = "{}".format(workload)
+
             if 'test' in classifiers:
                 # If the workload spec has a 'test' classifier, use that to
                 # identify it.
-                test = classifiers.pop('test')
+                test = classifiers.pop('test') or test
             elif 'test' in job['workload_parameters']:
                 # If not, some workloads have a 'test' workload_parameter, try
                 # using that
-                test = job['workload_parameters']['test']
+                test = job['workload_parameters']['test'] or test
             elif 'test_ids' in job['workload_parameters']:
                 # If not, some workloads have a 'test_ids' workload_parameter, try
                 # using that
-                test = job['workload_parameters']['test_ids']
-            else:
-                # Otherwise just use the workload name.
-                # This isn't ideal because it means the results from jobs with
-                # different workload parameters will be amalgamated.
-                test = workload
+                test = job['workload_parameters']['test_ids'] or test
 
             rich_tag = ';'.join('{}={}'.format(k, v) for k, v in classifiers.iteritems())
             tag = classifiers.get('tag', rich_tag)


### PR DESCRIPTION
When using the sched-evaluation-full.ipynb a weird exception about
unable to parse NaN values is thrown. This happens when running
example-jankbench.yaml agenda.

It turns out that since this agenda doesn't define test_ids, the code
tries to read the property anyway and sets it to None - which later
causes the exception when read from the ipython notebook.

Always check that the property is not empty before setting it - and
fallback to the workload name by default.

Signed-off-by: Qais Yousef <qais.yousef@arm.com>