### PR TITLE
Trim down ValueDB produced by exekall run --load-db

### DIFF
--- a/doc/man1/exekall.1
+++ b/doc/man1/exekall.1
@@ -183,6 +183,39 @@ optional arguments:
 .fi
 .UNINDENT
 .UNINDENT
+.SS exekall merge
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+usage: exekall merge [\-h] \-o OUTPUT [\-\-copy] artifact_dirs [artifact_dirs ...]
+
+Merge artifact directories of "exekall run" executions.
+
+By default, it will use hardlinks instead of copies to improve speed and
+avoid eating up large amount of space, but that means that artifact
+directories should be treated as read\-only.
+    
+
+positional arguments:
+  artifact_dirs         Artifact directories created using "exekall run", or value databases
+                        to merge.
+
+optional arguments:
+  \-h, \-\-help            show this help message and exit
+  \-o OUTPUT, \-\-output OUTPUT
+                        
+                        Output merged artifacts directory or value database. If the
+                        output already exists, the merged DB will only contain the same roots
+                        as this one. This allows patching\-up a pruned DB with other DBs that
+                        contains subexpression\(aqs values.
+  \-\-copy                Force copying files, instead of using hardlinks.
+
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
 .SH EXECUTING EXPRESSIONS
 .sp
 Expressions are built by scanning the python source code passed to \fBexekall

--- a/lisa/regression.py
+++ b/lisa/regression.py
@@ -187,9 +187,7 @@ def compute_regressions(old_list, new_list, remove_tags=[], **kwargs):
     The tests are first grouped by their ID, and then a
     :class:`RegressionResult` is computed for each of these ID.
 
-    :param old_list: old series of :class:`exekall.engine.FrozenExprVal`.  Values
-        with a UUID that is also present in `new_list` will be removed from
-        that list before the regressions are computed.
+    :param old_list: old series of :class:`exekall.engine.FrozenExprVal`.
     :type old_list: list(exekall.engine.FrozenExprVal)
 
     :param new_list: new series of :class:`exekall.engine.FrozenExprVal`. Values
@@ -217,13 +215,10 @@ def compute_regressions(old_list, new_list, remove_tags=[], **kwargs):
         ]
 
     # Remove from the new_list all the FrozenExprVal that were carried from the
-    # old_list sequence. That is important since running "exekall run --load-db"
-    # will contain both new and old data, so old data needs to be filtered out
-    # before we can actually compare the two sets.
-    _new_list = dedup_list(new_list, old_list)
-    _old_list = dedup_list(old_list, new_list)
-    old_list = _old_list
-    new_list = _new_list
+    # old_list sequence. That is important since a ValueDB could contain both
+    # new and old data, so old data needs to be filtered out before we can
+    # actually compare the two sets.
+    new_list = dedup_list(new_list, old_list)
 
     def get_id(froz_val):
         id_ = froz_val.get_id(qual=False, with_tags=True)

--- a/tools/exekall/doc/man/man.rst
+++ b/tools/exekall/doc/man/man.rst
@@ -39,6 +39,15 @@ exekall compare
 
    exekall compare --help
 
+exekall merge
+-------------
+
+.. run-command::
+   :ignore-error:
+   :literal:
+
+   exekall merge --help
+
 
 EXECUTING EXPRESSIONS
 +++++++++++++++++++++

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -139,9 +139,18 @@ class ValueDB:
         return cls._froz_val_dfs(froz_val_seq_list, rewrite_graph)
 
     @classmethod
-    def merge(cls, db_list):
+    def merge(cls, db_list, roots_from=None):
         """
         Merge multiple databases together.
+
+        :param db_list: Lists of DB to merge
+        :type db_list: list(ValueDB)
+
+        :param roots_from: Only get the root values from the specified DB.
+            The other DBs are only used to provide subexpressions values for
+            expressions already present in that DB. That DB is also appended to
+            ``db_list``.
+        :type roots_from: ValueDB
 
         When two different :class:`FrozenExprVal` are available for a given
         UUID, the one that contains the most information will be selected.
@@ -157,11 +166,30 @@ class ValueDB:
             raise ValueError('Cannot merge ValueDB with different adaptor classes: {}'.format(adaptor_cls_set))
         adaptor_cls = utils.take_first(adaptor_cls_set)
 
+        if roots_from is not None:
+            db_list.append(roots_from)
+
         froz_val_seq_list = list(itertools.chain.from_iterable(
             db.froz_val_seq_list
             for db in db_list
         ))
-        return cls(froz_val_seq_list, adaptor_cls=adaptor_cls)
+
+        db = cls(froz_val_seq_list, adaptor_cls=adaptor_cls)
+
+        # Remove all roots that we don't want
+        if roots_from is not None:
+            allowed_roots = {
+                froz_val.uuid for froz_val in roots_from.get_roots()
+            }
+            db.froz_val_seq_list = [
+                froz_val_seq
+                for froz_val_seq in db.froz_val_seq_list
+                # Only keep FrozenExprValSeq that only contains allowed
+                # FrozenExprVal
+                if {froz_val.uuid for froz_val in froz_val_seq} <= allowed_roots
+            ]
+
+        return db
 
     @classmethod
     def from_path(cls, path, relative_to=None):

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -102,10 +102,6 @@ class ValueDB:
             return froz_val
         cls._froz_val_dfs(froz_val_seq_list, update_uuid_map)
 
-        # Make sure no deduplication will occur on None, as it is used as a
-        # marker when no exception was raised or when no value was available.
-        uuid_map[(None, None)] = set()
-
         # Select one FrozenExprVal for each UUID pair
         def select_froz_val(froz_val_set):
             candidates = [
@@ -128,12 +124,14 @@ class ValueDB:
                 return utils.take_first(froz_val_set)
 
         uuid_map = {
-            uuid_pair: select_froz_val(froz_val_set)
-            for uuid_pair, froz_val_set in uuid_map.items()
+            uuid_: select_froz_val(froz_val_set)
+            for uuid_, froz_val_set in uuid_map.items()
         }
 
         # Second pass: only keep one frozen value for each UUID
         def rewrite_graph(froz_val):
+            if froz_val.uuid is None:
+                return froz_val
             return uuid_map[froz_val.uuid]
 
         return cls._froz_val_dfs(froz_val_seq_list, rewrite_graph)

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -352,11 +352,11 @@ directories should be treated as read-only.
 
     add_argument(merge_parser, '-o', '--output', required=True,
         help="""
-        Output merged artifacts directory or value database. If the
-        output already exists, the merged DB will only contain the same roots
-        as this one. This allows patching-up a pruned DB with other DBs that
-        contains subexpression's values.
-        """
+Output merged artifacts directory or value database. If the
+output already exists, the merged DB will only contain the same roots
+as this one. This allows patching-up a pruned DB with other DBs that
+contains subexpression's values.
+"""
     )
 
     add_argument(merge_parser, '--copy', action='store_true',


### PR DESCRIPTION
Only include values used in re-computed expressions in the ValueDB created when calling `exekall run --load-db`.