### PR TITLE
tools: Add check-test-fix.py

### DIFF
--- a/doc/man1/bisector.1
+++ b/doc/man1/bisector.1
@@ -353,12 +353,16 @@ Inherits from: shell
             consider only tests that failed or had an error
 
       \-o ignore\-testcase= (comma\-separated list) 
-            completely ignore test cases matching one of the patterns in the
-            comma\-separated list. * can be used to match any part of the name.
+            completely ignore untagged test cases matching one of the patterns
+            in the comma\-separated list. * can be used to match any part of the
+            name.
 
       \-o iterations= (comma\-separated list of integer ranges) 
             comma\-separated list of iterations to consider. Inclusive ranges can
             be specified with <first>\-<last>
+
+      \-o result\-uuid= (comma\-separated list) 
+            show only the test results with a UUID in the comma\-separated list.
 
       \-o show\-artifact\-dirs= (bool) 
             show exekall artifact directory for all iterations
@@ -383,8 +387,9 @@ Inherits from: shell
             tests
 
       \-o testcase= (comma\-separated list) 
-            show only the test cases matching one of the patterns in the comma\-
-            separated list. * can be used to match any part of the name
+            show only the untagged test cases matching one of the patterns in
+            the comma\-separated list. * can be used to match any part of the
+            name
 
       \-o upload\-artifact= (bool) 
             upload the artifact directory to Artifactorial and update the in\-

--- a/doc/workflows/automated_testing.rst
+++ b/doc/workflows/automated_testing.rst
@@ -444,6 +444,25 @@ collected ones. This can then be compared with another one for regressions:
   without relying on other files/folders being available (locally or over
   HTTP).
 
+Fixing regressions
+------------------
+
+``check-test-fix.py`` tool can be used to check that a fix to a test resolved
+errors or a regression, provided that the test can be re-executed on
+already-collected :class:`lisa.tests.base.TestBundle` instances. It will call
+``exekall run`` in parallel on all the ``exekall``'s
+:class:`exekall.engine.ValueDB` collected by ``bisector run``, and will produce
+a regression table using ``exekall compare`` with ``old`` being the results
+from the report, and ``new`` being the new results.
+
+.. code-block:: sh
+  
+  # The test to check is selected using --select in the same way as for `exekall run`.
+  # hikey960.report.yml.gz is a bisector report generated using `bisector run`
+  # All options coming after the report are passed to `bisector report` to
+  # control what artifacts are downloaded and what TestBundle are used.
+  check-test-fix.py --select 'OneSmallTask:test_task_placement' hikey960.report.yml.gz -oiterations=1-20
+
 When something goes wrong
 +++++++++++++++++++++++++
 

--- a/lisa/regression.py
+++ b/lisa/regression.py
@@ -221,14 +221,9 @@ def compute_regressions(old_list, new_list, remove_tags=[], **kwargs):
     new_list = dedup_list(new_list, old_list)
 
     def get_id(froz_val):
-        id_ = froz_val.get_id(qual=False, with_tags=True)
-
         # Remove tags, so that more test will share the same ID. This allows
         # cross-board comparison for example.
-        for tag in remove_tags:
-            id_ = re.sub(r'\[{}=.*?\]'.format(tag), '', id_)
-
-        return id_
+        return froz_val.get_id(qual=False, with_tags=True, remove_tags=remove_tags)
 
     def group_by_testcase(froz_val_list):
         return OrderedDict(

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -1740,6 +1740,7 @@ class LISATestStep(ShellStep):
             show_details = ChoiceOrBoolParam(['msg'], 'show details of results. Use "msg" for only a brief message'),
             show_artifact_dirs = BoolParam('show exekall artifact directory for all iterations'),
             testcase = CommaListParam('show only the test cases matching one of the patterns in the comma-separated list. * can be used to match any part of the name'),
+            result_uuid = CommaListParam('show only the test results with a UUID in the comma-separated list.'),
             ignore_testcase = CommaListParam('completely ignore test cases matching one of the patterns in the comma-separated list. * can be used to match any part of the name.'),
             ignore_non_issue = BoolParam('consider only tests that failed or had an error'),
             ignore_non_error = BoolParam('consider only tests that had an error'),
@@ -1910,6 +1911,7 @@ class LISATestStep(ShellStep):
             show_pass_rate = False,
             show_artifact_dirs = False,
             testcase = [],
+            result_uuid = [],
             ignore_testcase = [],
             iterations = [],
             ignore_non_issue = False,
@@ -1941,6 +1943,7 @@ class LISATestStep(ShellStep):
         out = MLString()
 
         considered_testcase_set = set(testcase)
+        considered_uuid_set = set(result_uuid)
         ignored_testcase_set = set(ignore_testcase)
         considered_iteration_set = set(iterations)
 
@@ -1980,6 +1983,10 @@ class LISATestStep(ShellStep):
                             fnmatch.fnmatch(testcase_id, pattern)
                             for pattern in considered_testcase_set
                         ))
