### PR TITLE
travis: check for commits touching external

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,17 @@ git:
   depth: 1000
 
 sudo: required
-language: python
-python:
-  - "3.5"
+# Use "generic" language to avoid having a virtualenv created for Python by default
+language: generic
+
 # Ubuntu Xenial 16.04 (latest version we can have on Travis)
 # https://docs.travis-ci.com/user/reference/overview/
 dist: xenial
 
 install:
-  - echo "$(python3 --version)"
   - cd "$TRAVIS_BUILD_DIR"
   - sudo ./install_base_ubuntu.sh
+  - echo "$(python3 --version)"
 
 script:
   - cd "$TRAVIS_BUILD_DIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ install:
   - echo "$(python3 --version)"
   - cd "$TRAVIS_BUILD_DIR"
   - sudo ./install_base_ubuntu.sh
-  # This will trigger the creation of a venv and install everything that is needed
-  - source init_env
 
 script:
   - cd "$TRAVIS_BUILD_DIR"
-  - env -i bash ./tools/scripts/travis_tests.sh
+  - bash ./tools/scripts/travis_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 
+git:
+  # make sure we have all relevant commits for subtree modif detection
+  depth: 1000
+
 sudo: required
 language: python
 python:

--- a/install_base_ubuntu.sh
+++ b/install_base_ubuntu.sh
@@ -71,8 +71,8 @@ apt-get update
 # venv is not installed by default on Ubuntu, even though it is part of the
 # Python standard library
 apt-get -y install build-essential git wget expect kernelshark \
-	python3 python3-pip python3-venv python3-tk gobject-introspection \
-	libcairo2-dev libgirepository1.0-dev gir1.2-gtk-3.0
+    python3 python3-pip python3-venv python3-setuptools python3-tk \
+    gobject-introspection libcairo2-dev libgirepository1.0-dev gir1.2-gtk-3.0
 
 install_nodejs
 

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -74,7 +74,7 @@ function lisa-help {
 }
 
 function lisa-version {
-cat << EOF
+cat <<EOF
 LISA version:
     $LISA_HOME
     branch: $(git -C "$LISA_HOME" describe --all)
@@ -203,7 +203,7 @@ function lisa-install {
     # system's site-packages location. This ensures we use up to date packages,
     # and that the installation process will give the same result on all
     # machines at a given point in time.
-    (cd "$LISA_HOME" && _lisa-python -m pip install -r "$LISA_HOME/$requirements" "$@")
+    (cd "$LISA_HOME" && _lisa-python -m pip install --no-cache-dir -r "$LISA_HOME/$requirements" "$@")
 
     local custom_requirements="$LISA_HOME/custom_requirements.txt"
     if [[ -e "$custom_requirements" ]]; then

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -179,11 +179,11 @@ function lisa-install {
     # cannot be installed using pip in a venv
     _lisa-python "$LISA_HOME/setup.py" systemcheck
 
-    # Record the point in time when we ran that install command
-    (cd "$LISA_HOME" && check-setuppy --update-recorded-commit HEAD)
-
     _lisa-venv-create &&
     _lisa-upgrade-pip || return 1
+
+    # Record the point in time when we ran that install command
+    (cd "$LISA_HOME" && check-setuppy --update-recorded-commit HEAD)
 
     if [[ "$LISA_DEVMODE" == 1 ]]; then
         # This set of requirements will install all the shipped dependencies

--- a/tools/scripts/travis_tests.sh
+++ b/tools/scripts/travis_tests.sh
@@ -20,9 +20,6 @@
 # Script run by Travis. It is mostly a workaround for Travis inability to
 # correctly handle environment variable set in sourced scripts.
 
-# Failing commands will make the script return with an error code
-set -e
-
 illegal_location="external/"
 illegal_commits=$(find "$illegal_location" -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 git log --no-merges --oneline)
 
@@ -31,7 +28,12 @@ if [[ -n "$illegal_commits" ]]; then
     exit 1
 fi;
 
-source init_env
+# Some commands are allowed to fail in init_env, e.g. to probe for installed
+# tools. However, the overall script has to succeed.
+source init_env || exit 1
+
+# Failing commands will make the script return with an error code
+set -e
 
 echo "Starting nosetests ..."
 python3 -m nose

--- a/tools/scripts/travis_tests.sh
+++ b/tools/scripts/travis_tests.sh
@@ -20,10 +20,18 @@
 # Script run by Travis. It is mostly a workaround for Travis inability to
 # correctly handle environment variable set in sourced scripts.
 
-source init_env
-
 # Failing commands will make the script return with an error code
 set -e
+
+illegal_location="external/"
+illegal_commits=$(find "$illegal_location" -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 git log --no-merges --oneline)
+
+if [[ -n "$illegal_commits" ]]; then
+    echo -e "The following commits are touching $illegal_location, which is not allowed apart from updates:\n$illegal_commits"
+    exit 1
+fi;
+
+source init_env
 
 echo "Starting nosetests ..."
 python3 -m nose


### PR DESCRIPTION
This still allows merge commits touching that location. The squashed
commit produced by git subtree is fine since it does not refer to
"external/" (path rewriting is done in the merge commit).

Also fixes various Travis issues.