### PR TITLE
lisa-help: Remove reference to lisa-report

### DIFF
--- a/shell/README.txt
+++ b/shell/README.txt
@@ -25,11 +25,6 @@ lisa-update-subtrees - Update the subtrees by pulling their latest changes
 
 lisa-jupyter - Start/Stop the Jupyter Notebook server
 
-.:: Results analysis and Documentation
---------------------------------------
-
-lisa-report  - Pretty format results of last test
-
 .:: Test commands
 --------------------------------------
 


### PR DESCRIPTION
The lisa-report command is long dead. Don't mention it in lisa-help.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>