### PR TITLE
document testing workflows

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,6 +34,7 @@ Contents:
    users_guide
    contributors_guide
    kernel_tests
+   automated_testing
    wlgen
    internals
    analysis

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -67,3 +67,6 @@ Miscellaneous utilities
 
 .. automodule:: lisa.target_script
    :members:
+
+.. automodule:: lisa.regression
+   :members:

--- a/doc/pedantic_build.sh
+++ b/doc/pedantic_build.sh
@@ -19,7 +19,7 @@
 
 # The documentation of those modules causes some issues,
 # be permissive for warnings related to them
-IGNORE_PATTERN="devlib|bart|wa"
+IGNORE_PATTERN="devlib|bart|wa|exekall.engine"
 
 make SPHINXOPTS='-n' html 2>doc_build.log
 all_warns=$(cat doc_build.log)

--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -84,6 +84,27 @@ access to many LISA related functions (done automatically by Vagrant)::
 
 .. tip:: Run ``lisa-help`` to see an overview of the provided LISA commands.
 
+Running tests
+=============
+
+The shortest path to executing a test is:
+
+1. Update the ``target_conf.yml`` file located at the root of the repository
+   with the credentials to connect to the development board (see
+   :class:`~lisa.env.TargetConf` keys for more information)
+2. Run the following:
+
+  .. code-block:: sh
+
+    # To run all tests
+    lisa-test
+    # To list available tests
+    lisa-test --list
+    # To run a test matching a pattern
+    lisa-test '*test_task_placement'
+
+More advanced workflows are described at :ref:`automated-testing-page`.
+
 Updating
 ========
 

--- a/lisa/regression.py
+++ b/lisa/regression.py
@@ -60,7 +60,7 @@ class RegressionResult:
     def from_result_list(cls, testcase_id, old_list, new_list, alpha=None):
         """
         Build a :class:`RegressionResult` from two list of
-        :class:`lisa.tests.kernel.test_bundle.Result`, or objects that can be
+        :class:`lisa.tests.base.Result`, or objects that can be
         converted to `bool`.
 
         .. note:: Only ``FAILED`` and ``PASSED`` results are taken into account,
@@ -70,10 +70,10 @@ class RegressionResult:
         :type testcase_id: str
 
         :param old_list: old series
-        :type old_list: list(lisa.tests.kernel.test_bundle.Result)
+        :type old_list: list(lisa.tests.base.Result)
 
         :param new_list: new series
-        :type new_list: list(lisa.tests.kernel.test_bundle.Result)
+        :type new_list: list(lisa.tests.base.Result)
 
         :param alpha: Alpha risk of the statistical test
         :type alpha: float

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -38,6 +38,10 @@ source "$LISA_HOME/shell/lisa_colors"
 export LISA_HOST_ABI=${LISA_HOST_ABI:-x86_64}
 export PATH=$PATH:$LISA_HOME/shell/:$LISA_HOME/tools/$LISA_HOST_ABI:$LISA_HOME/tools
 
+export LISA_CONF="$LISA_HOME/target_conf.yml"
+export LISA_RESULT_ROOT=$LISA_HOME/results
+export EXEKALL_ARTIFACT_ROOT=${EXEKALL_ARTIFACT_ROOT:-$LISA_RESULT_ROOT}
+
 ################################################################################
 # Helpers
 ################################################################################
@@ -355,35 +359,6 @@ function lisa-jupyter {
     esac
     echo
 echo
-}
-
-################################################################################
-# LISA Tests utility functions
-################################################################################
-
-export LISA_CONF="$LISA_HOME/target_conf.yml"
-export LISA_RESULT_ROOT=$LISA_HOME/results
-export EXEKALL_ARTIFACT_ROOT=${EXEKALL_ARTIFACT_ROOT:-$LISA_RESULT_ROOT}
-
-function lisa-test {
-    # Add --conf target_conf.yml if the file exists
-    if [[ -e "$LISA_CONF" ]]; then
-        local conf_opt=('--conf' "$LISA_CONF")
-    else
-        local conf_opt=()
-    fi
-
-    local cmd=(
-        exekall run "$LISA_HOME/lisa/tests/"             \
-        "${conf_opt[@]}"                                 \
-        --select-multiple "$@"
-    )
-
-    # Show the command before running, so --help makes more sense
-    echo "${cmd[@]}"
-    echo
-
-    "${cmd[@]}"
 }
 
 ################################################################################

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -5205,13 +5205,13 @@ command line""")
         subparser.add_argument('--debug', action='store_true',
             help="""Show Python traceback to help debugging this script.""")
 
