### PR TITLE
lisa.trace: Make API slightly clearer

### DIFF
--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -324,6 +324,7 @@ but we did rename/move things to make them more coherent.
 * Removed last occurences of camelCase
 * Removed big.LITTLE assumptions and made the code only rely on CPU capacities or
   frequency domains, where relevant.
+* Constructor now only takes trace files as input, not folders anymore.
 * ``Trace.data_frame`` is gone:
 
 **LISA legacy**::

--- a/ipynb/examples/typical_experiment.ipynb
+++ b/ipynb/examples/typical_experiment.ipynb
@@ -731,7 +731,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trace = Trace(wload.res_dir, te.plat_info, events=events)"
+    "trace_path = os.path.join(wload.res_dir, 'trace.dat')\n",
+    "trace = Trace(trace_path, te.plat_info, events=events)"
    ]
   },
   {
@@ -771,7 +772,8 @@
    "outputs": [],
    "source": [
     "plat_info = PlatformInfo.from_yaml_map(plat_info_path)\n",
-    "trace = Trace(wload.res_dir, plat_info, events=events)"
+    "trace_path = os.path.join(wload.res_dir, 'trace.dat')\n",
+    "trace = Trace(trace_path, plat_info, events=events)"
    ]
   },
   {

--- a/ipynb/profiling/kernel_functions_profiling.ipynb
+++ b/ipynb/profiling/kernel_functions_profiling.ipynb
@@ -623,7 +623,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trace = Trace(wload.res_dir, te.plat_info, events=events)"
+    "trace_path = os.path.join(wload.res_dir, 'trace.dat')\n",
+    "trace = Trace(trace_path, te.plat_info, events=events)"
    ]
   },
   {

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -376,7 +376,8 @@ class RTATestBundle(TestBundle, abc.ABC):
         allows updating the underlying path before it is actually loaded to
         match a different folder structure.
         """
-        return Trace(self.res_dir, self.plat_info, events=self.ftrace_conf["events"])
+        path = os.path.join(self.res_dir, 'trace.dat')
+        return Trace(path, self.plat_info, events=self.ftrace_conf["events"])
 
     def __init__(self, res_dir, plat_info, rtapp_profile):
         super().__init__(res_dir, plat_info)

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -43,8 +43,8 @@ class Trace(Loggable):
     """
     The Trace object is the LISA trace events parser.
 
-    :param data_dir: folder containing all trace data
-    :type data_dir: str
+    :param trace_path: File containing the trace
+    :type trace_path: str
 
     :param events: events to be parsed (all the events by default)
     :type events: str or list(str)
@@ -72,7 +72,7 @@ class Trace(Loggable):
     """
 
     def __init__(self,
-                 data_dir,
+                 trace_path,
                  plat_info=None,
                  events=None,
                  window=(0, None),
@@ -117,21 +117,15 @@ class Trace(Loggable):
         self.freq_coherency = True
 
         # Folder containing trace
-        self.data_dir = data_dir
+        self.trace_path = trace_path
 
-        # By deafult, use the trace dir to save plots
-        self.plots_dir = plots_dir
-        if self.plots_dir is None:
-            # In case we're passed the trace.dat
-            if os.path.isfile(data_dir):
-                self.plots_dir = os.path.dirname(data_dir)
-            else:
-                self.plots_dir = data_dir
+        # By default, use the trace dir to save plots
+        self.plots_dir = plots_dir if plots_dir else os.path.dirname(trace_path)
 
         self.plots_prefix = plots_prefix
 
         self._register_trace_events(events)
-        self._parse_trace(self.data_dir, window, trace_format)
+        self._parse_trace(self.trace_path, window, trace_format)
 
         # Import here to avoid a circular dependency issue at import time
         # with lisa.analysis.base

--- a/lisa/wa_results_collector.py
+++ b/lisa/wa_results_collector.py
@@ -423,7 +423,7 @@ class WaResultsCollector(Loggable):
                 df = trace.analysis.frequency.df_cluster_frequency_residency(cluster)
                 if df is None or df.empty:
                     logger.warning("Can't get cluster freq residency from %s",
-                                      trace.data_dir)
+                                      trace.trace_path)
                 else:
                     df = df.reset_index()
                     avg_freq = (df.frequency * df.time).sum() / df.time.sum()

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -296,7 +296,7 @@ class TestTrace(StorageTestCase):
         columns = ['comm', 'pid', 'load', 'util', '__cpu']
         for column in columns:
             msg = 'Task signals parsed from {} missing {} column'.format(
-                trace.data_dir, column)
+                trace.trace_path, column)
             self.assertIn(column, lt_df, msg=msg)
 
         # Pick an arbitrary PID to try plotting signals for.


### PR DESCRIPTION
Make it clear that Trace() takes a path to a trace file as a parameter, and not a folder. The folder of the trace is still used by default for saving plots, so that does not really introduce any breakage.