### PR TITLE
ftrace events: use @requires_events on top of hand-specified ftrace_conf

### DIFF
--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -20,6 +20,7 @@
 import pandas as pd
 
 from lisa.analysis.base import TraceAnalysisBase
+from lisa.trace import requires_one_event_of
 
 
 class LoadTrackingAnalysis(TraceAnalysisBase):
@@ -87,6 +88,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
 
         raise RuntimeError("Trace is missing one of either events: {}".format(events))
 
+    @requires_one_event_of('sched_load_cfs_rq', 'sched_load_avg_cpu')
     def df_cpus_signals(self):
         """
         Get the load-tracking signals for the CPUs
@@ -95,15 +97,10 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
 
           * A ``util`` column (the average utilization of a CPU at time t)
           * A ``load`` column (the average load of a CPU at time t)
-
-        :Required events:
-          Either of:
-
-          * ``sched_load_cfs_rq``
-          * ``sched_load_avg_cpu``
         """
         return self._df_either_event(['sched_load_cfs_rq', 'sched_load_avg_cpu'])
 
+    @requires_one_event_of('sched_load_se', 'sched_load_avg_task')
     def df_tasks_signals(self):
         """
         Get the load-tracking signals for the tasks
@@ -117,12 +114,6 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
 
           * A ``required_capacity`` column (the minimum available CPU capacity
             required to run this task without being CPU-bound)
-
-        :Required events:
-          Either of:
-
-          * ``sched_load_se``
-          * ``sched_load_avg_task``
         """
         df =  self._df_either_event(['sched_load_se', 'sched_load_avg_task'])
 
@@ -142,6 +133,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
 
         return df
 
+    @df_tasks_signals.used_events
     def df_top_big_tasks(self, util_threshold, min_samples=100):
         """
         Tasks which had 'utilization' samples bigger than the specified
@@ -171,6 +163,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
 
         return top_df
 
+    @df_cpus_signals.used_events
     def plot_cpus_signals(self, cpus=None, filepath=None):
         """
         Plot the CPU-related load-tracking signals
@@ -216,6 +209,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
         self.save_plot(fig, filepath)
         return axes
 
+    @df_tasks_signals.used_events
     def plot_task_signals(self, task, filepath=None):
         """
         Plot the task-related load-tracking signals
@@ -245,6 +239,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
         self.save_plot(fig, filepath)
         return axis
 
+    @df_tasks_signals.used_events
     def plot_task_required_capacity(self, task, filepath=None, axis=None):
         """
         Plot the minimum required capacity of a task
@@ -286,6 +281,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
 
         return axis
 
+    @df_tasks_signals.used_events
     def plot_task_placement(self, task, filepath=None):
         """
         Plot the CPU placement of the task

--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -176,29 +176,16 @@ class LISAAdaptor(AdaptorBase):
                 events.update(get_trace_events(param_expr))
             return events
 
-        def format_events(events):
-            if not events:
-                return '\n\t<no events>'
-            else:
-                joiner = '\n\t- '
-                return joiner + joiner.join(sorted(events))
+        events = set()
+        for expr in expr_list:
+            events.update(get_trace_events(expr))
 
-        def format_expr(expr):
-            hidden_callable_set = {
-                op.callable_ for op in self.hidden_op_set
-            }
-            expr_id = expr.get_id(
-                qual=False,
-                full_qual=verbose,
-                hidden_callable_set=hidden_callable_set
-            )
-            events = sorted(get_trace_events(expr))
-            return '{}:{}'.format(expr_id, format_events(events))
-
-        return 'Used trace events:\n' + '\n\n'.join(
-            format_expr(expr)
-            for expr in expr_list
-        )
+        if events:
+            joiner = '\n  - '
+            events_str = joiner + joiner.join(sorted(events))
+        else:
+            events_str = ' <no events>'
+        return 'Used trace events:{}'.format(events_str)
 
     @staticmethod
     def register_run_param(parser):

--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -157,9 +157,6 @@ class LISAAdaptor(AdaptorBase):
         return hidden_op_set
 
     def format_expr_list(self, expr_list, verbose=0):
-        if not self.args.list_trace_events:
-            return ''
-
         def get_trace_events(expr):
             events = set()
             if issubclass(expr.op.value_type, TestBundle):
@@ -197,9 +194,6 @@ class LISAAdaptor(AdaptorBase):
             metavar='SERIALIZED_OBJECT_PATH',
             default=[],
             help="Serialized object to inject when building expressions")
-
-        parser.add_argument('--list-trace-events', action='store_true',
-            help="Show the list of trace events collected for each testcase")
 
         # Create an empty TargetConf, so we are able to get the list of tests
         # as if we were going to execute them using a target.

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -410,6 +410,14 @@ class RTATestBundleMeta(abc.ABCMeta):
 class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
     """
     Abstract Base Class for :class:`lisa.wlgen.rta.RTA`-powered TestBundles
