### PR TITLE
Fix lisa/test PELTTask test cases

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -632,6 +632,11 @@ class PELTTask(LoadTrackingBase):
 
     task_prefix = 'pelt_behv'
 
+    TASK_PERIOD_MS = 16 * (1024/1000)
+    """
+    The task period must be n*1.024 due to :class:`bart.pelt.Simulator` restrictions
+    """
+
     @classmethod
     def from_target(cls, target:Target, res_dir:ArtifactPath=None, ftrace_coll:FtraceCollector=None) -> 'PELTTask':
         """
@@ -685,10 +690,11 @@ class PELTTask(LoadTrackingBase):
         )
 
         phase = self.rtapp_profile[self.task_name].phases[0]
-        pelt_task = pelt.PeriodicTask(period_samples=phase.period_ms,
-                                      duty_cycle_pct=phase.duty_cycle_pct)
         peltsim = pelt.Simulator(init_value=init_value,
                                  half_life_ms=HALF_LIFE_MS)
+        period_samples = int(phase.period_ms*1e3/peltsim._sample_us)
+        pelt_task = pelt.PeriodicTask(period_samples=period_samples,
+                                      duty_cycle_pct=phase.duty_cycle_pct)
         df = peltsim.getSignal(pelt_task, 0, phase.duration_s)
 
         return peltsim, pelt_task, df
@@ -743,6 +749,23 @@ class PELTTask(LoadTrackingBase):
         phase = task.phases[0]
         cpu = phase.cpus[0]
 
+        # Note: This test-case is only valid if executed at capacity == 1024.
+        # The below assertion is insufficient as it only checks the CPU can potentially
+        # reach a capacity of 1024.
+        assert self.plat_info["cpu-capacities"][cpu] == UTIL_SCALE
+
+        # Due to simplifications in the PELT simulator :class:`bart.pelt.Simulator` and
+        # general misalignment between the simulated PELT signal and the traced one the
+        # error margin has to be fairly generous. The error sources include:
+        #
+        # 1. Misaligned PELT period boundaries (error <= 22)
+        # 2. Inaccurate duty cycle of rt_app task which can't be compensated for in the
+        #    PELT simulator as it only speaks integer PELT periods.
+        # 3. Nearest sample can be up to 512us off (error <= 11).
+        #
+        # The combined error depends on the properties of the task being traced/modelled.
+        # For a 50% 16ms period task that amounts to 5-7% error on TC2.
+
         peltsim, _, sim_df = self.get_simulated_pelt(cpu, signal_name)
         signal_df = self.get_task_sched_signals(cpu)
 
@@ -761,19 +784,13 @@ class PELTTask(LoadTrackingBase):
         plt.close()
 
         # Compare actual PELT signal with the simulated one
-        period_s = phase.period_ms / 1e3
-        sim_period_ms = phase.period_ms * (peltsim._sample_us / 1e6)
         errors = 0
 
         for entry in signal_df.iterrows():
             trace_val = entry[1][signal_name]
             timestamp = entry[0]
-            # Next two instructions map the trace timestamp to a simulated
-            # signal timestamp. This is due to the fact that the 1 ms is
-            # actually 1024 us in the simulated signal.
-            n_periods = timestamp / period_s
-            nearest_timestamp = n_periods * sim_period_ms
-            sim_val_loc = sim_df.index.get_loc(nearest_timestamp,
+
+            sim_val_loc = sim_df.index.get_loc(timestamp,
                                                method='nearest')
             sim_val = sim_df.pelt_value.iloc[sim_val_loc]
 
@@ -806,10 +823,11 @@ class PELTTask(LoadTrackingBase):
         """
         return self._test_range('load', allowed_error_pct)
 
-    def test_util_avg_behaviour(self, error_margin_pct=5, allowed_error_pct=5)\
+    def test_util_avg_behaviour(self, error_margin_pct=7, allowed_error_pct=5)\
         -> ResultBundle:
         """
-        Validate every utilization signal event
+        Validate every utilization signal event by comparing traced events with
+        simulated ones based on :class:`bart.pelt.Simulator`.
 
         :param error_margin_pct: How much the actual signal can stray from the
           simulated signal
@@ -819,10 +837,11 @@ class PELTTask(LoadTrackingBase):
         """
         return self._test_behaviour('util', error_margin_pct, allowed_error_pct)
 
-    def test_load_avg_behaviour(self, error_margin_pct=5, allowed_error_pct=5)\
+    def test_load_avg_behaviour(self, error_margin_pct=7, allowed_error_pct=5)\
         -> ResultBundle:
         """
-        Validate every load signal event
+        Validate every load signal event by comparing traced events with
+        simulated ones based on :class:`bart.pelt.Simulator`.
 
         :param error_margin_pct: How much the actual signal can stray from the
           simulated signal

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -1275,7 +1275,6 @@ class StepBase(StepABC):
                 # systemd 236 so we call reset-failed manually at the end
                 cmd = ['systemd-run', '--user', '-q', '--scope',
                     '-p', 'TimeoutStopSec={self.kill_timeout}'.format(self=self),
-                    '-p', 'PrivateTmp=true',
                     '--unit', scope_name, '--'
                 ]
                 cmd.extend(subcmd)


### PR DESCRIPTION
Cleaned up PELTTask test cases. Behaviour test case need larger margins due to inaccurate PELT simulation, and range test is made much more accurate by dropping the broken mean comparison. Further details in the commit messages.