### PR TITLE
exekall: improve CLI option parsing

### DIFF
--- a/doc/man1/exekall.1
+++ b/doc/man1/exekall.1
@@ -148,6 +148,11 @@ optional arguments:
   \-n N                  Run the tests for a number of iterations.
   \-\-share TYPE_PATTERN  Class name pattern to share between multiple iterations.
   \-\-random\-order        Run the expressions in a random order, instead of sorting by name.
+
+LISA:
+  LISA custom options.
+  Can only be specified *after* positional parameters.
+
   \-\-conf CONF           LISA configuration file. If multiple configurations of a given type
                         are found, they are merged (last one can override keys in previous
                         ones)
@@ -171,6 +176,9 @@ Compare two DBs produced by exekall run.
 Note that the adaptor in the customization module recorded in the database
 is able to add more parameters to \(ga\(gaexekall compare\(ga\(ga. In order to get the
 complete set of options, please run \(ga\(gaexekall compare DB1 DB2 \-\-help\(ga\(ga.
+
+Options part of a custom group will need to be passed after positional
+arguments.
     
 
 positional arguments:

--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -220,7 +220,8 @@ class LISAAdaptor(AdaptorBase):
 
         add_argument(parser, '--remove-tag', action='append',
             default=[],
-            help="""Remove the given tags in the testcase IDs before comparison.""")
+            help="""Remove the given tags in the testcase IDs before
+comparison. Can be repeated.""")
 
     def compare_db_list(self, db_list):
         alpha = self.args.alpha / 100

--- a/tools/exekall/exekall/_utils.py
+++ b/tools/exekall/exekall/_utils.py
@@ -875,3 +875,7 @@ def add_argument(parser, *args, help, **kwargs):
         # Preserve all new lines where there are, and only wrap the other lines.
         help='\n'.join(textwrap.fill(line) for line in help.splitlines())
     return parser.add_argument(*args, **kwargs, help=help)
+
+def create_adaptor_parser_group(parser, adaptor_cls):
+    description = '{} custom options.\nCan only be specified *after* positional parameters.'.format(adaptor_cls.name)
+    return parser.add_argument_group(adaptor_cls.name, description)

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -581,7 +581,10 @@ def do_run(args, parser, run_parser, argv):
     adaptor_name = args.adaptor
     adaptor_cls = AdaptorBase.get_adaptor_cls(adaptor_name)
     if not adaptor_cls:
-        raise RuntimeError('Adaptor "{}" cannot be found'.format(adaptor_name))
+        if adaptor_name:
+            raise RuntimeError('Adaptor "{}" cannot be found'.format(adaptor_name))
+        else:
+            raise RuntimeError('No adaptor was found')
     # Add all the CLI arguments of the adaptor before reparsing the
     # command line.
     adaptor_group = utils.create_adaptor_parser_group(run_parser, adaptor_cls)

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -439,7 +439,9 @@ def do_compare(parser, compare_parser, argv, db_path_list):
 
     # Add all the CLI arguments of the adaptor before reparsing the
     # command line.
-    adaptor_cls.register_compare_param(compare_parser)
+
+    adaptor_group = utils.create_adaptor_parser_group(compare_parser, adaptor_cls)
+    adaptor_cls.register_compare_param(adaptor_group)
 
     # Reparse the command line after the adaptor had a chance to add its own
     # arguments.
@@ -574,7 +576,8 @@ def do_run(args, parser, run_parser, argv):
         raise RuntimeError('Adaptor "{}" cannot be found'.format(adaptor_name))
     # Add all the CLI arguments of the adaptor before reparsing the
     # command line.
-    adaptor_cls.register_run_param(run_parser)
+    adaptor_group = utils.create_adaptor_parser_group(run_parser, adaptor_cls)
+    adaptor_cls.register_run_param(adaptor_group)
 
     # Reparse the command line after the adaptor had a chance to add its own
     # arguments.


### PR DESCRIPTION
Adaptor's custom CLI options can now be specified before positional arguments for `exekall run`. The issue is still present for `exekall compare`, but `--help` now exhibits a parameter group, and also tells that these options should come last.