### PR TITLE
exekall: Add --list-trace-events

### DIFF
--- a/tools/exekall/exekall/customization.py
+++ b/tools/exekall/exekall/customization.py
@@ -52,6 +52,9 @@ class AdaptorBase:
             if op.get_prototype()[0]
         }
 
+    def format_expr_list(self, expr_list, verbose=0):
+        return ''
+
     def get_prebuilt_set(self):
         return set()
 

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -789,6 +789,10 @@ def do_run(args, parser, run_parser, argv):
             if verbose >= 2:
                 out(expr.get_structure() + '\n')
 
+    formatted_out = adaptor.format_expr_list(expr_list, verbose=verbose)
+    if formatted_out:
+        out('\n' + formatted_out + '\n')
+
     if only_list:
         return 0
 


### PR DESCRIPTION
Allow arbitrary pretty printing of the list of expressions by the
exekall Adaptor.

Use that to list trace events used for each test.