### PR TITLE
lisa.energy_meter: Cleanup EnergyMeter configuration

### DIFF
--- a/doc/transition_guide.rst
+++ b/doc/transition_guide.rst
@@ -252,3 +252,32 @@ framework has been put in place. Tests are now coded as pure Python classes,
 which means they can be imported and executed in scripts/notebooks without any
 additionnal effort. See :ref:`kernel-testing-page` for more details about
 using/writing tests.
+
+
+Energy Meter
+++++++++++++
+
+Energy meters are all subclasses of :class:`lisa.energy_meter.EnergyMeter`.
+They can now be created in two ways. For :class:`lisa.energy_meter.HWMon`, this
+would give::
+
+  target = Target.from_default_conf()
+  res_dir = "/foo/bar"
+
+  # Directly build an instance
+  emeter = HWMon(target, channel_map=..., res_dir=res_dir)
+
+  # Or using a configuration file
+  conf = HWMonConf.from_yaml_map('path/to/hwmon_conf.yml')
+  emeter = HWMon.from_conf(target, conf, res_dir)
+
+with ``hwmon_conf.yml`` containing:
+
+.. code-block:: YAML
+
+  hwmon-conf:
+       channel-map: ...
+
+All subclasses of :class:`lisa.energy_meter.EnergyMeter` have a configuration
+class named `*Conf`.
+

--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -1356,6 +1356,9 @@ class IntIntDict(TypedDict):
 class IntList(TypedList):
     _type = int
 
+class FloatList(TypedList):
+    _type = float
+
 class IntIntListDict(TypedDict):
     _type = (int, IntList)
 

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -105,6 +105,27 @@ def get_subclasses(cls, only_leaves=False, cls_set=None):
 
     return cls_set
 
+
+def get_cls_name(cls, style=None):
+    """
+    Get a prettily-formated name for the class given as parameter
+
+    :param cls: class to get the name from
+    :type cls: type
+
+    :param style: When "rst", a RestructuredText snippet is returned
+    :param style: str
+
+    """
+    if cls is None:
+        return 'None'
+    mod_name = inspect.getmodule(cls).__name__
+    mod_name = mod_name + '.' if mod_name not in ('builtins', '__main__') else ''
+    name = mod_name + cls.__qualname__
+    if style == 'rst':
+        name = ':class:`~{}`'.format(name)
+    return name
+
 class HideExekallID:
     """Hide the subclasses in the simplified ID format of exekall.
 


### PR DESCRIPTION
Use one configuration class per type of EnergyMeter, so that all keys
are properly described, and each of them will get an independent
configuration format to be used with `EnergyMeter.from_conf()`

Disclaimer:  that is untested code
Disclaimer 2: the change has only been done for HWMon as an example, the same would need to be done for the other classes as well.

Using it would give:
```
target = ...
res_dir = ...
conf = HWMonConf.from_yaml_map('path/to/hwmon_conf.yml')
emeter = HWMon.from_conf(target, conf, res_dir)
```
With `hwmon_conf.yml`:
```
hwmon-conf:
     channel-map: ...
```
OR 
```
target = ...
res_dir = ...
emeter = HWMon(target, channel_map=..., res_dir=res_dir)
```

`HWMonConf` documentation would describe the available keys just like `FtraceCollectorConf` does.