### PR TITLE
lisa.tests: load_tracking: Correctly join res_dir

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -461,7 +461,7 @@ class Invariance(TestBundle, LoadTrackingHelpers):
             freq_list.sort()
 
             for freq in freq_list:
-                item_dir = os.path.join(res_dir, "{prefix}_{cpu}@{freq}".format(
+                item_dir = ArtifactPath.join(res_dir, "{prefix}_{cpu}@{freq}".format(
                     prefix=InvarianceItem.task_prefix,
                     cpu=cpu,
                     freq=freq,

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -529,6 +529,25 @@ class ArtifactPath(str, Loggable, HideExekallID):
         # Swap-in the new root and return a new instance
         return type(self)(root, relative)
 
+    @classmethod
+    def join(cls, path1, path2):
+        """
+        Join two paths together, similarly to :func:`os.path.join`.
+
+        If ``path1`` is a :class:`ArtifactPath`, the result will also be one,
+        and the root of ``path1`` will be used as the root of the new path.
+        """
+        if isinstance(path1, cls):
+            joined = cls(
+                root=path1.root,
+                relative=os.path.join(path1.relative, str(path2))
+            )
+        else:
+            joined = os.path.join(str(path1), str(path2))
+
+        return joined
+
+
 def groupby(iterable, key=None):
     # We need to sort before feeding to groupby, or it will fail to establish
     # the groups as expected.


### PR DESCRIPTION
Correctly propagating a path of the right type (ArtifactPath) for res_dir is
important to allow relocating the res_dir of the TestBundle when
deserializing its instances.

When a sub-res_dir must be created to be passed to another TestBundle,
make sure to correctly join the paths together to not loose information.