### PR TITLE
install_base_ubuntu: use 0 exit status

### DIFF
--- a/install_base_ubuntu.sh
+++ b/install_base_ubuntu.sh
@@ -80,4 +80,10 @@ if [ "$install_android_sdk" == y ]; then
     install_sdk
 fi
 
+# Make sure we exit with no errors, so we can start making use of that
+# if we introduce some meaningful error handling. Since some packages are not
+# needed for some tasks and since we don't have mechanisms in place to group
+# related use cases, let's swallow errors and move on to lisa-install.
+exit 0
+
 # vim: set tabstop=4 shiftwidth=4 textwidth=80 expandtab:

--- a/install_base_ubuntu.sh
+++ b/install_base_ubuntu.sh
@@ -46,7 +46,14 @@ install_nodejs() {
     # NodeJS v8+ is required, Ubuntu 16.04 LTS supports only an older version.
     # As a special case we can install it as a snap package
     if grep 16.04 /etc/lsb-release >/dev/null; then
-        snap install node --classic --channel=8
+        # sanity check to make sure snap is up and running
+        if ! which snap >/dev/null 2>&1; then
+            echo 'Snap not installed on that system, not installing nodejs'
+        elif snap list >/dev/null 2>&1; then
+            echo 'Snap not usable on that system, not installing nodejs'
+        else
+            snap install node --classic --channel=8
+        fi
         return
     fi
     apt-get install -y nodejs npm


### PR DESCRIPTION
Since we don't make rational use of the exit status, let's make it 0 for
now. This way, the infrastructure can be written to catch non-zero, and
everything will fall into place if we actually give it a meaningful
value.