### PR TITLE
exekall: Allow user to point to package/__init__.py

### DIFF
--- a/tools/exekall/exekall/_utils.py
+++ b/tools/exekall/exekall/_utils.py
@@ -342,6 +342,16 @@ def find_customization_module_set(module_set):
 
 def import_file(python_src, module_name=None, is_package=False):
     python_src = pathlib.Path(python_src)
+
+    # Directly importing __init__.py does not really make much sense and may
+    # even break, so just import its package instead.
+    if python_src.name == '__init__.py':
+        return import_file(
+            python_src=python_src.parent,
+            module_name=module_name,
+            is_package=True
+        )
+
     if python_src.is_dir():
         is_package = True
 


### PR DESCRIPTION
Correctly import the enclosing package of __init__.py instead of trying
to import it as a regulard module. That can happen when using "**.py"
wildcard on a whole python package.