### PR TITLE
bisector: fix number of passed tests in summary line

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -2300,7 +2300,10 @@ class ExekallLISATestStep(ShellStep):
         assert counts['total'] == nr_tests
 
         # Only account for tests that only passed and had no other issues
-        counts['passed'] = nr_tests - (sum(counts.values()) - nr_tests)
+        counts['passed'] = sum(
+            set(stats['iterations_summary']) == {'passed'}
+            for stats in testcase_stats.values()
+        )
 
         out(
             'Error: {counts[error]}/{total}, '


### PR DESCRIPTION
Summar footer line for each step displays a number of pass test that
is not in line with the number of "passed" lines. Fix that by counting
the number of tests that had not other results than "passed".