### PR TITLE
tools/wltests: fix test_series's branch names resolution

### DIFF
--- a/tools/wltests/test_series
+++ b/tools/wltests/test_series
@@ -801,13 +801,17 @@ name_sha1() {
 	if [ "x$WLTEST_REPO_TARGET" == "xy" ]; then
 		return $OK
 	fi
+
 	# Find a name for each possible REF
+	# TODO: looks like "git name-rev --name-only $COMMIT_SHA1" could be used
+	#       to replace the following "for-each-ref + grep + awk" sequence
 	mkfifo tmp_pipe &>/dev/null
 	git -C $KERNEL_TREE for-each-ref \
 			--sort=-committerdate \
-			--format='%(objectname:short) %(refname:short)' \
+			--format='%(objectname) %(refname:short)' \
 			refs/heads/ refs/remotes/ refs/tags |
-	grep $COMMIT_SHA1 | awk '{print $2}' > tmp_pipe &
+	    grep -e "^$COMMIT_SHA1" |
+	    awk '{print $2}' > tmp_pipe &
 	while IFS= read -r NAME; do
 		# Return the fist name starting by "test_"
 		if [[ $NAME = test_* ]]; then
@@ -1026,29 +1030,20 @@ while read -u10 COMMITS; do
 	# Extract commit identifier from commit description
 	COMMIT=${COMMITS%% *}
 
-	# Translate possible branch name to SHA1
-	COMMITS=$(git -C $KERNEL_TREE show-ref -s $COMMIT)
-	if [ $? -ne 0 ]; then
-		COMMIT_SHA1=$COMMIT
-	elif [ $(echo $(git -C $KERNEL_TREE show-ref -s $COMMIT | sort | uniq) | wc -w) -eq 1 ]; then
-		if [ "x$WLTEST_REPO_TARGET" == "xy" ]; then
-			# For repo targets, the series file contains the name
-			# of repo branches, which is what 'repo checkout'
-			# understands
-			COMMIT_SHA1=$COMMIT
-		else
-			COMMIT_SHA1=$(git -C $KERNEL_TREE show-ref -s $COMMIT | sort | uniq)
-		fi
-	else
-		c_error "The branch name must be univocal, \"$COMMIT\" may refer to:"
-		for b in $(git -C $KERNEL_TREE show-ref $COMMIT | cut -f 2 -d " "); do
-			c_error "    $b"
-		done
+	# Get a full SHA1 for the specified branch name or short SHA1
+	COMMIT_SHA1=$(git -C $KERNEL_TREE rev-parse --quiet --verify "$COMMIT")
+	if [ $(echo $COMMIT_SHA1 | wc -w) -ne 1 ]; then
+		c_error "$COMMIT: unknown revision or path not in the working tree"
 		exit $EINVAL
 	fi
 
+	# For repo targets, the series file contains the name
+	# of repo branches, which is what 'repo checkout'
+	# understands
+	[ "x$WLTEST_REPO_TARGET" != "xy" ] || COMMIT_SHA1=$COMMIT
+
 	box_out "PROGRESS : $COMMIT_ID/$COMMITS_COUNT" \
-		"COMMIT   : $COMMITS"
+		"COMMIT   : $COMMIT_SHA1"
 	echo
 	device_status
 


### PR DESCRIPTION
When branch names are used instead of SHA1 in a series file, the name is
resolved to a full SHA1 string which is longer then the 12 chars
actually returned by the for-each-ref command we use to lookup names.

Ensure to always compare up to 12 chars of a specified SHA1.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>