### PR TITLE
lisa: Do some implicit notebook setup

### DIFF
--- a/lisa/__init__.py
+++ b/lisa/__init__.py
@@ -1,3 +1,16 @@
 from lisa.version import __version__
 
+# Put all the code inside one function, to allow easy cleanup of the namespace
+# at the end. We definitely don't want to expose these things to the outside
+# world
+def f():
+    import os
+    if os.getenv('LISA_DO_NOTEBOOK_SETUP'):
+        from lisa.utils import jupyter_notebook_setup
+        jupyter_notebook_setup()
+
+f()
+del f
+
+
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -49,6 +49,14 @@ The detected location of your LISA installation
 if not LISA_HOME:
     logging.getLogger(__name__).warning('LISA_HOME env var is not set, LISA may misbehave.')
 
+def jupyter_notebook_setup():
+    """
+    Function containing generic init boilerplate to be called at the beginning
+    of notebooks. This will be called automatically upon importing lisa if the
+    LISA_DO_NOTEBOOK_SETUP environment variable is set.
+    """
+    setup_logging()
+
 class Loggable:
     """
     A simple class for uniformly named loggers

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -308,7 +308,7 @@ function _lisa-jupyter-start {
     cd $PYDIR
     echo
     echo -n 'Notebook server task: '
-    nohup jupyter lab --ip="$IPADDR" --port="$PORT" \
+    LISA_DO_NOTEBOOK_SETUP=1 nohup jupyter lab --ip="$IPADDR" --port="$PORT" \
                       --NotebookApp.token="$TOKEN" \
                       >"$LOGFILE" 2>&1 &
     echo $! >"$PIDFILE"


### PR DESCRIPTION
When the lisa package is imported with LISA_DO_NOTEBOOK_SETUP
environment variable is set, some default setup code will be run. This
currently only calls utils.setup_logging() to save some boilerplate in
notebooks.