### PR TITLE
exekall: Allow customization of run exit code

### DIFF
--- a/tools/exekall/exekall/customization.py
+++ b/tools/exekall/exekall/customization.py
@@ -201,7 +201,7 @@ class AdaptorBase:
         :param result_map: Dictionary of expressions to the list of their
             values.
         :type result_map: dict(exekall.engine.ComputableExpression,
-            exekall.engine.ExprVal)
+            list(exekall.engine.ExprVal))
         """
         hidden_callable_set = {
             op.callable_
@@ -232,6 +232,17 @@ class AdaptorBase:
                     max_id_len=max_id_len,
                 ))
         return '\n'.join(summary)
+
+    def get_run_exit_code(self, result_map):
+        """
+        Return an integer used as ``exekall run`` exit status.
+
+        :param result_map: Dictionary of expressions to the list of their
+            values.
+        :type result_map: dict(exekall.engine.ComputableExpression,
+            exekall.engine.ExprVal)
+        """
+        return 0
 
     @classmethod
     def get_adaptor_cls(cls, name=None):

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -1142,7 +1142,7 @@ def exec_expr_list(iteration_expr_list, adaptor, artifact_dir, testsession_uuid,
     with script_path.open('wt', encoding='utf-8') as f:
         f.write(all_scripts + '\n')
 
-    return 0
+    return adaptor.get_run_exit_code(result_map)
 
 SILENT_EXCEPTIONS = (KeyboardInterrupt, BrokenPipeError)
 GENERIC_ERROR_CODE = 1


### PR DESCRIPTION
exekall run on LISA will return with exit code 20 if an exception was
raised during execution of any expression, and 10 if any of the
ResultBundle.result is Result.FAILED.