### PR TITLE
git: Decode branch names and sha1

### DIFF
--- a/lisa/git.py
+++ b/lisa/git.py
@@ -39,6 +39,7 @@ def find_shortest_symref(repo_path, sha1):
         "git for-each-ref --sort=-committerdate "
         "--format='%(objectname:short) %(refname:short)' "
         "refs/heads/ refs/remotes/ refs/tags",
+        universal_newlines=True,
         cwd=repo_path, shell=True)
     for line in branches.splitlines():
         try:


### PR DESCRIPTION
In find_shortest_symref() the subprocess command we use to get the list
of git branches returns a byte string. We then split this into byte
string 'name' and 'sha1' where this last will never match the SHA1
parameter passed in as a string.

Fix it be always decoding the strings we get as output of the subprocess
command.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>