### PR TITLE
doc: Update the name of the documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-LISA API Documentation
-======================
+LISA Documentation
+==================
 
 LISA - "Linux Integrated System Analysis" is a toolkit for interactive analysis
 and automated regression testing of Linux kernel behaviour.


### PR DESCRIPTION
The rst documentation now includes much more than just the API, so let's
rename the front-page title accordingly.