### PR TITLE
lisa/test: Adjust PELTTask.test_{util,load}_avg_range margin

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -807,7 +807,7 @@ class PELTTask(LoadTrackingBase):
 
         return res
 
-    def test_util_avg_range(self, allowed_error_pct=1) -> ResultBundle:
+    def test_util_avg_range(self, allowed_error_pct=1.5) -> ResultBundle:
         """
         Test that the util_avg value ranges (min, max) are sane
 
@@ -815,7 +815,7 @@ class PELTTask(LoadTrackingBase):
         """
         return self._test_range('util', allowed_error_pct)
 
-    def test_load_avg_range(self, allowed_error_pct=1) -> ResultBundle:
+    def test_load_avg_range(self, allowed_error_pct=1.5) -> ResultBundle:
         """
         Test that the load_avg value ranges (min, max) are sane
 


### PR DESCRIPTION
The margin was recently reduced from 15% to 1% however it turns out that
this is a little bit too tight as minor shifts in time and interference
from kthreads regularly causes the 1% margin to be breached. 1.5% should
be sufficient to accommodate for those inaccuracies.