### PR TITLE
doc/conf: Reintroduce sys.path setting

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -73,6 +73,11 @@ def patched_make_field(self, types, domain, items, env=None):
 
 TypedField.make_field = patched_make_field
 
+# This shouldn't be needed, as using a virtualenv + setup.py should set up the
+# sys.path correctly. However that seems to be half broken on ReadTheDocs, so
+# manually set it here
+sys.path.insert(0, os.path.abspath('../'))
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
e67cb1b31607 ("Merge pull request #658
from douglas-raillard-arm/lisa-next") broke ReadTheDocs, and while it
looked like it was due to some misuse of sys.path (which was removed
in ac2765933156 ("doc/conf: Remove path setting")), it looks like we
do need to play with sys.path to keep ReadTheDocs up and running.