### PR TITLE
tools/wltests: Fix mkdtimg python shebang

### DIFF
--- a/tools/wltests/android/mkdtimg
+++ b/tools/wltests/android/mkdtimg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright 2017, The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
As reported in https://github.com/ARM-software/lisa/issues/853, the
current shebang can cause issues on systems where `python` defaults to
`python3`.

Make it obvious that this is a python2 script.