### PR TITLE
bisector: do not optimize Pickle output for -oexport-db

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -2332,7 +2332,7 @@ class ExekallLISATestStep(ShellStep):
                 db_list.append(existing_db)
 
             merged_db = ValueDB.merge(db_list)
-            merged_db.to_path(export_db)
+            merged_db.to_path(export_db, optimize=False)
 
         return out
 


### PR DESCRIPTION
Since that DB is typically not reused a lot, it is pointless to spend
time optimizing it, as it can take a non-negligible amount of time.