### PR TITLE
Fastmodel fixes

### DIFF
--- a/external/bart/bart/sched/functions.py
+++ b/external/bart/bart/sched/functions.py
@@ -139,6 +139,25 @@ def sanitize_asymmetry(series, window=None):
                 if window:
                     series.index.values[-1] = window[1]
 
+            # Remove repeated entries - which could happen if a task switch in
+            # then immediately switches out; ie: time stamp is exactly the same
+            n = 0
+            next = n + 1
+            while next < len(series):
+                if not series.values[n]:
+                    n = next
+                    next = next + 1
+                    continue
+
+                while not series.values[next]:
+                    next = next + 1
+
+                if series.values[n] == series.values[next]:
+                    series = series.drop(series.index[next])
+                else:
+                    n = next
+                    next = next + 1
+
         # No point if the series just has one value and
         # one event. We do not have sufficient data points
         # for any calculation. We should Ideally never reach

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -139,6 +139,7 @@ class EASBehaviour(RTATestBundle):
 
         df = self.trace.ftrace.sched_switch.data_frame[['next_comm', '__cpu']]
         df = df[df['next_comm'].isin(tasks)]
+        df = df[~df.index.duplicated()]
         df = df.pivot(index=df.index, columns='next_comm').fillna(method='ffill')
         cpu_df = df['__cpu']
         # Drop consecutive duplicates


### PR DESCRIPTION
The two commit fix issues I've seen when running on fastmodels. The common cause is duplicated timestamps which seem to happen more often on fastmodels. I think this is an artefact of the simulated time in fastmodels so probably the fixes are valid but it'd be good to have more critical eyes at this.