### PR TITLE
bisector: Remove support for LISA legacy

### DIFF
--- a/doc/man1/bisector.1
+++ b/doc/man1/bisector.1
@@ -273,184 +273,6 @@ LISA\-test (test)
 \-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
 Inherits from: shell
 
-    Execute a LISA test command and collect xUnit results. Also compress the
-    result directory and record its path. It will also define some environment
-    variables that are expected to be used by the command to be able to locate
-    resources to collect.
-    
-    .. deprecated:: 1.0
-        This class is designed for legacy LISA, use
-        :class:\(gaExekallLISATestStep\(ga for current LISA instead.
-
-    run:
-      \-o bail\-out= (bool) 
-            start a new iteration if the command fails, without executing
-            remaining steps for this iteration
-
-      \-o cmd= (non\-empty str) 
-            shell command to be executed
-
-      \-o compress\-results= (bool) 
-            compress the LISA result directory in an archive
-
-      \-o env= (env var list) 
-            environment variables with a list of values that will be used for
-            each iterations, wrapping around. The string format is:
-            VAR1=val1%val2%...%%VAR2=val1%val2%.... In YAML, it is a map of var
-            names to list of values. A single string can be supplied instead of
-            a list of values.
-
-      \-o kill\-timeout= (int or "inf") 
-            time to wait before sending SIGKILL after having sent SIGTERM
-
-      \-o shell= (non\-empty str) 
-            shell to execute the command in
-
-      \-o timeout= (int or "inf") 
-            timeout in seconds before sending SIGTERM to the command, or "inf"
-            for infinite timeout
-
-      \-o trials= (int) 
-            number of times the command will be retried if it does not return 0
-
-      \-o upload\-results= (bool) 
-            upload the LISA results directory to Artifactorial as the execution
-            goes, and delete the local archive.
-
-      \-o use\-systemd\-run= (bool) 
-            use systemd\-run to run the command. This allows cleanup of daemons
-            spawned by the command (using cgroups), and using a private /tmp
-            that is also cleaned up automatically
-
-
-    report:
-      \-o download= (bool) 
-            Download the LISA results archives if necessary
-
-      \-o dump\-results\-dir= (non\-empty str) 
-            write the list of LISA result directories to a file. Useful to
-            implement garbage collection of unreferenced results archives
-
-      \-o export\-logs= (non\-empty str) 
-            export the logs, xUnit file and result dir symlink to the given
-            directory
-
-      \-o ignore\-excep= (comma\-separated list) 
-            ignore the given comma\-separated list of exceptions that caused
-            tests failure or error. * can be used to match any part of the name
-
-      \-o ignore\-non\-issue= (bool) 
-            consider only tests that failed
-
-      \-o iterations= (comma\-separated list of integer ranges) 
-            comma\-separated list of iterations to consider. Inclusive ranges can
-            be specified with <first>\-<last>
-
-      \-o show\-basic= (bool) 
-            show command exit status for all iterations
-
-      \-o show\-details= ("msg" or bool) 
-            show details of erros and failures. Use "msg" for only a brief
-            message
-
-      \-o show\-dist= (bool) 
-            show graphical distribution of issues among iterations with a one
-            letter code: passed=".", failed="F", error="#", skipped="s"
-
-      \-o show\-pass\-rate= (bool) 
-            always show the pass rate of tests, even when there are failures or
-            crashes as well
-
-      \-o show\-rates= (bool) 
-            show percentages of failure, error, skipped and passed tests
-
-      \-o show\-results\-dir= (bool) 
-            show LISA result directory for all iterations
-
-      \-o testcase= (comma\-separated list) 
-            show only the test cases matching one of the patterns in the comma\-
-            separated list. * can be used to match any part of the name.
-
-      \-o upload\-results= (bool) 
-            upload the results directory to Artifactorial and update the in\-
-            memory report. Following env var are needed: ARTIFACTORIAL_FOLDER
-            set to the folder URL and ARTIFACTORIAL_TOKEN. Note: \-\-export should
-            be used to save the report with updated paths
-
-      \-o verbose= (bool) 
-            increase verbosity
-
-      \-o xunit2json= (non\-empty str) 
-            append consolidated xUnit information to a JSON file
-
-
-
-build (build)
-\-\-\-\-\-\-\-\-\-\-\-\-\-
-Inherits from: shell
-
-    Similar to :class:\(gaShellStep\(ga .
-    
-    Non\-zero exit status of the command will be interpreted as a bisect
-    untestable status, and zero exit status as bisect good.
-
-    run:
-      \-o bail\-out= (bool) 
-            start a new iteration if the command fails, without executing
-            remaining steps for this iteration
-
-      \-o cmd= (non\-empty str) 
-            shell command to be executed
-
-      \-o env= (env var list) 
-            environment variables with a list of values that will be used for
-            each iterations, wrapping around. The string format is:
-            VAR1=val1%val2%...%%VAR2=val1%val2%.... In YAML, it is a map of var
-            names to list of values. A single string can be supplied instead of
-            a list of values.
-
-      \-o kill\-timeout= (int or "inf") 
-            time to wait before sending SIGKILL after having sent SIGTERM
-
-      \-o shell= (non\-empty str) 
-            shell to execute the command in
-
-      \-o timeout= (int or "inf") 
-            timeout in seconds before sending SIGTERM to the command, or "inf"
-            for infinite timeout
-
-      \-o trials= (int) 
-            number of times the command will be retried if it does not return 0
-
-      \-o use\-systemd\-run= (bool) 
-            use systemd\-run to run the command. This allows cleanup of daemons
-            spawned by the command (using cgroups), and using a private /tmp
-            that is also cleaned up automatically
-
-
-    report:
-      \-o export\-logs= (non\-empty str) 
-            export the logs to the given directory
-
-      \-o ignore\-non\-issue= (bool) 
-            consider only iteration with non\-zero command exit status
-
-      \-o iterations= (comma\-separated list of integer ranges) 
-            comma\-separated list of iterations to consider. Inclusive ranges can
-            be specified with <first>\-<last>
-
-      \-o show\-basic= (bool) 
-            show command exit status for all iterations
-
-      \-o verbose= (bool) 
-            increase verbosity
-
-
-
-exekall\-LISA\-test (test)
-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
-Inherits from: shell
-
     Execute an exekall LISA test command and collect
     :class:\(gaexekall.engine.ValueDB\(ga. Also compress the result directory and
     record its path. It will also define some environment variables that are
@@ -569,6 +391,68 @@ Inherits from: shell
             memory report. Following env var are needed: ARTIFACTORIAL_FOLDER
             set to the folder URL and ARTIFACTORIAL_TOKEN. Note: \-\-export should
             be used to save the report with updated paths
+
+      \-o verbose= (bool) 
+            increase verbosity
+
+
+
+build (build)
+\-\-\-\-\-\-\-\-\-\-\-\-\-
+Inherits from: shell
+
+    Similar to :class:\(gaShellStep\(ga .
+    
+    Non\-zero exit status of the command will be interpreted as a bisect
+    untestable status, and zero exit status as bisect good.
+
+    run:
+      \-o bail\-out= (bool) 
+            start a new iteration if the command fails, without executing
+            remaining steps for this iteration
+
+      \-o cmd= (non\-empty str) 
+            shell command to be executed
+
+      \-o env= (env var list) 
+            environment variables with a list of values that will be used for
+            each iterations, wrapping around. The string format is:
+            VAR1=val1%val2%...%%VAR2=val1%val2%.... In YAML, it is a map of var
+            names to list of values. A single string can be supplied instead of
+            a list of values.
+
+      \-o kill\-timeout= (int or "inf") 
+            time to wait before sending SIGKILL after having sent SIGTERM
+
+      \-o shell= (non\-empty str) 
+            shell to execute the command in
+
+      \-o timeout= (int or "inf") 
+            timeout in seconds before sending SIGTERM to the command, or "inf"
+            for infinite timeout
+
+      \-o trials= (int) 
+            number of times the command will be retried if it does not return 0
+
+      \-o use\-systemd\-run= (bool) 
+            use systemd\-run to run the command. This allows cleanup of daemons
+            spawned by the command (using cgroups), and using a private /tmp
+            that is also cleaned up automatically
+
+
+    report:
+      \-o export\-logs= (non\-empty str) 
+            export the logs to the given directory
+
+      \-o ignore\-non\-issue= (bool) 
+            consider only iteration with non\-zero command exit status
+
+      \-o iterations= (comma\-separated list of integer ranges) 
+            comma\-separated list of iterations to consider. Inclusive ranges can
+            be specified with <first>\-<last>
+
+      \-o show\-basic= (bool) 
+            show command exit status for all iterations
 
       \-o verbose= (bool) 
             increase verbosity
@@ -1049,7 +933,7 @@ steps:
     # exekall LISA test will interpret a non\-zero exit status of the command
     # as bisect bad, and a zero exit status as bisect good.
     \-
-      class: exekall\-LISA\-test
+      class: LISA\-test
       name: one\-small\-task
       # Using systemd\-run ensures all child process is killed if the session
       # is interrupted
@@ -1102,7 +986,7 @@ bisector report bisector.report.yml.gz
 bisector report bisector.report.yml.gz \-\-only test
 
 # Help of a exekall LISA\(aqs step options
-bisector step\-help exekall\-LISA\-test
+bisector step\-help LISA\-test
 
 # Get all information about tests failures
 bisector report bisector.report.yml.gz \-overbose

--- a/doc/workflows/automated_testing.rst
+++ b/doc/workflows/automated_testing.rst
@@ -272,7 +272,7 @@ file with this kind of content:
 
 
     # A test step will make the result good if the command exit with 0, or bad otherwise.
-    - class: exekall-LISA-test
+    - class: LISA-test
       name: eas-behaviour
       timeout: 3600
       # Block-style strings allow multiple lines. For more block style examples:
@@ -343,7 +343,7 @@ options can be set as usual:
 
 .. code-block:: sh
 
-  bisector run --inline reboot reboot -oreboot.cmd='reboot_my_board.sh' --inline exekall-LISA-test mytest -omytest.cmd='lisa-test' --report myreport.yml.gz
+  bisector run --inline reboot reboot -oreboot.cmd='reboot_my_board.sh' --inline LISA-test mytest -omytest.cmd='lisa-test' --report myreport.yml.gz
 
 Analyzing results
 +++++++++++++++++
@@ -378,7 +378,7 @@ that if everything went well:
       #4 : OK
       #5 : OK
 
-  test/behaviour (exekall-LISA-test) [GOOD]
+  test/behaviour (LISA-test) [GOOD]
       OneSmallTask[board=juno-r0]:test_slack:                      passed 163/163 (100.0%)
       OneSmallTask[board=juno-r0]:test_task_placement:             passed 163/163 (100.0%)
       Error: 0/2, Failed: 0/2, Undecided: 0/2, Skipped: 0/2, Passed: 2/2
@@ -398,7 +398,7 @@ will aggregate the results of all its iterations. The header is formatted as
 *<step name>/<step category> (step class name) [<step result>]*. The overall
 bisect result is the combination of the result of each steps.
 
-``exekall-LISA-test`` has special support for inspecting ``exekall``'s database
+``LISA-test`` has special support for inspecting ``exekall``'s database
 collected during each iteration of ``bisector``, and can display a summary
 table. By default, a **passed** label will only appear if all iteration
 successfully passed.  Otherwise, an appropriate combination of **FAILED**,
@@ -409,7 +409,7 @@ Various options can affect what is displayed and taken into account. For
 example, ``--skip my-other-test`` will remove the contribution of that step to
 the final result. Step-specific report options are documented in ``bisector
 step-help``. Some of the options allow exporting collected artifacts from the
-report, like ``-oexport-logs``. In the case of ``exekall-LISA-test`` step,
+report, like ``-oexport-logs``. In the case of ``LISA-test`` step,
 that option also makes a symlink to the artifact folder available along the
 stdout/stderr log.
 
@@ -421,7 +421,7 @@ stdout/stderr log.
 Looking for regressions
 -----------------------
 
-Using the ``exekall-LISA-test`` step, ``bisector`` collects a pruned version of
+Using the ``LISA-test`` step, ``bisector`` collects a pruned version of
 ``VALUE_DB.pickle.xz`` artifact for each iteration. These databases are stored
 directly inside the report. When using the ``-oexport-db=VALUE_DB.pickle.xz``,
 it is possible to export a database that is the result of merging all the
@@ -519,7 +519,7 @@ Integration in a CI loop
 ``bisector run`` has the ability of uploading reports on the fly to
 *Artifactorial* [#]_. *Artifactorial* is convenient since it allows pushing
 large quantities of data to a server, that are automatically cleaned up after a
-period of time. The ``exekall-LISA-test`` step can upload compressed exekall
+period of time. The ``LISA-test`` step can upload compressed exekall
 artifact archives using ``-oupload-artifact`` run option. It will record the
 new HTTP location of the artifacts in the report. In a way, the report becomes
 an index that contains enough information to make a decision on what artifact

--- a/tools/bisector/doc/man/man.rst
+++ b/tools/bisector/doc/man/man.rst
@@ -141,7 +141,7 @@ The YAML file is structured as following:
        # exekall LISA test will interpret a non-zero exit status of the command
        # as bisect bad, and a zero exit status as bisect good.
        -
-         class: exekall-LISA-test
+         class: LISA-test
          name: one-small-task
          # Using systemd-run ensures all child process is killed if the session
          # is interrupted
@@ -196,7 +196,7 @@ A typical flow of ``bisector`` looks like that:
    bisector report bisector.report.yml.gz --only test
     
    # Help of a exekall LISA's step options
-   bisector step-help exekall-LISA-test
+   bisector step-help LISA-test
     
    # Get all information about tests failures
    bisector report bisector.report.yml.gz -overbose


### PR DESCRIPTION
* Remove support for xUnit-based nostest output of LISA legacy
* Keep class aliases around for a while to be able to reload old reports
(both pickle and YAML)
* Reuse "LISA-test" step name for the exekall LISA test step, since the
old behavior (lisa legacy) of that name was not widely used.