### PR TITLE
lisa.tests: Turn rtapp_profile in a property

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -350,11 +350,7 @@ class TestBundle(Serializable, abc.ABC):
 
 class RTATestBundle(TestBundle):
     """
-    "Abstract" class for :class:`lisa.wlgen.rta.RTA`-powered TestBundles
-
-    :param rtapp_profile: The rtapp parameters used to create the synthetic
-      workload. That happens to be what is returned by :meth:`get_rtapp_profile`
-    :type rtapp_profile: dict
+    Abstract Base Class for :class:`lisa.wlgen.rta.RTA`-powered TestBundles
     """
 
     TRACE_PATH = 'trace.dat'
@@ -431,9 +427,12 @@ class RTATestBundle(TestBundle):
         trace = Trace(path, self.plat_info, events=self.ftrace_conf["events"])
         return trace.get_view(self.trace_window(trace))
 
-    def __init__(self, res_dir, plat_info, rtapp_profile):
-        super().__init__(res_dir, plat_info)
-        self.rtapp_profile = rtapp_profile
+    @property
+    def rtapp_profile(self):
+        """
+        Compute the RTapp profile based on ``plat_info``.
+        """
+        return self.get_rtapp_profile(self.plat_info)
 
     @TasksAnalysis.df_tasks_runtime.used_events
     def test_noisy_tasks(self, noise_threshold_pct=None, noise_threshold_ms=None):
@@ -602,6 +601,6 @@ class RTATestBundle(TestBundle):
         rtapp_profile = cls.get_rtapp_profile(plat_info)
         cls._run_rtapp(target, res_dir, rtapp_profile, ftrace_coll)
 
-        return cls(res_dir, plat_info, rtapp_profile)
+        return cls(res_dir, plat_info)
 
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -40,10 +40,6 @@ class EASBehaviour(RTATestBundle):
     """
     Abstract class for EAS behavioural testing.
 
-    :param rtapp_profile: The rtapp parameters used to create the synthetic
-      workload. That happens to be what is returned by :meth:`get_rtapp_profile`
-    :type rtapp_profile: dict
-
     :param nrg_model: The energy model of the platform the synthetic workload
       was run on
     :type nrg_model: EnergyModel
@@ -80,14 +76,15 @@ class EASBehaviour(RTATestBundle):
             with target.cpufreq.use_governor("schedutil"):
                 cls._run_rtapp(target, res_dir, rtapp_profile, ftrace_coll=ftrace_coll)
 
-        return cls(res_dir, plat_info, rtapp_profile)
+        return cls(res_dir, plat_info)
 
     @classmethod
     def from_target(cls, target:Target, res_dir:ArtifactPath=None, ftrace_coll:FtraceCollector=None) -> 'EASBehaviour':
         """
         Factory method to create a bundle using a live target
 
-        This will execute the rt-app workload described in :meth:`get_rtapp_profile`
+        This will execute the rt-app workload described in
+        :meth:`lisa.tests.base.RTATestBundle.get_rtapp_profile`
         """
         return super().from_target(target, res_dir, ftrace_coll=ftrace_coll)
 

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -60,15 +60,6 @@ class EASBehaviour(RTATestBundle):
         return self.plat_info['nrg-model']
 
     @classmethod
-    @abc.abstractmethod
-    def get_rtapp_profile(cls, plat_info):
-        """Returns the RTapp profile for the given :class:`lisa.platforms.platinfo.PlatformInfo`.
-
-        :returns: :class:`lisa.wlgen.rta.RTATask`
-        """
-        pass
-
-    @classmethod
     def check_from_target(cls, target):
         for domain in target.cpufreq.iter_domains():
             if "schedutil" not in target.cpufreq.list_governors(domain[0]):

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -194,7 +194,7 @@ class LoadTrackingBase(RTATestBundle, LoadTrackingHelpers):
             with target.cpufreq.use_governor(**cls.cpufreq_conf):
                 cls._run_rtapp(target, res_dir, rtapp_profile, ftrace_coll)
 
-        return cls(res_dir, plat_info, rtapp_profile)
+        return cls(res_dir, plat_info)
 
     def get_task_sched_signals(self, trace, cpu, task_name):
         """
@@ -240,12 +240,16 @@ class InvarianceItem(LoadTrackingBase):
         "governor" : "userspace"
     }
 
-    def __init__(self, res_dir, plat_info, rtapp_profile, cpu, freq, freq_list):
-        super().__init__(res_dir, plat_info, rtapp_profile)
+    def __init__(self, res_dir, plat_info, cpu, freq, freq_list):
+        super().__init__(res_dir, plat_info)
 
         self.freq = freq
         self.freq_list = freq_list
         self.cpu = cpu
+
+    @property
+    def rtapp_profile(self):
+        return self.get_rtapp_profile(self.plat_info, cpu=self.cpu)
 
     @classmethod
     def get_rtapp_profile(cls, plat_info, cpu):
@@ -285,7 +289,7 @@ class InvarianceItem(LoadTrackingBase):
             logger.debug('CPU{} frequency: {}'.format(cpu, target.cpufreq.get_frequency(cpu)))
             cls._run_rtapp(target, res_dir, rtapp_profile, ftrace_coll)
 
-        return cls(res_dir, plat_info, rtapp_profile, cpu, freq, freq_list)
+        return cls(res_dir, plat_info, cpu, freq, freq_list)
 
     def get_expected_util_avg(self, trace, cpu, task_name, capacity):
         """
@@ -895,8 +899,8 @@ class CPUMigrationBase(LoadTrackingBase):
 
         super()._run_rtapp(target, res_dir, profile, ftrace_coll)
 
-    def __init__(self, res_dir, plat_info, rtapp_profile):
-        super().__init__(res_dir, plat_info, rtapp_profile)
+    def __init__(self, res_dir, plat_info):
+        super().__init__(res_dir, plat_info)
 
         self.cpus = set()
 

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -122,8 +122,8 @@ class StaggeredFinishes(MisfitMigrationBase):
     rq->avg_idle > sysctl_sched_migration_cost
     """
 
-    def __init__(self, res_dir, plat_info, rtapp_profile):
-        super().__init__(res_dir, plat_info, rtapp_profile)
+    def __init__(self, res_dir, plat_info):
+        super().__init__(res_dir, plat_info)
 
         sdf = self.trace.df_events('sched_switch')
 


### PR DESCRIPTION
* Move get_rtapp_profile as an abstractmethod of RTATestBundle instead
of EASBehaviour
* Turn it into a property, to clean up __init__ signature, since it only
depends on plat_info attribute. That will make it clear what is part of
the minimal state of the object, and what is just derived information.