### PR TITLE
tools: lisa-test: Use --share '*Target'

### DIFF
--- a/doc/lisa_shell/man/man.rst
+++ b/doc/lisa_shell/man/man.rst
@@ -79,7 +79,9 @@ Test commands
    This is just a wrapper around ``exekall`` that selects all tests modules and
    use positional arguments as ``--select`` patterns. The default configuration
    file (``$LISA_CONF``) will be used if available. This can be extended with
-   user-supplied ``--conf``.
+   user-supplied ``--conf``. If multiple iterations are requested using ``-n``,
+   the :class:`lisa.target.Target` instance will be reused across iterations,
+   to avoid the overhead of setting up the target environment.
 
    Usage: ``lisa-test TEST_PATTERN ... [EXEKALL_OPTIONS ...]``
 

--- a/doc/man1/lisa.1
+++ b/doc/man1/lisa.1
@@ -133,7 +133,9 @@ _
 This is just a wrapper around \fBexekall\fP that selects all tests modules and
 use positional arguments as \fB\-\-select\fP patterns. The default configuration
 file (\fB$LISA_CONF\fP) will be used if available. This can be extended with
-user\-supplied \fB\-\-conf\fP\&.
+user\-supplied \fB\-\-conf\fP\&. If multiple iterations are requested using \fB\-n\fP,
+the \fBlisa.target.Target\fP instance will be reused across iterations,
+to avoid the overhead of setting up the target environment.
 .sp
 Usage: \fBlisa\-test TEST_PATTERN ... [EXEKALL_OPTIONS ...]\fP
 .sp

--- a/tools/lisa-test
+++ b/tools/lisa-test
@@ -29,6 +29,7 @@ cmd=(
 	exekall run "$LISA_HOME/lisa/tests/"				\
 	"${conf_opt[@]}"									\
 	--symlink-artifact-dir-to "$latest_link"			\
+	--share '*.Target'									\
 	--select-multiple									\
 	"$@"
 )


### PR DESCRIPTION
This will share the same lisa.target.Target for all iterations, if more
than one iteration is requested (with -n). That avoids reconnecting to
the target at every iteration, which is likely to be the expected
behaviour for usual use cases.

More advanced users will use exekall directly instead of lisa-test if
sharing the Target between iterations is not desired.