### PR TITLE
setup.py: Drop tornado version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,8 +94,6 @@ setup(
         "numpy",
         "scipy",
         "ruamel.yaml >= 0.15.81",
-        # 6.0 is borken
-        "tornado < 6.0",
 
         # Depdendencies that are shipped as part of the LISA repo as
         # subtree/submodule


### PR DESCRIPTION
Issues with Python 3.5.1 have been resolved, see
https://github.com/tornadoweb/tornado/issues/2604