### PR TITLE
lisa.trace: Remove Trace.df()

### DIFF
--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -294,6 +294,8 @@ but we did rename/move things to make them more coherent.
 **LISA legacy**::
 
   trace.data_frame.trace_event("sched_switch")
+  # or
+  trace.df("sched_switch")
 
 **LISA next**::
 

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -443,21 +443,6 @@ class Trace(Loggable):
 # DataFrame Getter Methods
 ###############################################################################
 
-    def df(self, event):
-        """
-        Get a dataframe containing all occurrences of the specified trace event
-        in the parsed trace.
-
-        :param event: Trace event name
-        :type event: str
-        """
-        warnings.simplefilter('always', DeprecationWarning) #turn off filter
-        warnings.warn("\n\tUse of Trace::df() is deprecated and will be soon removed."
-                      "\n\tUse Trace::df_events(event_name) instead.",
-                      category=DeprecationWarning)
-        warnings.simplefilter('default', DeprecationWarning) #reset filter
-        return self.df_events(event)
-
     def df_events(self, event):
         """
         Get a dataframe containing all occurrences of the specified trace event


### PR DESCRIPTION
This was a useless alias to Trace.df_events().
Also update the transition guide.