### PR TITLE
lisa.analysis: Fix import of submodules

### DIFF
--- a/lisa/analysis/__init__.py
+++ b/lisa/analysis/__init__.py
@@ -16,19 +16,18 @@
 # limitations under the License.
 #
 
-import pkgutil
-
-# Import all the submodules before they are asked for by user code, since we
-# need to create the *Analysis classes in order for them to be registered
-# against TraceAnalysisBase
 __all__ = []
-for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
-    __all__.append(module_name)
-    module = loader.find_module(module_name).load_module(module_name)
-    # Load module under its right name, so explicit imports of it will hit the
-    # sys.module cache instead of importing twice, with two "version" of each
-    # classes defined inside.
-    globals()[module_name] = module
 
+# Import all the submodules before they are asked for by user code, since
+# we need to create the *Analysis classes in order for them to be
+# registered against TraceAnalysisBase
+def _import_submodules():
+    from lisa.utils import _import_all_submodules
+    modules = _import_all_submodules(__name__, __path__)
+    __all__.extend(modules)
+
+_import_submodules()
+# Avoid polluting the namespace with non-necessary names
+del _import_submodules
 
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/target.py
+++ b/lisa/target.py
@@ -37,7 +37,7 @@ from devlib import Platform
 from devlib.platform.gem5 import Gem5SimulationPlatform
 
 from lisa.wlgen.rta import RTA
-from lisa.utils import Loggable, HideExekallID, resolve_dotted_name, get_all_subclasses, import_all_submodules, LISA_HOME, RESULT_DIR, LATEST_LINK, setup_logging, ArtifactPath
+from lisa.utils import Loggable, HideExekallID, resolve_dotted_name, get_subclasses, import_all_submodules, LISA_HOME, RESULT_DIR, LATEST_LINK, setup_logging, ArtifactPath
 from lisa.conf import SimpleMultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc, StrList, Configurable
 
 from lisa.platforms.platinfo import PlatformInfo
@@ -496,7 +496,7 @@ class Target(Loggable, HideExekallID, Configurable):
         # Get all devlib Module subclasses that exist
         devlib_module_set = {
             cls.name
-            for cls in get_all_subclasses(devlib.module.Module)
+            for cls in get_subclasses(devlib.module.Module)
             if (
                 getattr(cls, 'name', None)
                 # early modules try to connect to UART and do very

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -136,15 +136,6 @@ def resolve_dotted_name(name):
     mod = importlib.import_module(mod_name)
     return getattr(mod, callable_name)
 
-def get_all_subclasses(cls, cls_set=None):
-    if cls_set is None:
-        cls_set = set()
-    cls_set.add(cls)
-    for subcls in cls.__subclasses__():
-        get_all_subclasses(subcls, cls_set)
-
-    return cls_set
-
 def import_all_submodules(pkg):
     """Import all submodules of a given package."""
     return _import_all_submodules(pkg.__name__, pkg.__path__)

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -147,9 +147,21 @@ def get_all_subclasses(cls, cls_set=None):
 
 def import_all_submodules(pkg):
     """Import all submodules of a given package."""
+    return _import_all_submodules(pkg.__name__, pkg.__path__)
+
+def _import_all_submodules(pkg_name, pkg_path):
+    def import_module(module_name):
+        # Load module under its right name, so explicit imports of it will hit
+        # the sys.module cache instead of importing twice, with two "version"
+        # of each classes defined inside.
+        full_name = '{}.{}'.format(pkg_name, module_name)
+        module = importlib.import_module(full_name)
+        return module
+
     return [
-        loader.find_module(module_name).load_module(module_name)
-        for loader, module_name, is_pkg in pkgutil.walk_packages(pkg.__path__)
+        import_module(module_name)
+        for finder, module_name, is_pkg
+        in pkgutil.walk_packages(pkg_path)
     ]
 
 class UnknownTagPlaceholder:


### PR DESCRIPTION
Import submodules under their right full name, to avoid having clones of
the same module flying around, leading to unexpected issues.