### PR TITLE
bisector: disallow importing as __main__

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -5670,6 +5670,7 @@ def main(argv=sys.argv[1:]):
     sys.exit(return_code)
 
 if __name__ == '__main__':
-    main()
+    print('bisector needs to be installed using pip and called through its shim, not executed directly', file=sys.stderr)
+    sys.exit(2)
 
 # vim :set tabstop=4 shiftwidth=4 expandtab textwidth=80


### PR DESCRIPTION
Calling the script directly imports it as __main__, which breaks
references to classes expected to be hosted in a module called bisector.
That behavior is normal for a python application and handled by a shim
create by pip in a PATH location, so bisector needs to be called through
it.