### PR TITLE
bisector: Learn @file CLI syntax

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -5132,7 +5132,10 @@ def _main(argv):
     commands) or SIGHUP (when the terminal dies) and will save the completed
     iterations to the report. The execution can later be resumed with --resume.
     """.format(generic_code=GENERIC_ERROR_CODE),
-    formatter_class=argparse.RawTextHelpFormatter)
+        formatter_class=argparse.RawTextHelpFormatter,
+        # Allow passing CLI options through a file
+        fromfile_prefix_chars='@',
+    )
 
 
     subparsers = parser.add_subparsers(title='subcommands', dest='subcommand')


### PR DESCRIPTION
CLI command line can be put in a file (one option per line), and the
file referenced using @myfile syntax:
https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars