### PR TITLE
Fix wa_results_collector + wltests notebook, get last master changes

### DIFF
--- a/ipynb/wltests/sched-evaluation-full.ipynb
+++ b/ipynb/wltests/sched-evaluation-full.ipynb
@@ -14,23 +14,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from conf import LisaLogging\n",
-    "LisaLogging.setup()"
+    "from lisa.utils import setup_logging\n",
+    "setup_logging()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import logging\n",
+    "import pandas as pd\n",
+    "\n",
     "from IPython.display import display\n",
     "\n",
-    "from wa_results_collector import WaResultsCollector\n",
-    "import pandas as pd\n",
+    "from lisa.wa_results_collector import WaResultsCollector\n",
     "\n",
     "%pylab inline"
    ]
@@ -253,9 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Get Geekbench scores\n",
@@ -263,11 +260,11 @@
     "gb_scores_db = df[df.test == 'geekbench']\n",
     "\n",
     "# Group scores\n",
-    "grouped_df = gb_scores_db.groupby(['test', 'tag', 'kernel', 'metric'])\n",
+    "grouped_df = gb_scores_db.groupby(['test', 'kernel', 'metric'])\n",
     "\n",
     "# Get stats for grouped scores\n",
-    "stats_df = pd.DataFrame(grouped_df.describe(percentiles=[.95, .99]))\n",
-    "stats_df = stats_df.reset_index().rename(columns={'level_4': 'stats'})"
+    "stats_df = pd.DataFrame(grouped_df.value.describe(percentiles=[.95, .99])).reset_index()\n",
+    "#stats_df = stats_df.reset_index().rename(columns={'level_4': 'stats'})"
    ]
   },
   {
@@ -280,12 +277,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
-    "single_score_df = stats_df[stats_df.metric.str.match('Single.*')][['metric', 'kernel', 'stats', 'value']]\n",
-    "single_score_df['metric'] = single_score_df.metric.apply(lambda s : s.replace('Single-Core_', '').replace('_score', ''))\n",
-    "single_score_df = single_score_df.set_index(['metric', 'kernel', 'stats']).unstack()\n",
+    "single_score_df = stats_df[stats_df.metric.str.match(\"Single.*\")]\n",
+    "single_score_df.loc[:, \"metric\"] = single_score_df.metric.apply(lambda s : s.replace('Single-Core_', '').replace('_score', ''))\n",
+    "single_score_df = single_score_df.set_index(['kernel', 'test', 'metric'])\n",
     "logging.info(\"Detailed SINGLE core scores:\")\n",
     "single_score_df"
    ]
@@ -303,10 +302,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "multi_score_df = stats_df[stats_df.metric.str.match('Multi.*')][['metric', 'kernel', 'stats', 'value']]\n",
-    "multi_score_df['metric'] = multi_score_df.metric.apply(lambda s : s.replace('Multi-Core_', '').replace('_score', ''))\n",
-    "multi_score_df = multi_score_df.set_index(['metric', 'kernel', 'stats']).unstack()\n",
-    "logging.info(\"Detailed SINGLE core scores:\")\n",
+    "multi_score_df = stats_df[stats_df.metric.str.match(\"Multi.*\")]\n",
+    "multi_score_df.loc[:, \"metric\"] = multi_score_df.metric.apply(lambda s : s.replace('Multi-Core_', '').replace('_score', ''))\n",
+    "multi_score_df = multi_score_df.set_index(['kernel', 'test', 'metric'])\n",
+    "logging.info(\"Detailed MULTI core scores:\")\n",
     "multi_score_df"
    ]
   },
@@ -350,11 +349,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "scrolled": true
    },
    "outputs": [],
    "source": [
-    "# Get Geekbench scores\n",
+    "# Get PCMark scores\n",
     "df = collector.results_df\n",
     "pm_scores_db = df[df.workload == 'pcmark']\n",
     "\n",
@@ -362,8 +361,7 @@
     "grouped_df = pm_scores_db.groupby(['test', 'tag', 'kernel', 'metric'])\n",
     "\n",
     "# Get stats for grouped scores\n",
-    "stats_df = pd.DataFrame(grouped_df.describe(percentiles=[.95, .99]))\n",
-    "stats_df = stats_df.reset_index().rename(columns={'level_4': 'stats'})"
+    "stats_df = pd.DataFrame(grouped_df.value.describe(percentiles=[.95, .99])).reset_index()"
    ]
   },
   {
@@ -372,9 +370,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pm_score_df = stats_df[stats_df.metric.str.match('pcmark_.*')][['metric', 'kernel', 'stats', 'value']]\n",
-    "pm_score_df['metric'] = pm_score_df.metric.apply(lambda s : s.replace('pcmark_', ''))\n",
-    "pm_score_df = pm_score_df.set_index(['metric', 'kernel', 'stats']).unstack()\n",
+    "pm_score_df = stats_df[stats_df.metric.str.match('pcmark_.*')]\n",
+    "pm_score_df.loc[:, 'metric'] = pm_score_df.metric.apply(lambda s : s.replace('pcmark_', ''))\n",
+    "pm_score_df = pm_score_df.set_index(['kernel', 'test'])\n",
     "logging.info(\"Detailed scores:\")\n",
     "pm_score_df"
    ]
