### PR TITLE
energy_model: Reflect 80% capacity margin in optimal placement

### DIFF
--- a/tests/test_energy_model.py
+++ b/tests/test_energy_model.py
@@ -182,6 +182,11 @@ class TestOptimalPlacement(TestCase):
         self.assertRaises(EnergyModelCapacityError,
                           em.get_optimal_placements, {'task0' : 401})
 
+    def test_capacity_margin_single(self):
+        self.assertRaises(EnergyModelCapacityError,
+                          em.get_optimal_placements, {'task0' : 350},
+                          capacity_margin_pct=20)
+
     def test_overutilized_many(self):
         total_cap = 400 * 2 + 200 * 2
         task_size = 200


### PR DESCRIPTION
The Linux scheduler always tries to provide at least 20% of idle time to
all CPUs by not placing big tasks on small CPUs, and by selecting
appropriate frequencies. This is implemented by the 'capacity_margin'
coefficient in CFS, and schedutil's map_util_freq() (from 5.0 onwards).

However, this is not yet reflected in Lisa's optimal placement algorithm
which will assume a 39% task fits on a 40% CPU, for example. This
difference is the root cause for many task_task_placement failures on
some boards (TC2) although there is not much we can actually do to 'fix'
the kernel. One possibility would be to make the energy margin larger,
but that would lower the bar for all platforms so an alternative
solution is preferable.

In order to solve this, reflect the kernel's 80% capacity margin in
Lisa's algorithm to ensure an apple to apple comparison in the task
placement test. This arguably lowers the level of abstraction of the
test by making it deal with 'implementation caveats' rather than doing
pure functional testing. But we already do this for other things (e.g.
load tracking) and that should make the test actually work more
reliably, hence enabling better regression testing.

Signed-off-by: Quentin Perret <quentin.perret@arm.com>