+
+    Optionally, an ``ftrace_conf`` class attribute can be defined to hold
+    additional FTrace configuration used to record a trace while the synthetic
+    workload is being run. By default, the required events are extracted from
+    decorated test methods.
+
+    .. seealso: :class:`lisa.tests.base.RTATestBundleMeta` for default
+        ``ftrace_conf`` content.
     """
 
     TRACE_PATH = 'trace.dat'
@@ -419,17 +427,6 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
     DMESG_PATH = 'dmesg.log'
     """
     Path to the dmesg log in the result directory.
-    """
-
-    ftrace_conf = FtraceConf({
-        "events" : [
-            "sched_switch",
-            "sched_wakeup"
-        ],
-    }, __qualname__)
-    """
-    The FTrace configuration used to record a trace while the synthetic workload
-    is being run.
     """
 
     TASK_PERIOD_MS = 16

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -1094,6 +1094,16 @@ class TraceEventCheckerBase(abc.ABC, Loggable):
         """
         pass
 
+    @abc.abstractmethod
+    def get_all_events(self):
+        """
+        Return a set of all events that are checked by this checker.
+
+        That may be a superset of events that are strictly required, when the
+        checker checks a logical OR combination of events for example.
+        """
+        pass
+
     def __call__(self, f):
         """
         Decorator for methods that require some given trace events
@@ -1175,6 +1185,9 @@ class TraceEventChecker(TraceEventCheckerBase):
     def __init__(self, event):
         self.event = event
 
+    def get_all_events(self):
+        return {self.event}
+
     def check_events(self, event_set):
         if self.event not in event_set:
             raise MissingTraceEventError(self)
@@ -1209,6 +1222,12 @@ class AssociativeTraceEventChecker(TraceEventCheckerBase):
 
         self.checkers = checker_list
         self.op_str = op_str
+
+    def get_all_events(self):
+        events = set()
+        for checker in self.checkers:
+            events.update(checker.get_all_events())
+        return events
 
     @classmethod
     def from_events(cls, events):

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -789,9 +789,9 @@ def do_run(args, parser, run_parser, argv):
             if verbose >= 2:
                 out(expr.get_structure() + '\n')
 
-    formatted_out = adaptor.format_expr_list(expr_list, verbose=verbose)
-    if formatted_out:
-        out('\n' + formatted_out + '\n')
+        formatted_out = adaptor.format_expr_list(expr_list, verbose=verbose)
+        if formatted_out:
+            out('\n' + formatted_out + '\n')
 
     if only_list:
         return 0


### PR DESCRIPTION
Introduce a metaclass for RTATestBundle that makes sure that the `ftrace_conf` of each subclass get at least all the events that are needed by their methods when they are decorated using `@requires_events`.

That avoids duplication of that information and also avoids writing it explicitly in docstrings, since sphinx will add the list of required events using the same information. That also allows setting the required events deep in the analysis functions that actually use it, and then pointing to that through the call chain using `@the_analysis_method.used_events`.

Also, use that for --list-trace-events that has been revamped and removed at the occasion (removed=there is no CLI option anymore since it is always done by default).

In this PR, I've "ported" synthetic tests to use that system, so they don't need any manual `ftrace_conf` class attribute to be setup anymore.