### PR TITLE
env: Fix TargetConf.to_map()

### DIFF
--- a/lisa/env.py
+++ b/lisa/env.py
@@ -170,7 +170,7 @@ class TargetConf(MultiSrcConf, HideExekallID):
         return cls(mapping)
 
     def to_map(self):
-        return dict(self._get_chainmap())
+        return dict(self._get_effective_map())
 
 class TestEnv(Loggable, HideExekallID):
     """


### PR DESCRIPTION
Use the current utils.MutliSrcConf API instead of an old one that has
been replaced.