### PR TITLE
Fix wlgen Ramp

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -63,6 +63,26 @@ class Loggable:
             name += '.' + suffix
         return logging.getLogger(name)
 
+    @classmethod
+    def log_locals(cls, var_names=None, level='debug'):
+        """
+        Debugging aid: log the local variables of the calling function
+
+        :param var_names: List of variable names to display, or all of them if
+            left to default.
+        :type var_names: list(str)
+
+        :param level: log level to use.
+        :type level: str
+        """
+        level = getattr(logging, level.upper())
+        call_frame = sys._getframe(1)
+
+        for name, val in call_frame.f_locals.items():
+            if var_names and name not in var_names:
+                continue
+            cls.get_logger().log(level, 'Local variable: {}: {}'.format(name, val))
+
 def get_subclasses(cls, cls_set=None):
     """Get all indirect subclasses of the class."""
     if cls_set is None:

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -559,20 +559,19 @@ class Ramp(RTATask):
                  priority=None, cpus=None):
         super(Ramp, self).__init__(delay_s, loops, sched_policy, priority)
 
-        if start_pct not in list(range(0, 101)) or end_pct not in list(range(0, 101)):
+        if not (0 <= start_pct <= 100 and 0 <= end_pct <= 100):
             raise ValueError('start_pct and end_pct must be in [0..100] range')
 
-        if start_pct >= end_pct:
-            if delta_pct > 0:
-                delta_pct = -delta_pct
-            delta_adj = -1
-        if start_pct <= end_pct:
-            if delta_pct < 0:
-                delta_pct = -delta_pct
-            delta_adj = +1
+        # Make sure the delta goes in the right direction
+        sign = +1 if start_pct <= end_pct else -1
+        delta_pct = sign * abs(delta_pct)
+
+        steps = list(range(start_pct, end_pct+delta_pct, delta_pct))
+
+        # clip the last step
+        steps[-1] = end_pct
 
         phases = []
-        steps = list(range(start_pct, end_pct+delta_adj, delta_pct))
         for load in steps:
             if load == 0:
                 phase = Phase(time_s, 0, 0, cpus)


### PR DESCRIPTION
Make sure we get the expected number of steps, even if the `delta_pct` is not an exact divider of `(end_pct-start_pct)` but is slightly too large instead.  If the `delta_pct` is not an exact divider of `(end_pct-start_pct)`, we'll end up with a final phase that has a duty cycle that does not match `end_pct`. Force the last phase to have a duty cycle of `end_pct`.

Also add a debugging aid.