### PR TITLE
Update devlib and the EM debugfs loader

### DIFF
--- a/external/devlib/devlib/bin/scripts/shutils.in
+++ b/external/devlib/devlib/bin/scripts/shutils.in
@@ -255,6 +255,28 @@ sched_get_kernel_attributes() {
 # Misc
 ################################################################################
 
+read_tree_values() {
+    BASEPATH=$1
+    MAXDEPTH=$2
+
+    if [ ! -e $BASEPATH ]; then
+        echo "ERROR: $BASEPATH does not exist"
+        exit 1
+    fi
+
+    PATHS=$($BUSYBOX find $BASEPATH -follow -maxdepth $MAXDEPTH)
+    i=0
+    for path in $PATHS; do
+        i=$(expr $i + 1)
+        if [ $i -gt 1 ]; then
+            break;
+        fi
+    done
+    if [ $i -gt 1 ]; then
+        $BUSYBOX grep -s '' $PATHS
+    fi
+}
+
 read_tree_tgz_b64() {
     BASEPATH=$1
     MAXDEPTH=$2
@@ -352,6 +374,9 @@ ftrace_get_function_stats)
     ;;
 hotplug_online_all)
 	hotplug_online_all
+    ;;
+read_tree_values)
+	read_tree_values $*
     ;;
 read_tree_tgz_b64)
 	read_tree_tgz_b64 $*

--- a/external/devlib/devlib/module/hwmon.py
+++ b/external/devlib/devlib/module/hwmon.py
@@ -137,7 +137,7 @@ class HwmonModule(Module):
         self.scan()
 
     def scan(self):
-        values_tree = self.target.read_tree_values(self.root, depth=3)
+        values_tree = self.target.read_tree_values(self.root, depth=3, tar=True)
         for entry_id, fields in values_tree.items():
             path = self.target.path.join(self.root, entry_id)
             name = fields.pop('name', None)

--- a/external/devlib/doc/target.rst
+++ b/external/devlib/doc/target.rst
@@ -346,7 +346,7 @@ Target
        some sysfs entries silently failing to set the written value without
        returning an error code.
 
-.. method:: Target.read_tree_values(path, depth=1, dictcls=dict):
+.. method:: Target.read_tree_values(path, depth=1, dictcls=dict, [, tar [, decode_unicode [, strip_null_char ]]]):
 
    Read values of all sysfs (or similar) file nodes under ``path``, traversing
    up to the maximum depth ``depth``.
@@ -358,9 +358,18 @@ Target
    value is a dict-line object  with a key for every entry under ``path``
    mapping onto its value or further dict-like objects as appropriate.
 
+   Although the default behaviour should suit most users, it is possible to
+   encounter issues when reading binary files, or files with colons in their
+   name for example. In such cases, the ``tar`` parameter can be set to force a
+   full archive of the tree using tar, hence providing a more robust behaviour.
+   This can, however, slow down the read process significantly.
+
    :param path: sysfs path to scan
    :param depth: maximum depth to descend
    :param dictcls: a dict-like type to be used for each level of the hierarchy.
+   :param tar: the files will be read using tar rather than grep
+   :param decode_unicode: decode the content of tar-ed files as utf-8
+   :param strip_null_char: remove null chars from utf-8 decoded files
 
 .. method:: Target.read_tree_values_flat(path, depth=1):
 

--- a/external/workload-automation/wa/framework/target/info.py
+++ b/external/workload-automation/wa/framework/target/info.py
@@ -53,9 +53,9 @@ def kernel_version_from_pod(pod):
 
 def kernel_config_from_pod(pod):
     config = KernelConfig('')
-    config._config = pod['kernel_config']
+    config.typed_config._config = pod['kernel_config']
     lines = []
-    for key, value in config._config.items():
+    for key, value in config.items():
         if value == 'n':
             lines.append('# {} is not set'.format(key))
         else:
@@ -313,7 +313,7 @@ def cache_target_info(target_info, overwrite=False):
 
 class TargetInfo(Podable):
 
-    _pod_serialization_version = 2
+    _pod_serialization_version = 3
 
     @staticmethod
     def from_pod(pod):
@@ -400,4 +400,12 @@ class TargetInfo(Podable):
     def _pod_upgrade_v2(pod):
         pod['page_size_kb'] = pod.get('page_size_kb')
         pod['_pod_version'] = pod.get('format_version', 0)
+        return pod
+
+    @staticmethod
+    def _pod_upgrade_v3(pod):
+        config = {}
+        for key, value in pod['kernel_config'].items():
+            config[key.upper()] = value
+        pod['kernel_config'] = config
         return pod

--- a/external/workload-automation/wa/framework/workload.py
+++ b/external/workload-automation/wa/framework/workload.py
@@ -73,7 +73,7 @@ class Workload(TargetedPlugin):
 
         supported_platforms = getattr(self, 'supported_platforms', [])
         if supported_platforms and self.target.os not in supported_platforms:
-            msg = 'Supported platforms for "{}" are "{}", attemping to run on "{}"'
+            msg = 'Supported platforms for "{}" are "{}", attempting to run on "{}"'
             raise WorkloadError(msg.format(self.name, ' '.join(self.supported_platforms),
                                            self.target.os))
 

--- a/external/workload-automation/wa/output_processors/postgresql.py
+++ b/external/workload-automation/wa/output_processors/postgresql.py
@@ -206,7 +206,7 @@ class PostgresqlResultProcessor(OutputProcessor):
                 target_pod['sched_features'],
                 target_pod['page_size_kb'],
                 # Android Specific
-                target_pod.get('screen_resolution'),
+                list(target_pod.get('screen_resolution')),
                 target_pod.get('prop'),
                 target_pod.get('android_id'),
                 target_pod.get('pod_version'),

--- a/external/workload-automation/wa/workloads/manual/__init__.py
+++ b/external/workload-automation/wa/workloads/manual/__init__.py
@@ -85,7 +85,7 @@ class ManualWorkload(Workload):
     def run(self, context):
         self.logger.info('START NOW!')
         if self.duration:
-            self.device.sleep(self.duration)
+            self.target.sleep(self.duration)
         elif self.user_triggered:
             self.logger.info('')
             self.logger.info('hit any key to end your workload execution...')

--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -873,7 +873,7 @@ class EnergyModel(Serializable, Loggable):
         pd_attr = defaultdict(dict)
         cpu_to_pd = {}
 
-        debugfs_em = target.read_tree_values(directory, depth=3)
+        debugfs_em = target.read_tree_values(directory, depth=3, tar=True)
         if not debugfs_em:
             raise TargetStableError('Energy Model not exposed at {} in sysfs.'.format(directory))
 


### PR DESCRIPTION
The recent change to devlib's read_tree_values() API involve to fix the debugfs EM loader we have in Lisa. This PR does both at the same time.