### PR TITLE
lisa.tests.base: Use LRU cache for TestBundle.trace

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -475,8 +475,11 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
 
         return (rta_start, rta_stop)
 
+    # Use LRU cache instead of memoized, to avoid caching the trace forever, in
+    # case the thread is manipulating a large number of TestBundles without
+    # deleting them.
     @property
-    @memoized
+    @functools.lru_cache(maxsize=30, typed=True)
     def trace(self):
         """
         :returns: a :class:`lisa.trace.TraceView`


### PR DESCRIPTION
Avoid storing the parsed trace forever, to avoid consuming too much
memory in processes manipulating a large number of TestBundle. Most of
these kind of scripts will only process a bundle once and then go to the
next one anyway.