### PR TITLE
[RFC] tools: post-checkout: Fix git hook

### DIFF
--- a/tools/post-checkout
+++ b/tools/post-checkout
@@ -26,5 +26,8 @@ IS_BRANCH_CHECKOUT=$3
 
 if which check-setuppy >/dev/null 2>&1; then
     check-setuppy --current-rev "$NEW_HEAD"
+    # Make sure we always exit with 0 return code, otherwise it might break
+    # rebasing
+    exit 0
 fi
 


### PR DESCRIPTION
post-checkout hook can break interactive rebase when returning a
non-zero code.

Still need to investigate a bit why this happens, since it's not clear from the git documentation (after quick reading, I may have missed some details):
https://git-scm.com/docs/githooks