@@ -418,21 +416,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   },
   "toc": {
    "colors": {

--- a/lisa/wa_results_collector.py
+++ b/lisa/wa_results_collector.py
@@ -162,11 +162,11 @@ class WaResultsCollector(Loggable):
         df = df.append(df_list)
 
         kernel_refs = {}
-        if kernel_repo_path:
-            for sha1 in df['kernel_sha1'].unique():
-                ref = find_shortest_symref(kernel_repo_path, sha1)
-                if ref:
-                    kernel_refs[sha1] = ref
+        for sha1 in df['kernel_sha1'].unique():
+            if kernel_repo_path:
+                kernel_refs[sha1] = find_shortest_symref(kernel_repo_path, sha1) or sha1
+            else:
+                kernel_refs[sha1] = sha1
 
         common_prefix = os.path.commonprefix(list(kernel_refs.values()))
         for sha1, ref in kernel_refs.items():

--- a/lisa/wa_results_collector.py
+++ b/lisa/wa_results_collector.py
@@ -1134,7 +1134,7 @@ class WaResultsCollector(Loggable):
                 # For each of the things we're comparing we'll plot a bar chart
                 # but slightly shifted. That's how we get multiple bars on each
                 # y-axis point.
-                bars = ax.barh(bottom=pos + (i * thickness),
+                bars = ax.barh(pos + (i * thickness),
                                width=gdf['diff_pct'],
                                height=thickness, label=group,
                                color=colors[i % len(colors)], align='center')

--- a/lisa/wa_results_collector.py
+++ b/lisa/wa_results_collector.py
@@ -1083,7 +1083,7 @@ class WaResultsCollector(Loggable):
             return
 
         # Separate plot for each test (e.g. one plot for Jankbench list_view)
-        for (test, inv_id), test_comparisons in df.groupby(('test', 'inv_id')):
+        for (test, inv_id), test_comparisons in df.groupby(['test', 'inv_id']):
             # Vertical size of plot depends on how many metrics we're comparing
             # and how many things (kernels/tags) we're comparing metrics for.
             # a.k.a the total length of the comparisons df.

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -396,7 +396,7 @@ EOF
 
     # Check for required external dependencies
 
-    if which realpath &>/dev/null; then
+    if ! which realpath &>/dev/null; then
 cat <<EOF
 ERROR: this script requires the realpath binary!
 
@@ -410,7 +410,7 @@ EOF
 function lisa-wltest-series {
     # Ensure the wltest environment has been configured, and get the relative
     # patch loaded in the environment
-    lisa-wltest-init || exit -1
+    lisa-wltest-init || return -1
 
     # Run the build's provided test_series
     $WLTEST_HOME/test_series "$@"

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -380,7 +380,6 @@ function lisa-test {
 function lisa-wltest-init {
     export WLTEST_HOME="$LISA_HOME/tools/wltests"
     export WA_USER_DIRECTORY="$LISA_HOME/tools/wa_user_directory"
-    lisa-venv-activate
 
     # Check that the environment is properly configured
     if [[ -z "$ANDROID_HOME" ]]; then

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -258,9 +258,9 @@ function _lisa-jupyter-start {
     IPADDR=
 
     if [[ -x /sbin/ifconfig ]]; then
-        IPADDR=$(/sbin/ifconfig $NETIF 2>/dev/null  | \
-            awk '/inet / {print $2}' | \
-            sed 's/addr://')
+	IPADDR=$(/sbin/ifconfig $NETIF 2>/dev/null  | \
+	    awk '/inet / {print $2}' | \
+	    grep -Eo [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)
     fi
 
     if [[ -z "$IPADDR" && -x /sbin/ip ]]; then

--- a/tools/wltests/agendas/example-exoplayer-simple.yaml
+++ b/tools/wltests/agendas/example-exoplayer-simple.yaml
@@ -7,3 +7,5 @@
 workloads:
   - name: exoplayer
     iterations: 3
+    workload_parameters:
+      version: 2.4

--- a/tools/wltests/agendas/example-rich.yaml
+++ b/tools/wltests/agendas/example-rich.yaml
@@ -53,10 +53,13 @@ workloads:
   - name: exoplayer
     id: exoplayer_30s
     workload_parameters:
+      version: 2.4
       duration: 30
 
   - name: pcmark
     id: pcmark
+    runtime_parameters:
+      airplane_mode: false
 
   - name: geekbench
     id: geekbench
@@ -69,31 +72,31 @@ workloads:
     # easier to read/parse
     id: jb_list_view
     classifiers:
-      test: jb_list_view
+      test_ids: jb_list_view
     # workload_parameters are the real parameters that influence what gets run
     workload_parameters:
-      test: list_view
+      test_ids: list_view
   - name: jankbench
     id: jb_image_list_view
     classifiers:
-      test: jb_image_list_view
+      test_ids: jb_image_list_view
     workload_parameters:
-      test: image_list_view
+      test_ids: image_list_view
   - name: jankbench
     id: jb_shadow_grid
     classifiers:
-      test: jb_shadow_grid
+      test_ids: jb_shadow_grid
     workload_parameters:
-      test: shadow_grid
+      test_ids: shadow_grid
   - name: jankbench
     id: jb_low_hitrate_text
     classifiers:
-      test: jb_low_hitrate_text
+      test_ids: jb_low_hitrate_text
     workload_parameters:
-      test: low_hitrate_text
+      test_ids: low_hitrate_text
   - name: jankbench
     id: jb_edit_text
     classifiers:
-      test: jb_edit_text
+      test_ids: jb_edit_text
     workload_parameters:
-      test: edit_text
+      test_ids: edit_text

--- a/tools/wltests/agendas/sched-evaluation-full-traced.yaml
+++ b/tools/wltests/agendas/sched-evaluation-full-traced.yaml
@@ -57,6 +57,7 @@ workloads:
     classifiers:
        tag: mov_720p_30s
     workload_parameters:
+      version: 2.4
       format: "mov_720p"
       duration: 30
       landscape: True
@@ -67,6 +68,7 @@ workloads:
     classifiers:
        tag: ogg_128kbps_30s
     workload_parameters:
+      version: 2.4
       format: "ogg_128kbps"
       duration: 30
 
@@ -78,6 +80,8 @@ workloads:
     classifiers:
        tag: single
     iterations: 10
+    runtime_parameters:
+      airplane_mode: false
 
 ################################################################################
 # Geekbench
@@ -98,7 +102,7 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: list_view
+      test_ids: list_view
     iterations: 30
 
   - name: jankbench
@@ -106,7 +110,7 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: image_list_view
+      test_ids: image_list_view
     iterations: 30
 
   - name: jankbench
@@ -114,7 +118,7 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: shadow_grid
+      test_ids: shadow_grid
     iterations: 30
 
   - name: jankbench
@@ -122,7 +126,7 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: low_hitrate_text
+      test_ids: low_hitrate_text
     iterations: 30
 
   - name: jankbench
@@ -130,5 +134,5 @@ workloads:
     classifiers:
       tag: iter_30
     workload_parameters:
-      test: edit_text
+      test_ids: edit_text
     iterations: 30

--- a/tools/wltests/agendas/sched-evaluation-full.yaml
+++ b/tools/wltests/agendas/sched-evaluation-full.yaml
@@ -80,6 +80,8 @@ workloads:
     classifiers:
        tag: single
     iterations: 10
+    runtime_parameters:
+      airplane_mode: false
 
 ################################################################################
 # Geekbench

--- a/tools/wltests/agendas/sched-evaluation-small.yaml
+++ b/tools/wltests/agendas/sched-evaluation-small.yaml
@@ -57,6 +57,7 @@ workloads:
     classifiers:
        tag: mov_720p_3s
     workload_parameters:
+      version: 2.4
       format: "mov_720p"
       duration: 3
       landscape: True
@@ -67,6 +68,7 @@ workloads:
     classifiers:
        tag: ogg_128kbps_3s
     workload_parameters:
+      version: 2.4
       format: "ogg_128kbps"
       duration: 3
 
@@ -78,6 +80,8 @@ workloads:
     classifiers:
        tag: iter_5
     iterations: 5
+    runtime_parameters:
+      airplane_mode: false
 
 ################################################################################
 # Geekbench
@@ -98,7 +102,7 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: list_view
+      test_ids: list_view
     iterations: 3
 
   - name: jankbench
@@ -106,7 +110,7 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: image_list_view
+      test_ids: image_list_view
     iterations: 3
 
   - name: jankbench
@@ -114,7 +118,7 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: shadow_grid
+      test_ids: shadow_grid
     iterations: 3
 
   - name: jankbench
@@ -122,7 +126,7 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: low_hitrate_text
+      test_ids: low_hitrate_text
     iterations: 3
 
   - name: jankbench
@@ -130,5 +134,5 @@ workloads:
     classifiers:
       tag: iter_3
     workload_parameters:
-      test: edit_text
+      test_ids: edit_text
     iterations: 3


### PR DESCRIPTION
I had a geekbench wltests folder somewhere, so I used that to test the collector & notebook.

While at it, carry over the last few fixes that went into master that we didn't get in next.

closes https://github.com/ARM-software/lisa/issues/702