### PR TITLE
shell: Introduce LISA_PRESERVE_SHELL

### DIFF
--- a/init_env
+++ b/init_env
@@ -41,7 +41,9 @@ if [[ -n $BASH_VERSION ]]; then
 	export LISA_HOME=$(readlink -f "$(dirname "$BASH_SOURCE")")
 	source "$(dirname "$BASH_SOURCE")/shell/lisa_shell"; _lisa_shell_ret=$?
 
-	PS1="\[${LISASHELL_BLUE}\][LISAShell \[${LISASHELL_LCYAN}\]\W\[${LISASHELL_BLUE}\]] \> \[${LISASHELL_RESET}\]"
+	if [[ $LISA_PRESERVE_SHELL == 0 ]]; then
+		PS1="\[${LISASHELL_BLUE}\][LISAShell \[${LISASHELL_LCYAN}\]\W\[${LISASHELL_BLUE}\]] \> \[${LISASHELL_RESET}\]"
+	fi
 
 # Running under ZSH
 elif [[ -n $ZSH_VERSION ]]; then

--- a/shell/lisa_colors
+++ b/shell/lisa_colors
@@ -32,7 +32,7 @@
 # cyan    36 46
 # white   37 47
 
-if [[ -t 1 && $- = *"i"* ]]; then
+if [[ -t 1 && $- = *"i"* && $LISA_PRESERVE_SHELL == 0 ]]; then
     LISASHELL_WHITE="\033[1;37m"
     LISASHELL_LGRAY="\033[37m"
     LISASHELL_GRAY="\033[1;30m"

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -30,6 +30,9 @@ LISA_PYTHON=${LISA_PYTHON:-python3}
 # By default use internal libraries
 export LISA_DEVMODE=${LISA_DEVMODE:-1}
 
+# By default use Lisa's PS1 and colorscheme for the shell
+export LISA_PRESERVE_SHELL=${LISA_PRESERVE_SHELL:-0}
+
 # Setup colors
 source "$LISA_HOME/shell/lisa_colors"
 
@@ -426,21 +429,24 @@ EOF
 # LISA Shell MAIN
 ################################################################################
 
-# Dump out a nice LISA Shell logo
-clear
-echo -e "$LISASHELL_BANNER"
+if [[ $LISA_PRESERVE_SHELL == 0 ]]; then
+    # Dump out a nice LISA Shell logo
+    clear
+    echo -e "$LISASHELL_BANNER"
 
-echo "                                                                               "
-echo "                        .:: LISA Shell ::.                                     "
-echo "                                                                               "
-echo -ne "$LISASHELL_RESET"
-echo
+    echo "                                                                               "
+    echo "                        .:: LISA Shell ::.                                     "
+    echo "                                                                               "
+    echo -ne "$LISASHELL_RESET"
+    echo
+fi
 
 # Activate the venv unless it was explicitely disabled
 lisa-venv-activate
 
-echo -ne "$LISASHELL_RESET$LISASHELL_BLUE"
-cat <<EOF
+if [[ $LISA_PRESERVE_SHELL == 0 ]]; then
+    echo -ne "$LISASHELL_RESET$LISASHELL_BLUE"
+    cat <<EOF
 
 Welcome to the Linux Integrated System Analysis SHELL!
 
@@ -449,7 +455,11 @@ $(lisa-version)
 Type "lisa-help" for on-line help on available commands
 EOF
 
-# Setup default SHELL text color
-echo -e "$LISASHELL_DEFAULT"
-
+    # Setup default SHELL text color
+    echo -e "$LISASHELL_DEFAULT"
+else
+    lisa-version
+    echo "Environment variables:"
+    printenv | grep --color=no -E 'LISA|EXEKALL' | sort
+fi
 # vim: set tabstop=4 shiftwidth=4 textwidth=80 expandtab:


### PR DESCRIPTION
Sourcing init_env basically provides a set of bash functions (the lisa-*
commands) to the user and activates the python venv. However, that also
changes the PS1 and the colorscheme of the current shell, although this
isn't strictly necessary.

In order to give users the option of keeping their original shell
configuration, make the Lisa PS1 and colors depend on $LISA_SHELL_QUIET
not being set. While at it, list the env variables exported by init_env.

This results in:
  queper01@queper01-lin:~/lisa$ LISA_SHELL_QUIET=1 source init_env
  Activating LISA Python 3.6 venv (/data/work/lisa-next/.lisa-venv-3.6) ...
  LISA version:
      /data/work/lisa-next
      branch: heads/lisa-shell-quiet
      commit: 7f07c99ecec

  Python version: 3.6

  JupyterLab v0.35.4
  No installed extensions
  Environment variables:
  LISA_SHELL_QUIET=1
  LISA_CONF=/data/work/lisa-next/target_conf.yml
  LISA_HOME=/data/work/lisa-next
  LISA_RESULT_ROOT=/data/work/lisa-next/results
  LISA_USE_VENV=1
  LISA_HOST_ABI=x86_64
  LISA_DEVMODE=1
  LISA_VENV_PATH=/data/work/lisa-next/.lisa-venv-3.6
  queper01@queper01-lin:~/lisa$

without changing colors.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>