### PR TITLE
utils: Avoid registering the class in ruaml.yaml

### DIFF
--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -78,9 +78,6 @@ class ActiveState(namedtuple('ActiveState', ['capacity', 'power'])):
     def __new__(cls, capacity=None, power=None):
         return super(ActiveState, cls).__new__(cls, capacity, power)
 
-    # helpers for yaml serialization
-    yaml_tag = 'em_active_state:capacity,power'
-
 class _CpuTree(Loggable):
     """Internal class. Abstract representation of a CPU topology.
 

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -108,13 +108,13 @@ def import_all_submodules(pkg):
     ]
 
 class UnknownTagPlaceholder:
-    def __init__(self, yaml_tag, data, location=None):
-        self.yaml_tag = yaml_tag
+    def __init__(self, tag, data, location=None):
+        self.tag = tag
         self.data = data
         self.location = location
 
     def __str__(self):
-        return '<UnknownTagPlaceholder of {}>'.format(self.yaml_tag)
+        return '<UnknownTagPlaceholder of {}>'.format(self.tag)
 
 class Serializable(Loggable):
     """
@@ -245,13 +245,6 @@ class Serializable(Loggable):
 
     @classmethod
     def _to_path(cls, instance, filepath, fmt):
-        # On Python >= 3.6, __init_subclass__ will take care of that
-        if sys.version_info < (3, 6):
-            # Better late than never. Doing it here avoids using a metaclass
-            # just to register the class. If we don't do that, yaml_tag class
-            # attribute will be ignored.
-            cls._yaml.register_class(type(instance))
-
         if fmt is None:
             fmt = cls.DEFAULT_SERIALIZATION_FMT
 
@@ -352,12 +345,6 @@ class Serializable(Loggable):
 
     def __deepcopy__(self):
        return super().__deepcopy__()
-
-   # Will only be called with Python >= 3.6
-    def __init_subclass__(cls, **kwargs):
-        # Register the class to ensure yaml_tag will be used
-        cls._yaml.register_class(cls)
-        super().__init_subclass__(**kwargs)
 
 Serializable._init_yaml()
 


### PR DESCRIPTION
Registering the class properly can only be done in a metaclass, which
would complicate the use of abc.ABC for example.

Also, not all classes are required to inherit from Serializable, which
means that many classes would not get the tag stability provided by
registering the class explicitely. Instead, the dotted name of the
classes are used.

Therefore, we avoid registering the class altogether, and will rely on
keeping stable class names when backward compatibilty is needed. That
can be done by keeping the old name available.

Existing yaml_tag class attributes are removed since they are no longer
exploited by ruamel.yaml