### PR TITLE
lisa: Use inspect.getdoc() instead of textwrap.dedent

### DIFF
--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -1148,7 +1148,7 @@ class ConfigurableMeta(abc.ABCMeta):
         # Update the docstring by using the configuration help
         docstring = inspect.getdoc(new_cls)
         if docstring:
-            new_cls.__doc__ = textwrap.dedent(docstring).format(
+            new_cls.__doc__ = docstring.format(
                 configurable_params=new_cls._get_rst_param_doc()
             )
 

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -625,7 +625,7 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
             )
 
             # Make it obvious in the doc where the extra parameters come from
-            merged_doc = textwrap.dedent(cls.test_noisy_tasks.__doc__).splitlines()
+            merged_doc = inspect.getdoc(cls.test_noisy_tasks.__doc__).splitlines()
             # Replace the one-liner func description
             merged_doc[1] = textwrap.dedent(
                 """
@@ -637,8 +637,8 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
                 """.format(cls.__module__, cls.__name__, cls.check_noisy_tasks.__name__)
             )
 
-            #pylint: disable=no-member
-            wrapper.__doc__ = textwrap.dedent(wrapper.__doc__) + "\n".join(merged_doc)
+            wrapper_doc = inspect.getdoc(wrapper) or ''
+            wrapper.__doc__ = wrapper_doc + "\n".join(merged_doc)
 
             return wrapper
         return decorator


### PR DESCRIPTION
inspect.getdoc()/cleandoc() are better suited to handle docstrings than
textwrap.dedent(), since they handle properly lack of indentation on the
first line.