### PR TITLE
lisa: Use PlatformInfo directly instead of TestEnv

### DIFF
--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -112,6 +112,7 @@ class KeyDescBase(abc.ABC):
         """
         pass
 
+
 class KeyDesc(KeyDescBase):
     """
     Key descriptor describing a leaf key in the configuration.
@@ -198,6 +199,17 @@ class KeyDesc(KeyDescBase):
             ),
             help=': ' + self.help if self.help else ''
         )
+
+    def pretty_format(self, v):
+        """
+        Format the value for pretty printing.
+
+        :param v: Value of the key that is being printed
+        :type v: object
+
+        :return: A string
+        """
+        return str(v)
 
 class MissingBaseKeyError(KeyError):
     """
@@ -971,14 +983,17 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
             derived_items()
         ):
             v_cls = type(v)
-            is_sublevel = k in self._sublevel_map
+
+            key_desc = self._structure[k]
+            is_sublevel = isinstance(key_desc, LevelKeyDesc)
+
             if is_sublevel:
                 v = v.pretty_format(eval_deferred=eval_deferred)
                 # If there is no content, just skip that sublevel entirely
                 if not v.strip():
                    continue
             else:
-                v = str(v)
+                v = key_desc.pretty_format(v)
 
             if is_sublevel or '\n' in v:
                 v = '\n' + v

--- a/lisa/env.py
+++ b/lisa/env.py
@@ -47,6 +47,10 @@ FTRACE_BUFSIZE_DEFAULT = 10240
 RESULT_DIR = 'results'
 LATEST_LINK = 'results_latest'
 
+class PasswordKeyDesc(KeyDesc):
+    def pretty_format(self, v):
+        return '<password>'
+
 class TargetConf(MultiSrcConf, HideExekallID):
     """
     Target connection settings.
@@ -120,7 +124,7 @@ class TargetConf(MultiSrcConf, HideExekallID):
 
         KeyDesc('host', 'Hostname or IP address of the host', [str, None]),
         KeyDesc('username', 'SSH username', [str, None]),
-        KeyDesc('password', 'SSH password', [str, None]),
+        PasswordKeyDesc('password', 'SSH password', [str, None]),
         KeyDesc('port', 'SSH or ADB server port', [int, None]),
         KeyDesc('device', 'ADB device. Takes precedence over "host"', [str, None]),
         KeyDesc('keyfile', 'SSH private key file', [str, None]),