+                        or
+                        (considered_uuid_set and
+                            froz_val.uuid not in considered_uuid_set
+                        )
                         or
                         (ignored_testcase_set and any(
                             fnmatch.fnmatch(testcase_id, pattern)

--- a/tools/check-test-fix.py
+++ b/tools/check-test-fix.py
@@ -1,0 +1,353 @@
+#! /usr/bin/env python3
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2019, Arm Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import collections
+import os
+import subprocess
+import sys
+import tarfile
+import multiprocessing.pool
+import glob
+import pickle
+import shutil
+import contextlib
+from pathlib import Path
+import traceback
+
+from exekall.utils import DB_FILENAME
+
+def print_exception(e):
+    traceback.print_exception(type(e), e, e.__traceback__)
+
+def stringify(seq):
+    return [str(x) for x in seq]
+
+def cleanup(path):
+    """
+    Remove a folder of file.
+    """
+    _path = str(path)
+    with contextlib.suppress(FileNotFoundError):
+        try:
+            shutil.rmtree(_path)
+        except NotADirectoryError:
+            os.unlink(_path)
+    return path
+
+def check_output(*args, **kwargs):
+    try:
+        return subprocess.check_output(*args, **kwargs)
+    except subprocess.CalledProcessError as e:
+        for out in (e.stderr, e.stdout):
+            if out:
+                print(out.decode('utf-8'))
+        raise
+
+def download_artifacts(bisector_report, log_folder, exekall_db, extra_opts):
+    subprocess.call([
+        'bisector', 'report', bisector_report,
+        '-oexport-logs={}'.format(log_folder),
+        '-oexport-db={}'.format(exekall_db),
+        '-odownload',
+        *stringify(extra_opts),
+    ])
+
+def extract_tar(tar, dest):
+    """
+    Tar extraction worker.
+
+    Only extracts files not already extracted.
+    """
+
+    with tarfile.open(str(tar)) as f:
+        member_names = f.getnames()
+        root = Path(os.path.commonpath(member_names))
+        # Only extract once if the file has already been downloaded and
+        # extracted before to save IO bandwith
+        if not all((dest/name).exists() for name in member_names):
+            f.extractall(str(dest))
+
+    return dest/root
+
+def exekall_run(artifact_dir, db_path, test_patterns, test_src_list, log_level, load_type, replay_uuid):
+    """
+    exekall run worker
+    """
+    cmd = [
+        'exekall', 'run', *stringify(test_src_list),
+	    '--load-db', str(db_path), '--artifact-dir', str(artifact_dir),
+    ]
+    if replay_uuid:
+    	cmd.extend(['--replay', replay_uuid])
+    else:
+        cmd.extend([
+            '--load-type', load_type,
+    	    *('--select={}'.format(x) for x in test_patterns)
+            ])
+
+    if log_level:
+        cmd += ['--log-level', log_level]
+
+    # Capture output so it is not interleaved since multiple workers are
+    # running at the same time.
+    out = check_output(cmd, stderr=subprocess.STDOUT)
+
+    return artifact_dir, out.decode('utf-8')
+
+def exekall_merge(merged_artifact, db_path_list):
+    subprocess.check_call([
+        'exekall', 'merge',
+        '-o', str(merged_artifact),
+        *(str(path.parent) for path in db_path_list),
+    ])
+
+    return merged_artifact
+
+def exekall_compare(ref_db_path, new_db_path):
+    out = check_output([
+        'exekall', 'compare',
+        str(ref_db_path), str(new_db_path),
+        '--non-significant',
+        '--remove-tag', 'board',
+    ])
+    return out.decode('utf-8')
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="""
+Re-execute a LISA test on a artifacts referenced by a bisector report, and
+show the summary of changes in the results.
+
+All `bisector` options need to come last on the command line.
+
+EXAMPLE:
+    Re-execute all the "test_task_placement" tests on the 10 first iterations
+    of a hikey960 integration test.
+    $ check-test-fix.py -s '*:test_task_placement' hikey960.report.yml.gz --cache --only behaviour -oiterations=1-10
+""",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    load_group = parser.add_mutually_exclusive_group(required=True)
+    load_group.add_argument('-s', '--select',
+        action='append',
+        metavar='EXEKALL_SELECT_PATTERN',
+        help='Exekall run --select pattern to re-execute',
+    )
+
+    load_group.add_argument('--replay',
+        metavar='EXEKALL_RESULT_UUID',
+        help='See exekall run --replay and bisector report -oresult-uuid',
+    )
+
+    parser.add_argument('-t', '--python-src',
+        metavar='EXEKALL_PYTHON_SOURCES',
+        action='append',
+        default=[os.path.expandvars('$LISA_HOME/lisa/tests')],
+        help='Exekall run python modules',
+    )
+
+    parser.add_argument('--log-level',
+        action='store_true',
+        help='See exekall run --log-level',
+    )
+
+    parser.add_argument('--load-type',
+        default='*TestBundle',
+        help='See `exekall run --load-type`. It is ignored if --replay is used.',
+    )
+
+    parser.add_argument('bisector_report',
+        metavar='BISECTOR_REPORT',
+        help='Bisector report to use',
+    )
+
+    parser.add_argument('bisector_options',
+        metavar='BISECTOR_EXTRA_OPTIONS',
+        nargs=argparse.REMAINDER,
+        default=[],
+        help='Extra bisector options',
+    )
+
+    parser.add_argument('-j',
+        metavar='NR_CPUS',
+        type=int,
+        default=os.cpu_count() + 2,
+        help="""Number of processes to use for exekall run and tar extraction.
+        Defaults to number of CPUs + 2""",
+    )
+
+    parser.add_argument('-w', '--work-area',
+        type=Path,
+        help="Work area to use when processing the artifacts",
+    )
+
+    args = parser.parse_args(argv)
+
+    nr_cpus = args.j
+    nr_cpus = nr_cpus if nr_cpus > 0 else 1
+    bisector_extra_opts = args.bisector_options
+    result_uuid = args.replay
+    if result_uuid:
+        bisector_extra_opts.append('-oresult-uuid={}'.format(result_uuid))
+    bisector_report = args.bisector_report
+    exekall_test_patterns = args.select
+    if exekall_test_patterns:
+        bisector_extra_opts.append('-otestcase={}'.format(
+            ','.join(exekall_test_patterns)
+        ))
+
+    exekall_python_srcs = args.python_src
+    exekall_log_level = args.log_level
+    exekall_load_type = args.load_type
+    exekall_replay_uuid = result_uuid
+
+    work_area = args.work_area or Path('{}.check-test-fix'.format(Path(bisector_report).name))
+    work_area.mkdir(exist_ok=True)
+
+    # Read-back the options used the previous time. If they are the same,
+    # no need to re-download an extract everything.
+    extraction_state_path = str(work_area/'extraction_state')
+    try:
+        with open(extraction_state_path, 'rb') as f:
+            extraction_state = pickle.load(f)
+    except FileNotFoundError:
+        need_download = True
+    # If bisector options are different, we need to download and extract again
+    else:
+        need_download = (extraction_state['bisector_opts'] != bisector_extra_opts)
+
+    if need_download:
+        log_folder = work_area/'bisector_logs'
+        ref_db_path = work_area/'reference_VALUE_DB.pickle.xz'
+
+        # Make sure we don't have any archives from previous download, to avoid
+        # selecting more archives than we want when listing the content of the
+        # folder.
+        cleanup(log_folder)
+
+        download_artifacts(bisector_report, log_folder, ref_db_path,
+            bisector_extra_opts)
+    else:
+        print('Reusing previously downloaded artifacts ...')
+        ref_db_path = extraction_state['ref_db_path']
+        extracted_artifacts = extraction_state['extracted_artifacts']
+        log_folder = None
+
+
+    # List of ValueDB paths that are freshly created by exekall run.
+    # Since it is accessed by the pool's callback thread, use an atomic deque
+    new_db_path_deque = collections.deque()
+
+    # Use the context manager to make sure all worker subprocesses are
+    # terminated
+    with multiprocessing.pool.Pool(processes=nr_cpus) as exekall_pool:
+
+        def exekall_run_callback(run_result):
+            artifact_dir, out = run_result
+            # Since all callbacks are called from the same thread,
+            new_db_path_deque.append(artifact_dir/DB_FILENAME)
+
+            # Show the log of the run in one go, to avoid interleaved output
+            print('#'*80)
+            print('New results for {}'.format(artifact_dir))
+            print('\n\n')
+            print(out)
+
+        def schedule_exekall_run(artifact_dir):
+            # schedule an `exekall run` job
+            new_artifact_dir = cleanup(work_area/'new_exekall_artifacts'/artifact_dir.name)
+            exekall_pool.apply_async(exekall_run,
+                kwds=dict(
+                    artifact_dir=new_artifact_dir,
+                    db_path=artifact_dir/DB_FILENAME,
+                    test_patterns=exekall_test_patterns,
+                    test_src_list=exekall_python_srcs,
+                    log_level=exekall_log_level,
+                    load_type=exekall_load_type,
+                    replay_uuid=exekall_replay_uuid,
+                ),
+                callback=exekall_run_callback,
+            )
+
+        # Uncompress all downloaded archives and kick off exekall run from the
+        # callback
+        if need_download:
+            # Use a deque since it is appended from a different thread
+            extracted_artifacts = collections.deque()
+
+            def untar_callback(artifact_dir):
+                extracted_artifacts.append(artifact_dir)
+                return schedule_exekall_run(artifact_dir)
+
+            # extract archives asynchronously
+            with multiprocessing.pool.Pool(processes=nr_cpus) as untar_pool:
+                for tar in glob.iglob(
+                        str(log_folder/'**'/'lisa_artifacts.tar.xz'),
+                        recursive=True
+                    ):
+                    untar_pool.apply_async(extract_tar,
+                        kwds=dict(
+                            tar=tar,
+                            dest=work_area/'extracted_exekall_artifacts'
+                        ),
+                        callback=untar_callback,
+                        error_callback=print_exception,
+                    )
+
+                untar_pool.close()
+                untar_pool.join()
+        # Kick of exekall run
+        else:
+            for artifact_dir in extracted_artifacts:
+                schedule_exekall_run(artifact_dir)
+
+        # Save what was extracted for future reference when we know all the
+        # archives have been extracted successfully
+        with open(extraction_state_path, 'wb') as f:
+            pickle.dump({
+                    'bisector_opts': bisector_extra_opts,
+                    'ref_db_path': ref_db_path,
+                    'extracted_artifacts': list(extracted_artifacts),
+                },
+                f
+            )
+
+        # We know that once all archives has been uncompressed, all exekall run
+        # jobs have been submitted
+        exekall_pool.close()
+        exekall_pool.join()
+
+    # Merge DB before comparison
+    print('Merging the new artifacts for comparison ...')
+    merged_artifact = cleanup(work_area/'merged_new_exekall_artifacts')
+
+    print('Comparing the results ...')
+    merged_artifact_dir = exekall_merge(merged_artifact, new_db_path_deque)
+
+    out = exekall_compare(ref_db_path, merged_artifact_dir/DB_FILENAME)
+    print('\n\nRegressions/improvements:')
+    print(out)
+
+
+if __name__ == '__main__':
+    ret = main(sys.argv[1:])
+    sys.exit(ret)
+
+# vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/tools/exekall/exekall/_utils.py
+++ b/tools/exekall/exekall/_utils.py
@@ -38,6 +38,8 @@ import glob
 import textwrap
 import argparse
 
+DB_FILENAME = 'VALUE_DB.pickle.xz'
+
 class NotSerializableError(Exception):
     pass
 

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -3139,7 +3139,7 @@ class FrozenExprVal(ExprValBase):
     def type_names(self):
         return [
             utils.get_name(type_, full_qual=True)
-            for type_ in utils.get_mro(type(value))
+            for type_ in utils.get_mro(type(self.value))
             if type_ is not object
         ]
 

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -431,22 +431,25 @@ class ValueDB:
         This allows trimming a :class:`ValueDB` to a smaller size by removing
         non-necessary content.
         """
-        def prune(froz_val):
+        def prune(froz_val, do_prune):
             if isinstance(froz_val, PrunedFrozVal):
                 return froz_val
-            elif predicate(froz_val):
+            elif do_prune:
                 return PrunedFrozVal(froz_val)
             else:
                 # Edit the param_map in-place, so we keep it potentially shared
                 # if possible.
                 for param, param_froz_val in list(froz_val.param_map.items()):
-                    froz_val.param_map[param] = prune(param_froz_val)
+                    froz_val.param_map[param] = prune(
+                        param_froz_val,
+                        do_prune=predicate(param_froz_val)
+                    )
 
                 return froz_val
 
         def make_froz_val_seq(froz_val_seq):
             froz_val_list = [
-                prune(froz_val)
+                prune(froz_val, do_prune=False)
                 for froz_val in froz_val_seq
                 # Just remove the root PrunedFrozVal, since they are useless at
                 # this level (i.e. nothing depends on them)

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -36,8 +36,6 @@ import exekall.utils as utils
 from exekall.utils import NoValue, error, warn, debug, info, out, add_argument
 import exekall.engine as engine
 
-DB_FILENAME = 'VALUE_DB.pickle.xz'
-
 # Create an operator for all callables that have been detected in a given
 # set of modules
 def build_op_set(callable_pool, non_reusable_type_set, allowed_pattern_set, adaptor):
@@ -481,7 +479,7 @@ def do_merge(artifact_dirs, output_dir, use_hardlink=True, output_exist=False):
         # This will fail loudly if the folder already exists
         output_dir.mkdir(parents=True, exist_ok=output_exist)
         (output_dir/'BY_UUID').mkdir(exist_ok=True)
-        merged_db_path = output_dir/DB_FILENAME
+        merged_db_path = output_dir/utils.DB_FILENAME
 
     testsession_uuid_list = []
     for artifact_dir in artifact_dirs:
@@ -551,7 +549,7 @@ def do_merge(artifact_dirs, output_dir, use_hardlink=True, output_exist=False):
                 else:
                     shutil.copy2(str(path), str(dst_path))
 
-                if dirpath == artifact_dir and name == DB_FILENAME:
+                if dirpath == artifact_dir and name == utils.DB_FILENAME:
                     db_path_list.append(path)
 
     if artifact_dirs:
@@ -954,7 +952,7 @@ def exec_expr_list(iteration_expr_list, adaptor, artifact_dir, testsession_uuid,
             f.write(
                 expr.get_script(
                     prefix = 'expr',
-                    db_path = os.path.join('..', DB_FILENAME),
+                    db_path = os.path.join('..', utils.DB_FILENAME),
                     db_relative_to = '__file__',
                 )[1]+'\n',
             )
@@ -1079,7 +1077,7 @@ def exec_expr_list(iteration_expr_list, adaptor, artifact_dir, testsession_uuid,
                 f.write(
                     expr.get_script(
                         prefix = 'expr',
-                        db_path = os.path.join('..', '..', DB_FILENAME),
+                        db_path = os.path.join('..', '..', utils.DB_FILENAME),
                         db_relative_to = '__file__',
                     )[1]+'\n',
                 )
@@ -1117,7 +1115,7 @@ def exec_expr_list(iteration_expr_list, adaptor, artifact_dir, testsession_uuid,
         adaptor_cls=adaptor_cls,
     )
 
-    db_path = artifact_dir/DB_FILENAME
+    db_path = artifact_dir/utils.DB_FILENAME
     db.to_path(db_path)
 
     out('#'*80)

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -479,10 +479,10 @@ def do_merge(artifact_dirs, output_dir, use_hardlink=True, output_exist=False):
         merged_db_path = output_dir
     else:
         # This will fail loudly if the folder already exists
-        os.makedirs(str(output_dir), exist_ok=output_exist)
+        output_dir.mkdir(parents=True, exist_ok=output_exist)
+        (output_dir/'BY_UUID').mkdir(exist_ok=True)
         merged_db_path = output_dir/DB_FILENAME
 
-    (output_dir/'BY_UUID').mkdir(exist_ok=True)
     testsession_uuid_list = []
     for artifact_dir in artifact_dirs:
         with (artifact_dir/'UUID').open(encoding='utf-8') as f:


### PR DESCRIPTION
tools: Add check-test-fix.py

Add a tool to re-run a given test against data collected using bisector,
like for the fortnightly integration. It will show a
regression/improvement table at the end to compare the reference data in
the bisector report with the new ones that were just generated. It can
be called as follow to check that a fix to a
RampDown:test_task_placement has been fixed on the first 10 available
traces:
$ check-test-fix.py -s 'RampDown:test_task_placement' bisector_report.yml.gz -oiterations=1-10 --only behaviour

Note: this will spawn one `exekall run` per CPU to speed up the
computation. That means the logs are output only when `exekall run`
command finishes to avoid interleaved output.