### PR TITLE
trace: Improve/fix add_events_deltas()

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -91,7 +91,8 @@ class TraceBase(abc.ABC):
         if not inplace:
             df = df.copy()
 
-        df.loc[df.index[:-1], col_name] = df.index.values[1:] - df.index.values[:-1]
+        df[col_name] = df.index
+        df[col_name] = df[col_name].diff().shift(-1)
         # Fix the last event, which will have a NaN duration
         # Set duration to trace_end - last_event
         df.loc[df.index[-1], col_name] = self.end - df.index[-1]


### PR DESCRIPTION
While we're not supposed to get duplicate timestamps (see
trappy.utils::handle_duplicate_index), these seem to still happen and
they throw pandas.DataFrame.loc[] off balance.

Use diff() + shift() instead of handcrafted equivalents. Performance
difference is insignificant, but at least we rely on a standard pandas
API.