### PR TITLE
lisa.conf: Adapt generated docstring to usage

### DIFF
--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -1148,8 +1148,9 @@ class ConfigurableMeta(abc.ABCMeta):
             # keys that really need to be of a certain type when specified.
             filter_none=True,
         )
-        # Since a MultiSrcConf is a Mapping, it is useable as a source
-        conf_cls.DEFAULT_SRC = default_conf
+        # Convert to a dict so that the Sphinx documentation is able to show
+        # the content of the source
+        conf_cls.DEFAULT_SRC = dict(default_conf._get_effective_map())
 
         # Update the docstring by using the configuration help
         docstring = new_cls.__doc__

--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -25,7 +25,8 @@ import itertools
 import textwrap
 
 from lisa.utils import (
-    Serializable, Loggable, get_nested_key, set_nested_key, get_call_site
+    Serializable, Loggable, get_nested_key, set_nested_key, get_call_site,
+    is_running_sphinx,
 )
 
 class DeferredValue:
@@ -420,8 +421,8 @@ class MultiSrcConfMeta(abc.ABCMeta):
     """
     Metaclass of :class:`MultiSrcConf`.
 
-    It will use the docstring of the class, using it as a ``str.format`` template
-    with the ``{generated_help}`` placeholder replaced by a snippet of
+    It will use the docstring of the class, using it as a ``str.format``
+    template with the ``{generated_help}`` placeholder replaced by a snippet of
     ResStructuredText containing the list of allowed keys.
 
     .. note:: Since the dosctring is interpreted as a template, "{" and "}"
@@ -432,8 +433,10 @@ class MultiSrcConfMeta(abc.ABCMeta):
         if not inspect.isabstract(new_cls):
             doc = new_cls.__doc__
             if doc:
-                # Create a ResStructuredText preformatted block
-                generated_help = '\n' + new_cls.get_help(style='rst')
+                # Create a ResStructuredText preformatted block when rendering
+                # with Sphinx
+                style = 'rst' if is_running_sphinx() else None
+                generated_help = '\n' + new_cls.get_help(style=style)
                 new_cls.__doc__ = doc.format(generated_help=generated_help)
         return new_cls
 

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -1241,6 +1241,9 @@ class MissingTraceEventError(RuntimeError):
 class FtraceConf(SimpleMultiSrcConf, HideExekallID):
     """
     Configuration class of :class:`FtraceCollector`
+
+    Available keys:
+    {generated_help}
     """
     STRUCTURE = TopLevelKeyDesc('ftrace-conf', 'FTrace configuration', (
         KeyDesc('events', 'FTrace events to trace', [StrList]),

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -662,4 +662,11 @@ def get_call_site(levels=0, exclude_caller_module=False):
 
     return (caller, filename, lineno)
 
+def is_running_sphinx():
+    """
+    Returns True if the module is imported when Sphinx is running, False
+    otherwise.
+    """
+    return 'sphinx' in sys.modules
+
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab


### PR DESCRIPTION
When running under Sphinx, generate a reStructuredText docstring,
otherwise generate a plain text docstring.

EDIT: added also:
* key description placeholder in FtraceConf's docstring
* improved display of DEFAULT_SRC in Sphinx doc by using a dict instead of a MultiSrcConf instance
