### PR TITLE
Minor improvements for scheduler/sanity.py

### DIFF
--- a/lisa/env.py
+++ b/lisa/env.py
@@ -173,7 +173,7 @@ class TestEnv(Loggable):
             plat_info = copy.copy(plat_info)
         self.plat_info = plat_info
 
-        logger.info('Pre-configured platform information:\n%s', self.plat_info)
+        logger.info('User-defined platform information:\n%s', self.plat_info)
 
         self.ftrace = None
         self._installed_tools = set()

--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -84,8 +84,9 @@ class ArtifactStorage(ArtifactPath, Loggable, HideExekallID):
 
         # Find a non-used directory
         for i in itertools.count(1):
-            artifact_dir = Path(artifact_dir, consumer_name, str(i))
-            if not artifact_dir.exists():
+            artifact_dir_ = Path(artifact_dir, consumer_name, str(i))
+            if not artifact_dir_.exists():
+                artifact_dir = artifact_dir_
                 break
 
         # Get canonical absolute paths

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -556,7 +556,11 @@ class Expression:
                 hidden_callable_set = hidden_callable_set,
             )))
             for param, param_expr in self.param_map.items()
-            if not param_expr.op.callable_ in hidden_callable_set
+            if (
+                param_expr.op.callable_ not in hidden_callable_set
+                # If the value is marked, the ID will not be hidden
+                or param_value_map.get(param, None) in marked_value_set
+            )
         )
 
         def tags_iter(value_list):

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -176,13 +176,20 @@ the name of the parameter, the start value, stop value and step size.""")
 
     adaptor_cls = AdaptorBase
     module_set = set()
+
+    try:
+        import_excep = ModuleNotFoundError
+    # Python < 3.6
+    except NameError:
+        import_excep = ImportError
+
     for name in reversed(package_name_list):
         customize_name = name + '.exekall_customize'
         # Only hide ModuleNotFoundError exceptions when looking up that
         # specific module, we don't want to hide issues inside the module
         # itself.
         module_exists = False
-        with contextlib.suppress(ModuleNotFoundError):
+        with contextlib.suppress(import_excep):
             module_exists = importlib.util.find_spec(customize_name)
 
         if module_exists:

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -48,7 +48,7 @@ def _main(argv):
     """,
     formatter_class=argparse.RawTextHelpFormatter)
 
-    subparsers = parser.add_subparsers(title='subcommands', dest='subcommand')
+    subparsers = parser.add_subparsers(title='subcommands', dest='subcommand', required=True)
 
     run_parser = subparsers.add_parser('run',
     description="""
@@ -148,11 +148,6 @@ the name of the parameter, the start value, stop value and step size.""")
     # show the message.
     except SystemExit:
         args, _ = parser.parse_known_args(argv, args)
-
-    if not args.subcommand == 'run':
-        # Show the help messages
-        parser.parse_args(argv)
-        return 0
 
     global show_traceback
     show_traceback = args.debug

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -250,7 +250,7 @@ the name of the parameter, the start value, stop value and step size.""")
         debug_log = None
     else:
         artifact_dir.mkdir(parents=True)
-        debug_log = artifact_dir.joinpath('log.txt')
+        debug_log = artifact_dir.joinpath('debug_log.txt')
 
     utils.setup_logging(args.log_level, debug_log, verbose)
 
@@ -688,25 +688,16 @@ the name of the parameter, the start value, stop value and step size.""")
                     ),
                 )
 
-            info('Finished {short_id}{uuid}'.format(
-                short_id = result.get_id(
-                    hidden_callable_set=hidden_callable_set,
-                    full_qual=False,
-                ),
-                full_id = result.get_id(
-                    hidden_callable_set=hidden_callable_set,
-                    full_qual=True,
-                ),
-                uuid=get_uuid_str(result)
-            ))
-            prefix = 'ID: '
-            out('{prefix}{id}'.format(
+            prefix = 'Finished '
+            info('{prefix}{id}{uuid}'.format(
                 id=result.get_id(
                     full_qual=False,
                     mark_excep=True,
                     with_tags=True,
+                    hidden_callable_set=hidden_callable_set,
                 ).strip().replace('\n', '\n'+len(prefix)*' '),
                 prefix=prefix,
+                uuid=get_uuid_str(result),
             ))
             if verbose:
                 out('Full ID:{}'.format(result.get_id(full_qual=True)))


### PR DESCRIPTION
Save the work done on all CPUs for a given capacity, and then reduce
that to the minimum work to avoid comparing with sys.maxsize

Also add annotated `from_testenv` method.