### PR TITLE
tests: Refactor TestBundle and LoadTracking

### DIFF
--- a/doc/kernel_tests.rst
+++ b/doc/kernel_tests.rst
@@ -83,6 +83,7 @@ Load tracking tests
 -------------------
 .. automodule:: lisa.tests.kernel.scheduler.load_tracking
    :members:
+   :private-members: _from_testenv
 
 Misfit tests
 ------------

--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -31,6 +31,7 @@ from lisa.env import TestEnv, TargetConf
 from lisa.platforms.platinfo import PlatformInfo
 from lisa.utils import HideExekallID, Loggable, ArtifactPath
 from lisa.tests.kernel.test_bundle import TestBundle, Result, ResultBundle, CannotCreateError
+from lisa.tests.kernel.scheduler.load_tracking import FreqInvarianceItem
 
 from exekall import utils, engine
 from exekall.engine import reusable, ExprData, Consumer, PrebuiltOperator, NoValue, get_name, get_mro
@@ -174,15 +175,22 @@ class LISAAdaptor(AdaptorBase):
 
     @classmethod
     def get_tag_list(cls, value):
+        tags = []
         if isinstance(value, TestEnv):
             board_name = value.target_conf.get('name')
-            tags = [board_name] if board_name else []
+            if board_name:
+                tags.append(board_name)
         elif isinstance(value, PlatformInfo):
             name = value.get('name')
-            tags = [name] if name else []
+            if name:
+                tags.append(name)
         elif isinstance(value, TestBundle):
             name = value.plat_info.get('name')
-            tags = [name] if name else []
+            if name:
+                tags.append(name)
+            if isinstance(value, FreqInvarianceItem):
+                tag_str = 'cpu{cpu}@{freq}' if value.cpu is not None else '{}'
+                tags.append(tag_str.format(cpu=value.cpu, freq=value.freq))
         else:
             tags = super().get_tag_list(value)
 

--- a/lisa/tests/kernel/scheduler/eas_behaviour.py
+++ b/lisa/tests/kernel/scheduler/eas_behaviour.py
@@ -87,6 +87,15 @@ class EASBehaviour(RTATestBundle, abc.ABC):
         return cls(res_dir, te.plat_info, rtapp_profile)
 
     @classmethod
+    def from_testenv(cls, te:TestEnv, res_dir:ArtifactPath=None) -> 'EASBehaviour':
+        """
+        Factory method to create a bundle using a live target
+
+        This will execute the rt-app workload described in :meth:`get_rtapp_profile`
+        """
+        return super().from_testenv(te, res_dir)
+
+    @classmethod
     def min_cpu_capacity(cls, te):
         """
         The smallest CPU capacity on the target

--- a/lisa/tests/kernel/scheduler/load_tracking.py
+++ b/lisa/tests/kernel/scheduler/load_tracking.py
@@ -520,7 +520,7 @@ class FreqInvariance(TestBundle, LoadTrackingHelpers):
 
         return overall_bundle
 
-class PELTTaskTest(LoadTrackingBase):
+class PELTTask(LoadTrackingBase):
     """
     Basic checks for task related PELT signals behaviour
 
@@ -551,7 +551,7 @@ class PELTTaskTest(LoadTrackingBase):
     task_prefix = 'pelt_behv'
 
     @classmethod
-    def from_testenv(cls, te:TestEnv, res_dir:ArtifactPath=None) -> 'PELTTaskTest':
+    def from_testenv(cls, te:TestEnv, res_dir:ArtifactPath=None) -> 'PELTTask':
         """
         Factory method to create a bundle using a live target
 

--- a/lisa/tests/kernel/scheduler/misfit.py
+++ b/lisa/tests/kernel/scheduler/misfit.py
@@ -19,10 +19,11 @@ import pandas as pd
 
 from devlib.module.sched import SchedDomain
 
-from lisa.utils import memoized
+from lisa.utils import memoized, ArtifactPath
 from lisa.trace import Trace
 from lisa.wlgen.rta import Periodic
 from lisa.tests.kernel.test_bundle import RTATestBundle, Result, ResultBundle, CannotCreateError, TestMetric
+from lisa.env import TestEnv
 
 class MisfitMigrationBase(RTATestBundle):
     """
@@ -70,6 +71,16 @@ class MisfitMigrationBase(RTATestBundle):
         """
         HZ = te.target.sched.get_hz()
         return ((HZ * te.target.number_of_cpus) // 10) * (1. / HZ)
+
+    @classmethod
+    def from_testenv(cls, te:TestEnv, res_dir:ArtifactPath=None) -> 'MisfitMigrationBase':
+        """
+        Factory method to create a bundle using a live target
+
+        This will execute the rt-app workload described in
+        :meth:`~lisa.tests.kernel.test_bundle.RTATestBundle.get_rtapp_profile`
+        """
+        return super().from_testenv(te, res_dir)
 
 class StaggeredFinishes(MisfitMigrationBase):
     """

--- a/lisa/tests/kernel/test_bundle.py
+++ b/lisa/tests/kernel/test_bundle.py
@@ -397,15 +397,6 @@ class RTATestBundle(TestBundle, abc.ABC):
 
         return cls(res_dir, te.plat_info, rtapp_profile)
 
-    @classmethod
-    def from_testenv(cls, te:TestEnv, res_dir:ArtifactPath=None) -> 'RTATestBundle':
-        """
-        Factory method to create a bundle using a live target
-
-        This will execute the rt-app workload described in :meth:`get_rtapp_profile`
-        """
-        return super().from_testenv(te, res_dir)
-
     def test_slack(self, negative_slack_allowed_pct=15) -> ResultBundle:
         """
         Assert that the RTApp workload was given enough performance


### PR DESCRIPTION
* Refactor TestBundle and RTATestBundle to split the test aspects from
the from_testenv aspect. This is needed for some tests that create a
collection of bundles.

* Refactor the *Invariance test in load_tracking to enable test_slack
and avoid code duplication