### PR TITLE
lisa.regression: Add Regression.fix_validation_min_iter_nr

### DIFF
--- a/doc/workflows/automated_testing.rst
+++ b/doc/workflows/automated_testing.rst
@@ -109,15 +109,17 @@ iterations, out of which 80 passed and 20 failed.
 
 The output of ``exekall compare`` looks like that:
 
+.. Comparison of 20190222 and 20190412 integration
+
 ::
 
-    testcase                                                           old%   new% delta%      pvalue
-    -------------------------------------------------------------------------------------------------
-    PELTTask:test_load_avg_behaviour                                   3.8%   6.7%   2.9%    9.26e-02
-    ThreeSmallTasks:test_task_placement                                0.0%   1.8%   1.8%    4.13e-03
-    TwoBigTasks:test_slack                                             0.0%   3.1%   3.1%    1.03e-04
-    TwoBigThreeSmall:test_slack                                       82.1%  95.7%  13.6%    1.69e-06
-    TwoBigThreeSmall:test_task_placement                              79.7%  95.7%  16.0%    7.18e-08
+  testcase                                                             old%   new%  delta%       pvalue fix_iter# 
+  ----------------------------------------------------------------------------------------------------------------
+  PELTTask:test_load_avg_behaviour                                     2.9%   0.0%   -2.9%     4.58e-04           
+  PELTTask:test_load_avg_range                                         0.0%   7.1%    7.1%     1.08e-10        54 
+  PELTTask:test_util_avg_behaviour                                     2.4%   0.0%   -2.4%     1.70e-03           
+  PELTTask:test_util_avg_range                                         0.0%   7.1%    7.1%     1.08e-10        54 
+  TwoBigTasks:test_slack                                               4.7%   1.6%   -3.1%     1.25e-02           
 
 The columns have the following meaning:
 
@@ -126,6 +128,13 @@ The columns have the following meaning:
   * ``delta%``: the difference in the old and new failure rates
   * ``pvalue``: The p-value resulting from the Fisher's exact test used to
     filter significant regressions or improvements
+  * ``fix_iter#``: The number of iterations required to observe the effects of
+    a fix of a regression. This gives an indication on how many iterations are
+    needed to have `exekall compare` answer the question "is my fix fixing this
+    regression ?", assuming that you actually fixed it. Running less iterations
+    than that to validate a fix will likely result in ``exekall compare`` not
+    being able to conclude that there was a failure rate change (i.e. an
+    improvement), even if the fix is actually correct.
 
 .. tip:: When comparing results collected from different boards, the test IDs
   will probably not match since they are tagged with the user-defined board

--- a/doc/workflows/automated_testing.rst
+++ b/doc/workflows/automated_testing.rst
@@ -105,6 +105,22 @@ That would represent an ``old`` test session with 20 iterations of the test, 15
 of which passed and 5 failed. The ``new`` session would have had 100
 iterations, out of which 80 passed and 20 failed.
 
+.. note:: This kind of experiments only fixes some marginal totals and
+  therefore does not totally satisfy the conditions to use Fisher's exact test.
+  The total number of results on one column (columns marginal total) is fixed,
+  since a test either has to pass or fail. However, the row marginal totals are
+  not fixed, since the experiment does not constrains the total number of
+  success and total number of failures. This kind of experiment would be best
+  analysed using Barnard's test.
+
+  That said, Fisher's exact test is just less powerful than Barnard's test,
+  which means its only issue is to be too conservative, i.e. will sometimes
+  fail to spot a failure rate change although there actually was one.
+
+  Another way to express that is that Fisher's exact test will require more
+  iterations before detecting a failure rate change than strictly required.
+  Barnard's test is unfortunately not widely implemented, so Fisher it is !
+
 .. seealso:: :class:`lisa.regression.RegressionResult`
 
 The output of ``exekall compare`` looks like that:

--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -247,7 +247,7 @@ comparison. Can be repeated.""")
 
         id_len = max(len(regr.testcase_id) for regr in regr_list)
 
-        header = '{id:<{id_len}}   old%   new% delta%      pvalue{regr_column}'.format(
+        header = '{id:<{id_len}}   old%   new%  delta%       pvalue fix_iter# {regr_column}'.format(
             id='testcase'.format(alpha),
             id_len=id_len,
             regr_column=' significant' if show_non_significant else ''
@@ -256,13 +256,21 @@ comparison. Can be repeated.""")
         for regr in regr_list:
             if regr.significant or show_non_significant:
                 old_pc, new_pc = regr.failure_pc
-                print('{id:<{id_len}} {old_pc:>5.1f}% {new_pc:>5.1f}% {delta_pc:>5.1f}%    {pval:.2e} {significant}'.format(
+                # Only show the number of iterations required to validate a fix
+                # when there was a regression.
+                if regr.failure_delta_pc > 0:
+                    validation_nr=regr.fix_validation_min_iter_nr
+                else:
+                    validation_nr = ''
+
+                print('{id:<{id_len}} {old_pc:>5.1f}% {new_pc:>5.1f}% {delta_pc:>6.1f}%    {pval:>9.2e} {validation_nr:>9} {significant}'.format(
                     id=regr.testcase_id,
                     old_pc=old_pc,
                     new_pc=new_pc,
                     delta_pc=regr.failure_delta_pc,
                     pval=regr.p_val,
                     id_len=id_len,
+                    validation_nr=validation_nr,
                     significant='*' if regr.significant and show_non_significant else '',
                 ))
 


### PR DESCRIPTION
Compute the number of iterations required to observe the effects of a
fix to a test case, compared to the new failing rate. This gives an
indication on how many iterations are needed to have `exekall compare`
answer the question "is my fix fixing this regression ?", assuming that
you actually fixed it. If `exekall compare` says that there is no
significant change after that number of iterations, chances are that the
fix is only partial (or not fixing anything at all).