### PR TITLE
bisector: Still allow exekall-LISA-test step name

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -2330,7 +2330,10 @@ class ExekallLISATestStep(LISATestStep, Deprecated):
         Deprecated alias for :class:`LISATestStep`, it is only kept around to
         be able to reload old pickle reports.
     """
-    pass
+
+    # Use the former name
+    attr_init = copy.copy(LISATestStep.attr_init)
+    attr_init['name'] = 'exekall-LISA-test'
 
 class StepNotifService:
     """Allows steps to send notifications."""


### PR DESCRIPTION
LISA-test can now be used as the support for legacy has been removed,
but still allow to use "exekall-LISA-test".