### PR TITLE
tests: eas_behaviour: Fix TwoBigThreeSmall duty cycle

### DIFF
--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -480,9 +480,9 @@ class TwoBigThreeSmall(EASBehaviour):
         # 50% of the smallest CPU's capacity
         small_duty = cls.unscaled_utilization(
             plat_info, plat_info["capacity-classes"][0][0], 50)
-        # 80% of the biggest CPU's capacity
+        # 70% of the biggest CPU's capacity
         big_duty = cls.unscaled_utilization(
-            plat_info, plat_info["capacity-classes"][-1][0], 80)
+            plat_info, plat_info["capacity-classes"][-1][0], 70)
 
         rtapp_profile = {}
 


### PR DESCRIPTION
The big tasks in TwoBigThreeSmall are 80%. Because of this, EAS is kept
overutilized consistently, hence not giving the small tasks an
opportunity to be placed appropriately on little CPUs.

Although this is arguably something that could be improved on the kernel
side, it should also be noted that these tasks used to be 70% in the old
Lisa implementation, hence avoiding the problem altogether. Since the
change to 80% was not intended, and since the current test failures
don't teach us anything that we didn't know before, let's revert to 70%
tasks and avoid unnecessary pain.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>