### PR TITLE
bisector: use requests package instead of curl

### DIFF
--- a/tools/bisector/setup.py
+++ b/tools/bisector/setup.py
@@ -44,6 +44,7 @@ setup(
         "ruamel.yaml >= 0.15.72",
         "pandas",
         "scipy",
+        "requests",
     ],
 
     extras_require={


### PR DESCRIPTION
Avoid depending on external CLI tool, use the well-known "requests"
package for network HTTP operations.