### PR TITLE
exekall: Make serialization test more robust

### DIFF
--- a/tools/exekall/exekall/_utils.py
+++ b/tools/exekall/exekall/_utils.py
@@ -164,7 +164,7 @@ def is_serializable(obj, raise_excep=False):
         # This may be slow for big objects but it is the only way to be sure
         # it can actually be serialized
         pickle.dumps(obj)
-    except (TypeError, pickle.PickleError) as e:
+    except (TypeError, pickle.PickleError, AttributeError) as e:
         debug('Cannot serialize instance of {}: {}'.format(
             type(obj).__qualname__, str(e)
         ))


### PR DESCRIPTION
pickle.dumps() seems to also raise AttributeError sometimes, in addition
to pickle.PickleError:
AttributeError: Can't pickle local object 'SpawnBase.__init__.<locals>.write_to_stdout