### PR TITLE
[RFC] lisa.tests: load_tracking: Invariance: Treat load like util

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -309,9 +309,18 @@ class InvarianceItem(LoadTrackingBase):
 
         signal_mean = area_under_curve(signal) / (signal.index[-1] - signal.index[0])
 
-        if signal_name == 'load':
-            # Load isn't CPU invariant
-            exp_signal /= (self.plat_info['cpu-capacities'][cpu] / UTIL_SCALE)
+        # Since load is now CPU invariant in recent kernel versions, we don't
+        # rescale it back. To match the old behavior, that line is
+        # needed:
+        #  exp_signal /= (self.plat_info['cpu-capacities'][cpu] / UTIL_SCALE)
+        kernel_version = self.plat_info['kernel']['version']
+        if (
+            signal_name == 'load'
+            and kernel_version.parts[:2] < (5, 1)
+        ):
+            self.get_logger().warning('Load signal is assumed to be CPU invariant, which is true for recent mainline kernels, but may be wrong for {}'.format(
+                kernel_version,
+            ))
 
         ok = self.is_almost_equal(exp_signal, signal_mean, allowed_error_pct)
 


### PR DESCRIPTION
Do not rescale the signal specifically when it is the load.
