### PR TITLE
lisa-ipython: shell support fr-FR language

### DIFF
--- a/src/shell/lisa_shell
+++ b/src/shell/lisa_shell
@@ -193,7 +193,7 @@ IPADDR=
 if [ -x /sbin/ifconfig ]; then
     IPADDR=$(/sbin/ifconfig $NETIF 2>/dev/null  | \
         awk '/inet / {print $2}' | \
-        sed 's/addr://')
+        grep -Eo [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)
 fi
 
 if [ "x$IPADDR" == "x" -a -x /sbin/ip ]; then


### PR DESCRIPTION
ifconfig returns
 inet adr:172.17.0.1
instead
 inet addr:172.17.0.1
when language is set to fr-FR

update the sed command to support it

Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>