### PR TITLE
eas_behaviour: Make TwoBigThreeSmallTask small task smaller

### DIFF
--- a/lisa/tests/kernel/scheduler/eas_behaviour.py
+++ b/lisa/tests/kernel/scheduler/eas_behaviour.py
@@ -476,7 +476,7 @@ class TwoBigThreeSmall(EASBehaviour):
     @classmethod
     def get_rtapp_profile(cls, te):
         # 50% of the smallest CPU's capacity
-        small_duty = cls.unscaled_utilization(cls.min_cpu_capacity(te), 50)
+        small_duty = cls.unscaled_utilization(cls.min_cpu_capacity(te), 25)
         # 80% of the biggest CPU's capacity
         big_duty = cls.unscaled_utilization(cls.max_cpu_capacity(te), 80)
 


### PR DESCRIPTION
Reduce to 25% of a LITTLE CPU instead of 50% to match more closely the
lisa legacy version of the test.