--- a/lisa/platforms/platinfo.py
+++ b/lisa/platforms/platinfo.py
@@ -23,7 +23,7 @@ from lisa.conf import (
 from lisa.energy_model import EnergyModel
 from lisa.wlgen.rta import RTA
 
-from devlib.target import KernelVersion
+from devlib.target import KernelVersion, TypedKernelConfig
 from devlib.exception import TargetStableError
 
 def compute_capa_classes(conf):
@@ -58,9 +58,13 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
         LevelKeyDesc('rtapp', 'RTapp configuration', (
             KeyDesc('calib', 'RTapp calibration dictionary', [IntIntDict]),
         )),
+
+        LevelKeyDesc('kernel', 'Kernel-related information', (
+            KeyDesc('version', '', [KernelVersion]),
+            KeyDesc('config', '', [TypedKernelConfig]),
+        )),
         KeyDesc('nrg-model', 'Energy model object', [EnergyModel]),
         KeyDesc('cpu-capacities', 'Dictionary of CPU ID to capacity value', [IntIntDict]),
-        KeyDesc('kernel-version', '', [KernelVersion]),
         KeyDesc('abi', 'ABI, e.g. "arm64"', [str]),
         KeyDesc('os', 'OS being used, e.g. "linux"', [str]),
         KeyDesc('name', 'Free-form name of the board', [str]),
@@ -86,7 +90,10 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
         target = te.target
         info = {
             'nrg-model': self._nrg_model_from_target(target),
-            'kernel-version': target.kernel_version,
+            'kernel': {
+                'version': target.kernel_version,
+                'config': target.config.typed_config,
+            },
             'abi': target.abi,
             'os': target.os,
             'rtapp': {
@@ -118,89 +125,4 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
             logger.error("Couldn't read target energy model: %s", err)
             return None
 
-    # OLD CODE AFTER REFACTORING, FOR REFERENCE OF WHAT IS THE EXPECTED FORMAT
-    # AND CONTENT OF THE COMPATIBILITY KEYS
-    #  @classmethod
-    #  def _topology_from_target(cls, target):
-        #  logger = cls.get_logger()
-        #  # Initialize target Topology for behavior analysis
-        #  clusters = []
-
-        #  # Build topology for a big.LITTLE systems
-        #  if target.big_core and \
-           #  (target.abi == 'arm64' or target.abi == 'armeabi'):
-            #  # Populate cluster for a big.LITTLE platform
-            #  if target.big_core:
-                #  # Load cluster of LITTLE cores
-                #  clusters.append(
-                    #  [i for i,t in enumerate(target.core_names)
-                                #  if t == target.little_core])
-                #  # Load cluster of big cores
-                #  clusters.append(
-                    #  [i for i,t in enumerate(target.core_names)
-                                #  if t == target.big_core])
-        #  # Build topology for an SMP systems
-        #  elif not target.big_core or \
-             #  target.abi == 'x86_64':
-            #  for core in set(target.core_clusters):
-                #  clusters.append(
-                    #  [i for i,v in enumerate(target.core_clusters)
-                     #  if v == core])
-        #  logger.info('Topology:')
-        #  logger.info('   %s', clusters)
-
-        #  return Topology(clusters=clusters)
-
-    # ANY CODE RELYING ON THAT SHOULD BE UPDATED TO USE THE Topology OBJECT
-    # The following 2 methods provide platform keys:
-    # * 'clusters'
-    # * 'freqs'
-    # * 'cpus_count'
-    #  @staticmethod
-    #  def _init_plat_info[cpus-count]bl(target):
-        #  #TODO: replace with PlatformInfo
-        #  platform = {
-            #  'clusters' : {
-                #  'little'    : target.bl.littles,
-                #  'big'       : target.bl.bigs
-            #  },
-            #  'freqs' : {
-                #  'little'    : target.bl.list_littles_frequencies(),
-                #  'big'       : target.bl.list_bigs_frequencies()
-            #  }
-        #  }
-        #  plat_info['cpus-count'] = \
-            #  len(platform['clusters']['little']) + \
-            #  len(platform['clusters']['big'])
-
-        #  return platform
-
-    #  @classmethod
-    #  def _init_plat_info[cpus-count]smp(cls, target):
-        #  logger = cls.get_logger()
-        #  #TODO: replace with PlatformInfo
-        #  clusters = {}
-        #  freqs = {}
-
-        #  for cpu_id, cluster_id in enumerate(target.core_clusters):
-            #  clusters.setdefault(cluster_id, []).append(cpu_id)
-
-        #  if 'cpufreq' in target.modules:
-            #  # Try loading frequencies using the cpufreq module
-            #  for cluster_id, cluster in clusters.items():
-                #  core_id = cluster[0]
-                #  freqs[cluster_id] = \
-                    #  target.cpufreq.list_frequencies(core_id)
-        #  else:
-            #  logger.warning('Unable to identify cluster frequencies')
-
-        #  # TODO: get the performance boundaries in case of intel_pstate driver
-
-        #  platform = dict(
-            #  clusters = clusters,
-            #  freqs = freqs,
-            #  cpus_count = len(target.core_clusters)
-        #  }
-        #  return platform
-
-# vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab
+ # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/platforms/platinfo.py
+++ b/lisa/platforms/platinfo.py
@@ -35,6 +35,9 @@ def compute_capa_classes(conf):
     """
     return list(group_by_value(conf['cpu-capacities']).values())
 
+class KernelConfigKeyDesc(KeyDesc):
+    def pretty_format(self, v):
+        return '<kernel config>'
 
 class PlatformInfo(MultiSrcConf, HideExekallID):
     """
@@ -51,6 +54,7 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
     {generated_help}
 
     """
+
     # we could use mypy.subtypes.is_subtype and use the infrastructure provided
     # by typing module, but adding an external dependency is overkill for what
     # we need.
@@ -61,7 +65,7 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
 
         LevelKeyDesc('kernel', 'Kernel-related information', (
             KeyDesc('version', '', [KernelVersion]),
-            KeyDesc('config', '', [TypedKernelConfig]),
+            KernelConfigKeyDesc('config', '', [TypedKernelConfig]),
         )),
         KeyDesc('nrg-model', 'Energy model object', [EnergyModel]),
         KeyDesc('cpu-capacities', 'Dictionary of CPU ID to capacity value', [IntIntDict]),

--- a/lisa/platforms/platinfo.py
+++ b/lisa/platforms/platinfo.py
@@ -43,14 +43,6 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
     """
     Platform-specific information made available to tests.
 
-    .. warning::
-        The follwing keys are here for compatibility with old code only, do not
-        write new code depending on them:
-
-            * topology
-            * clusters
-            * freqs
-
     {generated_help}
 
     """

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -383,7 +383,7 @@ class RTATestBundle(TestBundle, abc.ABC):
         self.rtapp_profile = rtapp_profile
 
     @classmethod
-    def unscaled_utilization(cls, te, cpu, utilization_pct):
+    def unscaled_utilization(cls, plat_info, cpu, utilization_pct):
         """
         Convert utilization scaled to a CPU to a 'raw', unscaled one.
 
@@ -393,16 +393,16 @@ class RTATestBundle(TestBundle, abc.ABC):
         :param utilization_pct: The scaled utilization in %
         :type utilization_pct: int
         """
-        if "nrg-model" in te.plat_info:
-            capacity_scale = te.plat_info["nrg-model"].capacity_scale
+        if "nrg-model" in plat_info:
+            capacity_scale = plat_info["nrg-model"].capacity_scale
         else:
             capacity_scale = 1024
 
-        return int((te.plat_info["cpu-capacities"][cpu] / capacity_scale) * utilization_pct)
+        return int((plat_info["cpu-capacities"][cpu] / capacity_scale) * utilization_pct)
 
     @classmethod
     @abc.abstractmethod
-    def get_rtapp_profile(cls, te):
+    def get_rtapp_profile(cls, plat_info):
         """
         :returns: a :class:`dict` with task names as keys and
           :class:`lisa.wlgen.rta.RTATask` as values
@@ -424,7 +424,7 @@ class RTATestBundle(TestBundle, abc.ABC):
 
     @classmethod
     def _from_testenv(cls, te, res_dir):
-        rtapp_profile = cls.get_rtapp_profile(te)
+        rtapp_profile = cls.get_rtapp_profile(te.plat_info)
         cls._run_rtapp(te, res_dir, rtapp_profile)
 
         return cls(res_dir, te.plat_info, rtapp_profile)

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -58,7 +58,7 @@ class MisfitMigrationBase(RTATestBundle):
 
     @classmethod
     @memoized
-    def _get_max_lb_interval(cls, te):
+    def _get_max_lb_interval(cls, plat_info):
         """
         Get the value of maximum_load_balance_interval.
 
@@ -70,8 +70,8 @@ class MisfitMigrationBase(RTATestBundle):
 
         :returns: The absolute maximum load-balance interval in seconds
         """
-        HZ = te.target.sched.get_hz()
-        return ((HZ * te.target.number_of_cpus) // 10) * (1. / HZ)
+        HZ = plat_info['kernel']['config']['CONFIG_HZ']
+        return ((HZ * plat_info['cpus-count']) // 10) * (1. / HZ)
 
     @classmethod
     def from_testenv(cls, te:TestEnv, res_dir:ArtifactPath=None) -> 'MisfitMigrationBase':
@@ -162,12 +162,12 @@ class StaggeredFinishes(MisfitMigrationBase):
                 "Target doesn't have SD_ASYM_CPUCAPACITY on any sched_domain")
 
     @classmethod
-    def get_rtapp_profile(cls, te):
-        cpus = list(range(te.target.number_of_cpus))
+    def get_rtapp_profile(cls, plat_info):
+        cpus = list(range(plat_info['cpus-count']))
 
         # We're pinning stuff in the first phase, so give it ample time to
         # clean the pinned logic out of balance_interval
-        free_time_s = 1.1 * cls._get_max_lb_interval(te)
+        free_time_s = 1.1 * cls._get_max_lb_interval(plat_info)
         stagger_s = free_time_s // (10 * len(cpus))
 
         profile = {}

--- a/lisa/wa_results_collector.py
+++ b/lisa/wa_results_collector.py
@@ -404,7 +404,7 @@ class WaResultsCollector(Loggable):
         events = ['irq_handler_entry', 'cpu_frequency', 'nohz_kick', 'sched_switch',
                   'sched_load_cfs_rq', 'sched_load_avg_task', 'thermal_temperature']
         plat_info = PlatformInfo({
-            'kernel-version': KernelVersion(target_info['kernel_release']),
+            'kernel': {'version': KernelVersion(target_info['kernel_release'])},
         })
         trace = Trace(trace_path, plat_info, events, self.platform)
 

--- a/tests/traces/plat_info.yml
+++ b/tests/traces/plat_info.yml
@@ -53,18 +53,19 @@ platform-info:
             - 700000
             - 775000
             - 850000
-        kernel-version: !!python/object:devlib.target.KernelVersion
-            major: 19
-            minor: 0
-            parts: !!python/tuple
-            - 4
-            - 19
-            - 0
-            rc: null
-            release: 4.19.0-07801-gf317706
-            sha1: f317706
-            version: 38 SMP PREEMPT Fri Nov 30 13:55:54 GMT 2018
-            version_number: 4
+        kernel:
+            version: !!python/object:devlib.target.KernelVersion
+                major: 19
+                minor: 0
+                parts: !!python/tuple
+                - 4
+                - 19
+                - 0
+                rc: null
+                release: 4.19.0-07801-gf317706
+                sha1: f317706
+                version: 38 SMP PREEMPT Fri Nov 30 13:55:54 GMT 2018
+                version_number: 4
         name: juno
         nrg-model: !!python/object:lisa.energy_model.EnergyModel
             cpu_nodes:

--- a/tests/traces/sched_load/plat_info.yml
+++ b/tests/traces/sched_load/plat_info.yml
@@ -53,18 +53,19 @@ platform-info:
             - 700000
             - 775000
             - 850000
-        kernel-version: !!python/object:devlib.target.KernelVersion
-            major: 19
-            minor: 0
-            parts: !!python/tuple
-            - 4
-            - 19
-            - 0
-            rc: null
-            release: 4.19.0-07801-gf317706
-            sha1: f317706
-            version: 38 SMP PREEMPT Fri Nov 30 13:55:54 GMT 2018
-            version_number: 4
+        kernel:
+            version: !!python/object:devlib.target.KernelVersion
+                major: 19
+                minor: 0
+                parts: !!python/tuple
+                - 4
+                - 19
+                - 0
+                rc: null
+                release: 4.19.0-07801-gf317706
+                sha1: f317706
+                version: 38 SMP PREEMPT Fri Nov 30 13:55:54 GMT 2018
+                version_number: 4
         name: juno
         nrg-model: !!python/object:lisa.energy_model.EnergyModel
             cpu_nodes:

--- a/tests/traces/sched_load_avg/plat_info.yml
+++ b/tests/traces/sched_load_avg/plat_info.yml
@@ -52,5 +52,6 @@ platform-info:
                     2054400,
                     2150400
           ]
-        kernel-version: !call:devlib.target.KernelVersion
-            version_string: "3.18.31-gbd96fbf #1 SMP PREEMPT Mon Nov 7 20:29:14 UTC 2016"
+        kernel:
+            version: !call:devlib.target.KernelVersion
+                version_string: "3.18.31-gbd96fbf #1 SMP PREEMPT Mon Nov 7 20:29:14 UTC 2016"


### PR DESCRIPTION
Avoid using TestEnv when not necessary, since it forces a live
connection to a target. For example, getting the RTapp profile of a test
only requires accessing PlatformInfo, and we should be able to get it
without any live connection to a target.