### PR TITLE
lisa/bisector: improve yaml init code

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -182,15 +182,15 @@ class Serializable(Loggable):
         yaml.allow_unicode = ('utf' in cls.YAML_ENCODING)
         yaml.default_flow_style = False
         yaml.indent = 4
-        yaml.Constructor.add_constructor('!include', cls._yaml_include_constructor)
-        yaml.Constructor.add_constructor('!var', cls._yaml_var_constructor)
-        yaml.Constructor.add_multi_constructor('!env:', cls._yaml_env_var_constructor)
-        yaml.Constructor.add_multi_constructor('!call:', cls._yaml_call_constructor)
+        yaml.constructor.add_constructor('!include', cls._yaml_include_constructor)
+        yaml.constructor.add_constructor('!var', cls._yaml_var_constructor)
+        yaml.constructor.add_multi_constructor('!env:', cls._yaml_env_var_constructor)
+        yaml.constructor.add_multi_constructor('!call:', cls._yaml_call_constructor)
 
         # Replace unknown tags by a placeholder object containing the data.
         # This happens when the class was not imported at the time the object
         # was deserialized
-        yaml.Constructor.add_constructor(None, cls._yaml_unknown_tag_constructor)
+        yaml.constructor.add_constructor(None, cls._yaml_unknown_tag_constructor)
 
     @classmethod
     def _yaml_unknown_tag_constructor(cls, loader, node):

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -3988,8 +3988,8 @@ def init_yaml(yaml, relative_root):
     def map_constructor(loader, node):
         return collections.OrderedDict(loader.construct_pairs(node))
 
-    yaml.Representer.add_representer(collections.OrderedDict, map_representer)
-    yaml.Constructor.add_constructor(yaml.resolver.DEFAULT_MAPPING_TAG, map_constructor)
+    yaml.representer.add_representer(collections.OrderedDict, map_representer)
+    yaml.constructor.add_constructor(yaml.resolver.DEFAULT_MAPPING_TAG, map_constructor)
 
     # Since strings are immutable, we can memoized the output to deduplicate
     # strings. This will make the dumped strings live forever, but that should
@@ -4001,7 +4001,7 @@ def init_yaml(yaml, relative_root):
         style = '|' if '\n' in data else None
         return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=style)
 
-    yaml.Representer.add_representer(str, str_presenter)
+    yaml.representer.add_representer(str, str_presenter)
 
 # Compute the SHA1 of the script itself, to identify the version of the tool
 # that was used to generate a given report.


### PR DESCRIPTION
Use yaml.representer instead of yaml.Representer, and the same for
Constructor. That avoids touching the class directly, and multiple YAML
loaders and dumpers can coexist in the same process.