### PR TITLE
Unify invariance tests

### DIFF
--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -29,7 +29,7 @@ from lisa.platforms.platinfo import PlatformInfo
 from lisa.utils import HideExekallID, Loggable, ArtifactPath, get_subclasses, groupby, Serializable
 from lisa.conf import MultiSrcConf
 from lisa.tests.base import TestBundle, ResultBundle
-from lisa.tests.scheduler.load_tracking import FreqInvarianceItem
+from lisa.tests.scheduler.load_tracking import InvarianceItem
 from lisa.regression import compute_regressions
 
 from exekall.utils import get_name
@@ -283,11 +283,11 @@ class LISAAdaptor(AdaptorBase):
             tags['board'] = value.target_conf.get('name')
         elif isinstance(value, PlatformInfo):
             tags['board'] = value.get('name')
+        elif isinstance(value, InvarianceItem):
+            if value.cpu is not None:
+                tags['cpu'] = '{}@{}'.format(value.cpu, value.freq)
         elif isinstance(value, TestBundle):
             tags['board'] = value.plat_info.get('name')
-            if isinstance(value, FreqInvarianceItem):
-                if value.cpu is not None:
-                    tags['cpu'] = '{}@{}'.format(value.cpu, value.freq)
         else:
             tags = super().get_tags(value)
 


### PR DESCRIPTION
Unify CPU invariance and frequency invariance. The rational is:

* simplify the hierarchy of class in the test, and simplify the signature of functions by removing some defaults that are not always used depending on the execution path.
* Avoid misleading assumptions: if CPU invariance fail, that could just mean that invariance is broken for the highest frequency, since working freq invariance is a hardcoded assumption in the CPU invariance test. The new layout allows unbiased access to data.
* Allow running the test for any combination of CPU and frequency without arbitrary constraint
* The previous point also means that some duplicated was removed

Also, make sure only one set of InvarianceItem is collected and use that for both the aggregated and non-aggregated version of each test method.