### PR TITLE
tools: Introduce extract-platinfo

### DIFF
--- a/tools/extract-platinfo.py
+++ b/tools/extract-platinfo.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env python3
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2019, ARM Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Basic tool to extract a lisa.platform.plat_info.PlatformInfo from a live
+# target
+
+from lisa.target import Target
+
+def main():
+    target = Target.from_cli()
+    plat_info = target.plat_info
+
+    # Make sure we get all the information we can, even if it means running for
+    # a bit longer. RTapp calibration will be computed as it is a DeferredValue
+    plat_info.eval_deferred()
+
+    print(plat_info)
+
+    path = 'plat_info.yml'
+    plat_info.to_yaml_map(path)
+    print('\nPlatform info written to: {}'.format(path))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduce a dummy CLI tool to get a plat_info.yml file suitable for
loading using either:
* PlatformInfo.from_yaml_map('plat_info.yml')"
* exekall run --conf plat_info.yml"

The CLI is a bit crippled as it does not allow using a different file
name than plat_info.yml, and it does not give the choice to evaluate
deffered values or not (i.e. RTapp calibration will be run, which can be
lengthy and useless depending on the use case).

We may want to introduce a `Target.add_argparse_args(parser)` function that would add the same arguments as `from_cli()`, but on an existing parser. That would allow simple scripts to be built on top of that, giving a chance to register a couple of parameters like the ones missing here.

Also, we may want to change the default log-level, to avoid having to specify `--log-level info` all the time.