### PR TITLE
lisa.env: Issue adb root when connecting to AndroidTarget

### DIFF
--- a/lisa/env.py
+++ b/lisa/env.py
@@ -509,6 +509,9 @@ class TestEnv(Loggable, HideExekallID):
 
         target.setup()
 
+        if isinstance(target, devlib.AndroidTarget):
+            target.adb_root(force=True)
+
         # Verify that all the required modules have been initialized
         for module in devlib_module_list:
             if not hasattr(target, module):


### PR DESCRIPTION
Since we need it in all cases, let's do it in LISA rather than having to
do it manually.