-    # Same option for both subcommands
-    for subparser in (run_parser, report_parser):
+    run_step_group = run_parser.add_mutually_exclusive_group()
+    for subparser in (run_step_group, report_parser):
         subparser.add_argument('--steps',
-            help="""YAML configuration of steps to run. It superseeds inline
-            steps options. The steps definitions lives under a "step" toplevel
-            key.""")
+            help="""YAML configuration of steps to run. The steps definitions
+            lives under a "step" toplevel key.""")
 
+    for subparser in (run_parser, report_parser):
         stat_test_group = subparser.add_mutually_exclusive_group()
         stat_test_group.add_argument('--allowed-bad', type=int,
             default=0,
@@ -5256,6 +5256,12 @@ command line""")
         checkout failure that leads to bisect abortion. WARNING: this will
         erase all changes and untracked files from the worktree.""")
 
+    run_step_group.add_argument('--inline', '-s', nargs=2, action='append',
+        metavar=('CLASS', 'NAME'),
+        default=[],
+        help="""Class and name of inline step. Can be repeated to build a list
+        of steps in the order of appearance.""")
+
     run_parser.add_argument('-n', '--iterations', type=parse_iterations,
         # Use "inf" as default so that if only --timeout is specified, it will
         # iterate until the timeout expires instead of just 1 iteration.
@@ -5292,11 +5298,6 @@ command line""")
         steps will be extracted from the report instead of from the command
         line. The number of completed iterations will be deducted from the
         specified number of iterations.""")
-
-    run_parser.add_argument('--inline', '-s', nargs=2, metavar=('CLASS', 'NAME'),
-        default=[], action='append',
-        help="""Class and name of inline step. Can be repeated to build a list
-        of steps in the order of appearance. Superseded by --steps.""")
 
     run_parser.add_argument('--desc',
         default='Executed from ' + os.getcwd() + ' ({commit}, {date})',

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -5374,18 +5374,15 @@ command line""")
     cmd_group.add_argument('--log', action='store_true',
         help="""Show log in $PAGER.""")
 
-    cmd_group.add_argument('--notif', nargs=2,
-        help="Enable and disable desktop notifications.")
-
     cmd_group.add_argument('--report', nargs=argparse.REMAINDER,
         help="""Equivalent to running bisector report, all remaining options
         being passed to it.
         """)
 
-    # Options for monitor-server subcommand
-    dbus_service_parser.add_argument('--notif', nargs=2,
-        default=('enable', 'all'),
-        help="Enable and disable desktop notifications.")
+    for group in (cmd_group, dbus_service_parser):
+        group.add_argument('--notif', nargs=2,
+            metavar=('enable/disable', 'PROPERTY'),
+            help="Enable and disable desktop notifications when the given property changes. 'all' will select all properties.")
 
     try:
         args = parser.parse_args(argv)

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -1763,11 +1763,11 @@ class ExekallLISATestStep(ShellStep):
     attr_init = dict(
         cat = 'test',
         name = 'exekall-LISA-test',
-        use_systemd_run = False,
         compress_artifact = True,
         upload_artifact = False,
         delete_artifact = False,
         prune_db = True,
+        cmd = 'lisa-test',
     )
 
     options = dict(
@@ -2380,7 +2380,6 @@ class LISATestStep(ShellStep):
     attr_init = dict(
         cat = 'test',
         name = 'LISA-test',
-        use_systemd_run = False,
         compress_results = True,
         upload_results = False,
     )

--- a/tools/lisa-test
+++ b/tools/lisa-test
@@ -1,0 +1,36 @@
+#! /bin/bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2019, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ -e "$LISA_CONF" ]]; then
+	conf_opt=('--conf' "$LISA_CONF")
+else
+	conf_opt=()
+fi
+
+cmd=(
+	exekall run "$LISA_HOME/lisa/tests/"             \
+	"${conf_opt[@]}"                                 \
+	--select-multiple "$@"
+)
+
+# Show the command before running, so --help makes more sense
+echo "${cmd[@]}"
+echo
+
+exec "${cmd[@]}"


### PR DESCRIPTION
Add user-guide style documentation on synthetic tests workflows using bisector and exekall. That is meant to be a kind of reference flow, with documentation and command line examples, and without too much advanced content. More details about the concepts of exekall and bisector will be documented in their own documentation to come.