### PR TITLE
setup.py: Update needed version of ruamel.yaml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "matplotlib >= 1.4.2",
         "pandas >= 0.23.0",
         "numpy",
-        "ruamel.yaml >= 0.15.72",
+        "ruamel.yaml >= 0.15.81",
 
         # Depdendencies that are shipped as part of the LISA repo as
         # subtree/submodule

--- a/tools/exekall/setup.py
+++ b/tools/exekall/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         # Older versions will have troubles with serializing complex nested
         # objects hierarchy implementing custom __getstate__ and __setstate__
-        "ruamel.yaml >= 0.15.72",
+        "ruamel.yaml >= 0.15.81",
     ],
 
     classifiers=[


### PR DESCRIPTION
Since we removed a workaround that has been merged upstream, we need to
bump the required version of ruamel.yaml.