### PR TITLE
setup.py: Don't use tornado >= 6.0 (again)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,9 @@ setup(
         "scipy",
         "ruamel.yaml >= 0.15.81",
 
+        # Jupyter doesn't like >= 6.0
+        "tornado < 6.0",
+
         # Depdendencies that are shipped as part of the LISA repo as
         # subtree/submodule
         "devlib",


### PR DESCRIPTION
This time it's Jupyter that breaks, see
https://github.com/jupyter/notebook/issues/4439