### PR TITLE
doc: Add a doc_requirements.txt for ReadTheDocs

### DIFF
--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -1,0 +1,16 @@
+# A streamlined version of devmode_requirements.txt for doc building
+
+# devlib before WA and LISA
+-e ./external/devlib/
+
+# TRAPpy before BART and LISA
+-e ./external/trappy/
+# BART before LISA
+-e ./external/bart/
+
+# WA before LISA
+-e ./external/workload-automation/
+-e ./[doc]
+
+-e ./tools/exekall
+-e ./tools/bisector


### PR DESCRIPTION
Commit f3c2fbc13a9b ("bisector: add dbus dependencies") added an
apt dependency that RtD cannot satisfy, so let's make a minimal
requirements file just for doc building.