### PR TITLE
lisa.target: Update the cricital tasks list

### DIFF
--- a/lisa/target.py
+++ b/lisa/target.py
@@ -169,7 +169,9 @@ class Target(Loggable, HideExekallID, Configurable):
     CRITICAL_TASKS = {
         'linux': [
             'init',
-            'systemd',
+            # We want to freeze everything except PID 1, we don't want to let
+            # sysmted-journald or systemd-timesyncd running.
+            'systemd[^-]',
             'dbus',
             'sh',
             'ssh',


### PR DESCRIPTION
Since all commands part of the systemd package are named
systemd-<something>, we need a more refined pattern in order to properly
freeze systemd-journald process for example.

This commit is ported from LISA legacy:
263dec9685b79351ff16020130fc67e99c82e166