### PR TITLE
conf: Introduce derived configuration keys

### DIFF
--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -192,7 +192,7 @@ class KeyDesc(KeyDescBase):
             prefix=prefix,
             key=self.name,
             classinfo=' or '.join(
-                self._get_cls_name(key_cls, style='rst')
+                self._get_cls_name(key_cls, style=style)
                 for key_cls in self.classinfo
             ),
             help=': ' + self.help if self.help else ''
@@ -278,7 +278,8 @@ class LevelKeyDesc(KeyDescBase, Mapping):
         # of nested list avoids getting extra blank line between list items.
         # That prevents ResStructuredText from thinking each item must be a
         # paragraph.
-        suffix = '\n\n..\n\n' + idt if style == 'rst' else '\n'
+        suffix = '\n\n..\n\n' if style == 'rst' else '\n'
+        suffix += idt
         help_ = '{prefix} {key}:{help}{suffix}'.format(
             prefix=prefix,
             suffix=suffix,

--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -622,9 +622,8 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
         key_desc = self._structure[key]
         if isinstance(key_desc, LevelKeyDesc):
             key = key_desc.qualname
-            raise ValueError('Cannot force source of the sub-level "{key}" in {cls}'.format(
+            raise ValueError('Cannot force source of the sub-level "{key}"'.format(
                 key=key,
-                cls=type(self).__qualname__
             ), key)
 
         # None means removing the src override for that key
@@ -828,9 +827,8 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
         key_desc = self._structure[key]
         if isinstance(key_desc, LevelKeyDesc):
             key = key_desc.qualname
-            raise ValueError('Key "{key}" is a nested configuration level in {cls}, it does not have a source on its own.'.format(
+            raise ValueError('Key "{key}" is a nested configuration level, it does not have a source on its own.'.format(
                 key=key,
-                cls=type(self).__qualname__,
             ), key)
 
         return OrderedDict(

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -504,4 +504,53 @@ def deduplicate(seq, keep_last=True, key=lambda x: x):
     )
     return list(reorder(dedup.values()))
 
+def get_nested_key(mapping, key_path):
+    """
+    Get a key in a nested mapping
+
+    :param mapping: The mapping to lookup in
+    :type mapping: collections.abc.Mapping
+
+    :param key_path: Path to the key in the mapping, in the form of a list of
+        keys.
+    :type key_path: list
+    """
+    if not key_path:
+        return mapping
+    for key in key_path[:-1]:
+        mapping = mapping[key]
+    return mapping[key_path[-1]]
+
+def set_nested_key(mapping, key_path, val, level=None):
+    """
+    Set a key in a nested mapping
+
+    :param mapping: The mapping to update
+    :type mapping: collections.abc.MutableMapping
+
+    :param key_path: Path to the key in the mapping, in the form of a list of
+        keys.
+    :type key_path: list
+
+    :param level: Factory used when creating a level is needed. By default,
+        ``type(mapping)`` will be called without any parameter.
+    :type level: collections.abc.Callable
+    """
+    assert key_path
+
+    if level is None:
+        # This should work for dict and most basic structures
+        level = type(mapping)
+
+    for key in key_path[:-1]:
+        try:
+            mapping = mapping[key]
+        except KeyError:
+            new_level = level()
+            mapping[key] = new_level
+            mapping = new_level
+
+    mapping[key_path[-1]] = val
+
+
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab


### PR DESCRIPTION
* Allow using a key that is purely defined in term of other keys. That key cannot be added from a source, and is not shown when iterating over the `MultiSrcConf` instance. This avoids inconsistencies when adding it back as a source for example.

* minor cleanup in conf-related classes