### PR TITLE
utils: Remove Serializable.__deepcopy__

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -412,9 +412,6 @@ class Serializable(Loggable):
        """
        return super().__copy__()
 
-    def __deepcopy__(self):
-       return super().__deepcopy__()
-
 Serializable._init_yaml()
 
 class SerializableConfABC(Serializable, abc.ABC):


### PR DESCRIPTION
Since it had a missing parameter and no implementation on super(), just
remove it. We can revisit that if state lost during serialization is not
acceptable when doing deep copies.