### PR TITLE
doc/conf: Remove path setting

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -73,15 +73,6 @@ def patched_make_field(self, types, domain, items, env=None):
 
 TypedField.make_field = patched_make_field
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
-lisa_home = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../modules_root')
-sys.path.insert(0, lisa_home)
-for lib in ['lisa', 'devlib', 'trappy', 'bart']:
-    sys.path.insert(0, os.path.join(lisa_home, 'libs', lib))
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
Not only is this no longer needed, it broke ReadTheDocs.