### PR TITLE
bisector: Fix syntax issue on Python 3.5

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -3308,7 +3308,7 @@ class MacroStep(StepBase):
             stat_test=Default, step_options=None,
             iterations = Default,
             timeout = Default,
-            bail_out_early = Default,
+            bail_out_early = Default
         ):
         if step_options is None:
             step_options = dict()


### PR DESCRIPTION
Python 3.5 does not allow trailing comma in parameter list of function
definitions.