### PR TITLE
Fixes for wltests on P3

### DIFF
--- a/doc/workflows/wltest.rst
+++ b/doc/workflows/wltest.rst
@@ -2,6 +2,69 @@
 Wltest
 ******
 
-.. TODO:: write me
+Wltest enables the comparison of power and performance impacts of kernel
+changes on Android devices. Wltest takes a list of kernel commits as input,
+build and flashes each one on a device, and runs a `workload-automation` agenda
+in order to collect power and performance metrics. After the execution, the
+results can be parsed and analyized using the ipython agenda provided in Lisa
+under ``ipynb/wltests/sched-evaluation-full.ipynb``
 
-**(This page is being worked on, come back later!)**
+The ``lisa-wltest-series --help`` command provides the full list of parameters
+for wltest.
+
+Target types
+============
+
+Wltests supports two types of targets:
+
+ 1. the `standard` targets, for which the build procedure is aligned with
+    upstream (using a simple defconfig and make command);
+
+ 2. the `repo` targets, for which the build procedure is entirely managed
+    by a repo containing the kernel sources, modules, toolchains and build
+    scripts. The repo targets have ``WLTEST_REPO_TARGET="y"`` set in their
+    `definitions` file.
+
+Standard targets
+++++++++++++++++
+
+For standard targets, such as Hikey 960, the wltest workflow goes as follows:
+
+ 1. Clone the kernel sources with
+    ``git clone https://android.googlesource.com/kernel/hikey-linaro``
+
+ 2. Hack the kernel and commit your changes
+
+ 3. Repeat 2. as necessary
+
+ 4. Put in a 'series' file the list commits you want to test using the
+    ``<sha1> <commit title>`` format as provided by
+    ``git log --oneline --no-color --no-decorate``
+
+ 5. Run ``lisa-wltest-series`` with ``-k`` pointed at the kernel source tree and
+    ``-s`` pointed at the file created in 4.
+
+Repo targets
+++++++++++++
+
+The kernel sources of `repo` targets are managed using Google's ``repo`` tool
+(see https://source.android.com/setup/develop/repo). The kernel repo usually
+features the kernel sources, the module sources, the required toolchains, the
+build scripts, and potentially more.
+
+For repo targets, such as Pixel 3, the wltest workflow goes as follows:
+
+ 1. Download the sources using ``repo`` as explained in
+    https://source.android.com/setup/build/building-kernels#downloading
+
+ 2. Issue ``repo start --all <branch name>`` in the repo
+
+ 3. Go in the sub-trees (kernel and/or modules), hack the code, and commit
+    your changes
+
+ 4. Repeat 2. and 3. as necessary
+
+ 5. Put in a 'series' files the list of repo branches you want to test
+
+ 6. Run ``lisa-wltest-series`` with ``-k`` pointed at the top level repo folder
+    downloaded in 1., and ``-s`` pointing at the file created in 5.

--- a/tools/wltests/test_series
+++ b/tools/wltests/test_series
@@ -325,12 +325,10 @@ export PLATFORM_OVERLAY_PATH=$PLATFORM_PATH
 
 source $PLATFORM_PATH/definitions
 
-# On targets that don't use 'repo', KERNEL_SRC == GIT_TREE == KERNEL_TREE
+# On targets that don't use 'repo', KERNEL_SRC == KERNEL_TREE
 # On targets that do use 'repo':
 #   - KERNEL_SRC points to the top level of the repo
-#   - GIT_TREE points to the _manifest_ git tree in the repo
 #   - KERNEL_TREE points to the _kernel_ git tree in the repo
-GIT_TREE=""
 KERNEL_TREE=""
 
 export KERNEL_SRC=$(realpath -s $KERNEL_SRC)
@@ -348,7 +346,6 @@ if [ "x$WLTEST_REPO_TARGET" == "xy" ]; then
 		echo
 		exit $EINVAL
 	fi
-	GIT_TREE="$KERNEL_SRC/.repo/manifests"
 	KERNEL_TREE="$KERNEL_SRC/$REPO_KERNEL_PATH"
 else
 	# Prepare KERNEL_SRC
@@ -359,7 +356,6 @@ else
 		echo
 		exit $EINVAL
 	fi
-	GIT_TREE="$KERNEL_SRC"
 	KERNEL_TREE="$KERNEL_SRC"
 fi
 
@@ -807,9 +803,12 @@ name_sha1() {
 	# In case the specified SHA1 has not a name, let's use the SHA1
 	COMMIT_NAME=$COMMIT_SHA1
 
+	if [ "x$WLTEST_REPO_TARGET" == "xy" ]; then
+		return $OK
+	fi
 	# Find a name for each possible REF
 	mkfifo tmp_pipe &>/dev/null
-	git -C $GIT_TREE for-each-ref \
+	git -C $KERNEL_TREE for-each-ref \
 			--sort=-committerdate \
 			--format='%(objectname:short) %(refname:short)' \
 			refs/heads/ refs/remotes/ refs/tags |
@@ -852,28 +851,21 @@ match_sha1() {
 build_sha1() {
 	COMMIT_SHA1=$1
 
-	### Prepare GIT_TREE for build
-	pushd $GIT_TREE &>/dev/null
+	### Prepare KERNEL_SRC for build
+	pushd $KERNEL_SRC &>/dev/null
 	echo
-	c_info "Checkout: $GIT_TREE @ $COMMIT_SHA1..."
-	git checkout $COMMIT_SHA1; ERROR=$?
+	c_info "Checkout: $KERNEL_SRC @ $COMMIT_SHA1..."
+	if [ "x$WLTEST_REPO_TARGET" == "xy" ]; then
+		repo checkout $COMMIT_SHA1; ERROR=$?
+	else
+		git checkout $COMMIT_SHA1; ERROR=$?
+	fi
 	if [ $ERROR -ne 0 ]; then
 		c_error "Failed to checkout [$COMMIT_SHA1]"
 		popd &>/dev/null
 		return $ERROR
 	fi
 	popd &>/dev/null
-
-	### Sync the repo if needed
-	if [ "x$WLTEST_REPO_TARGET" == "xy" ]; then
-		pushd $KERNEL_SRC &> /dev/null
-		repo sync -l; ERROR=$?
-		popd &> /dev/null
-		if [ $ERROR -ne 0 ]; then
-			c_error "Failed to sync [$COMMIT_SHA1]"
-			return $ERROR
-		fi
-	fi
 
 	### Build all IMAGES
 	pushd $BASE_DIR &>/dev/null
@@ -1040,14 +1032,21 @@ while read -u10 COMMITS; do
 	COMMIT=${COMMITS%% *}
 
 	# Translate possible branch name to SHA1
-	COMMITS=$(git -C $GIT_TREE show-ref -s $COMMIT)
+	COMMITS=$(git -C $KERNEL_TREE show-ref -s $COMMIT)
 	if [ $? -ne 0 ]; then
 		COMMIT_SHA1=$COMMIT
-	elif [ $(echo $COMMITS | wc -w) -eq 1 ]; then
-		COMMIT_SHA1=$COMMITS
+	elif [ $(echo $(git -C $KERNEL_TREE show-ref -s $COMMIT | sort | uniq) | wc -w) -eq 1 ]; then
+		if [ "x$WLTEST_REPO_TARGET" == "xy" ]; then
+			# For repo targets, the series file contains the name
+			# of repo branches, which is what 'repo checkout'
+			# understands
+			COMMIT_SHA1=$COMMIT
+		else
+			COMMIT_SHA1=$(git -C $KERNEL_TREE show-ref -s $COMMIT | sort | uniq)
+		fi
 	else
 		c_error "The branch name must be univocal, \"$COMMIT\" may refer to:"
-		for b in $(git -C $GIT_TREE show-ref $COMMIT | cut -f 2 -d " "); do
+		for b in $(git -C $KERNEL_TREE show-ref $COMMIT | cut -f 2 -d " "); do
 			c_error "    $b"
 		done
 		exit $EINVAL


### PR DESCRIPTION
So it turns out `repo sync -l` _can_ rebase stuff behind your back ... I'm a bit tired of playing around with this so I took the decision to stop messing around with `repo sync` and to just use proper repo branches (which is what I should have done from the start). That makes it a bit harder to test different toolchains and things like that, but that actually works properly for what we really want to do, that is, testing kernel changes.

I understand this whole thing is becoming more confusing than necessary (since I change my mind every week or so), so this PR also creates some basic wltest doc to explain how to use it for 'repo' targets.

For the future implementation of wltest we should drop the support for !repo targets I think -- Google now ship build scripts for all platforms we have in wltest (https://source.android.com/setup/build/building-kernels#downloading) but I think that's for later.