### PR TITLE
doc: Cleanup creation of test list

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -407,20 +407,13 @@ def setup(app):
 
 def get_test_id_list():
     import lisa.tests as test_package
-    with tempfile.NamedTemporaryFile('wt') as conf:
-        # Create a dummy target configuration, so that exekall can build all
-        # expressions starting from that
-        conf.write('target-conf:\n')
-        conf.flush()
-
-        rst_list = []
-        for path in test_package.__path__:
-            rst_list.extend(subprocess.check_output((
-                'exekall', 'run', path,
-                '--conf', conf.name,
-                '--rst-list'
-                ), stderr=subprocess.STDOUT).decode('utf-8').splitlines()
-            )
+    rst_list = []
+    for path in test_package.__path__:
+        rst_list.extend(subprocess.check_output((
+            'exekall', 'run', path,
+            '--rst-list', '--inject-empty-target-conf',
+            ), stderr=subprocess.STDOUT).decode('utf-8').splitlines()
+        )
     return rst_list
 
 def create_test_list_file(path):

--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -118,6 +118,12 @@ class LISAAdaptor(AdaptorBase):
                 non_reusable_type_set=non_reusable_type_set
             ))
 
+        # Inject a dummy empty TargetConf
+        if self.args.inject_empty_target_conf:
+            op_set.add(PrebuiltOperator(TargetConf, [TargetConf(conf={})],
+                non_reusable_type_set=non_reusable_type_set
+            ))
+
         return op_set
 
     def get_hidden_op_set(self, op_set):
@@ -138,6 +144,12 @@ class LISAAdaptor(AdaptorBase):
             metavar='SERIALIZED_OBJECT_PATH',
             default=[],
             help="Serialized object to inject when building expressions")
+
+        # Create an empty TargetConf, so we are able to get the list of tests
+        # as if we were going to execute them using a target.
+        # note: that is only used for generating the documentation.
+        parser.add_argument('--inject-empty-target-conf', action='store_true',
+            help=argparse.SUPPRESS)
 
     @staticmethod
     def register_compare_param(parser):


### PR DESCRIPTION
Add an undocumented option to LISA's exekall glue to avoid having to
create a temp file with dummy content.