### PR TITLE
lisa.trace: Avoid stacking event checker wrappers

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -1125,6 +1125,9 @@ class TraceEventCheckerBase(abc.ABC, Loggable):
             checker = self
         else:
             checker = AndTraceEventChecker([self, used_events])
+            # remove a layer of wrapper, since we took its used_events into
+            # account already
+            f = f.__wrapped__
 
         sig = inspect.signature(f)
         if sig.parameters:


### PR DESCRIPTION
When a function is decorated mutlitple times with required events,
accumulate all the information in the top-level wrapper and discard
inner levels of wrappers.