### PR TITLE
bisector: Fix -oexport-logs

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -2350,6 +2350,11 @@ def urlretrieve(url, path):
     response = requests.get(url)
     # Raise an exception is the request failed
     response.raise_for_status()
+
+    # If that is a broken symlink, get rid of it
+    if not os.path.exists(path) and os.path.islink(path):
+        os.unlink(path)
+
     with open(path, 'wb') as f:
         f.write(response.content)
 


### PR DESCRIPTION
bisector report -oexport-logs -odownlad=no may create symlinks pointing
to URLs. If -oexport-logs is later used with -odownlad=yes, the symlink
is followed when downloading into the file, which breaks. Fix that by
removing broken symlinks before trying to open the file for writing.