### PR TITLE
doc: Make conf.py friendlier to RTD

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,6 +26,12 @@ from docutils import nodes
 from sphinx.util.docfields import TypedField
 from sphinx import addnodes
 
+# This shouldn't be needed, as using a virtualenv + setup.py should set up the
+# sys.path correctly. However that seems to be half broken on ReadTheDocs, so
+# manually set it here
+sys.path.insert(0, os.path.abspath('../'))
+
+# Import our packages after modifying sys.path
 import lisa
 
 # This ugly hack is required because by default TestCase.__module__ is
@@ -75,11 +81,6 @@ def patched_make_field(self, types, domain, items, env=None):
     return nodes.field('', fieldname, fieldbody)
 
 TypedField.make_field = patched_make_field
-
-# This shouldn't be needed, as using a virtualenv + setup.py should set up the
-# sys.path correctly. However that seems to be half broken on ReadTheDocs, so
-# manually set it here
-sys.path.insert(0, os.path.abspath('../'))
 
 # -- General configuration ------------------------------------------------
 

--- a/external/devlib/devlib/bin/scripts/shutils.in
+++ b/external/devlib/devlib/bin/scripts/shutils.in
@@ -271,9 +271,7 @@ read_tree_tgz_b64() {
     # 'tar' doesn't work as expected on debugfs, so copy the tree first to
     # workaround the issue
     cd $BASEPATH
-    for CUR_FILE in $($BUSYBOX find . -follow -type f -maxdepth $MAXDEPTH); do
-        $BUSYBOX cp --parents $CUR_FILE $TMP_FOLDER/ 2> /dev/null
-    done
+	$BUSYBOX find . -follow -type f -maxdepth $MAXDEPTH -print0 | $BUSYBOX xargs -0 -I '{}' -n 999999 $BUSYBOX cp --parents '{}' $TMP_FOLDER/ 2> /dev/null
 
     cd $TMP_FOLDER
     $BUSYBOX tar cz * 2>/dev/null | $BUSYBOX base64


### PR DESCRIPTION
Since RTD fails to import lisa for unknown reason, even if it shares the
same venv, move the sys.path update before `import lisa`.