### PR TITLE
doc: Remove capitalization in man page headings

### DIFF
--- a/doc/lisa_shell/man/man.rst
+++ b/doc/lisa_shell/man/man.rst
@@ -2,7 +2,7 @@
 LISA shell
 **********
 
-DESCRIPTION
+Description
 +++++++++++
 
 Once you have all of the required dependencies installed, you can use the LISA
@@ -10,7 +10,7 @@ shell, which provides a convenient set of commands for easy access to many LISA
 related functions, scripts and environment variables.
 
 
-ACTIVATION
+Activation
 ++++++++++
 
 In order to use the shell, source the script:
@@ -27,7 +27,7 @@ In order to use the shell, source the script:
 .. tip:: Run ``man lisa`` to see an overview of the provided LISA commands.
 
 
-COMMANDS
+Commands
 ++++++++
 
 Most LISA Shell commands start with ``lisa-``, thus using shell completion it
@@ -98,7 +98,7 @@ Buildroot commands
 * ``lisa-buildroot-update-kernel-config`` - Update a kernel config to bake a
   buildroot initramfs into the kernel.
 
-ENVIRONMENT VARIABLES
+Environment variables
 +++++++++++++++++++++
 
 The following environment variables are available:

--- a/doc/man1/exekall.1
+++ b/doc/man1/exekall.1
@@ -323,7 +323,7 @@ Executing an expression means evaluating each node if it has not already been
 evaluated. If an operator is not reusable, it will always be called when a
 value is requested from it, even if some existing values computed with the same
 parameters exist. By default, all operators are reusable, but some types can be
-flagged as non\-reusable by the customization module (see \fI\%CUSTOMIZING EXEKALL\fP).
+flagged as non\-reusable by the customization module (see \fI\%Customizing exekall\fP).
 .sp
 Operators are allowed to be generator functions as well. In that case, the
 engine will iterate over the generator, and will execute the downstream

--- a/tools/bisector/doc/man/man.rst
+++ b/tools/bisector/doc/man/man.rst
@@ -1,7 +1,7 @@
 Man page
 ========
 
-DESCRIPTION
+Description
 +++++++++++
 
 ``bisector`` is a ``git bisect run`` [#]_ compatible tool used in LISA. Its goal is
@@ -31,7 +31,7 @@ user-specified command line tool and will use the return code to decide what
 reporting, and additional run behaviors.
 
 
-OPTIONS
+Options
 +++++++
 
 bisector
@@ -99,7 +99,7 @@ bisector edit
 
    bisector edit --help
 
-CONFIGURATION
+Configuration
 +++++++++++++
 
 ``bisector run`` is configured using a YAML [#]_ file specified using ``--steps`` that
@@ -152,7 +152,7 @@ The YAML file is structured as following:
 All step options can also be specified using ``--options/-o``, which will
 override what is described in the YAML steps configuration.
 
-MONITORING
+Monitoring
 ++++++++++
 
 ``bisector run`` allows some live monitoring by exposing a DBus interface. This
@@ -176,7 +176,7 @@ the server is running), and allows querying various information from them.
 Since the query can be directed to a specific PID, the server is only necessary
 for listing.
 
-EXAMPLES
+Examples
 ++++++++
 
 A typical flow of ``bisector`` looks like that:
@@ -237,7 +237,7 @@ A typical flow of ``bisector`` looks like that:
    bisector report bisector.report.yml.gz -oeas_behaviour.iterations=2
 
 
-REFERENCES
+References
 ++++++++++
 
 .. [#] https://git-scm.com/docs/git-bisect#_bisect_run

--- a/tools/exekall/doc/man/man.rst
+++ b/tools/exekall/doc/man/man.rst
@@ -1,13 +1,13 @@
 Man page
 ========
 
-DESCRIPTION
+Description
 +++++++++++
 
 ``exekall`` is a python-based test runner. The expressions it executes are
 discovered from Python PEP 484 parameter and return value annotations.
 
-OPTIONS
+Options
 +++++++
 
 exekall
@@ -49,7 +49,7 @@ exekall merge
    exekall merge --help
 
 
-EXECUTING EXPRESSIONS
+Executing expressions
 +++++++++++++++++++++
 
 Expressions are built by scanning the python source code passed to ``exekall
@@ -72,7 +72,7 @@ The adaptor found in the customization module of the python sources you are
 using can add extra options to ``exekall run``, which are shown in ``--help``
 only when these sources are specified as well. 
 
-EXPRESSION ENGINE
+Expression engine
 +++++++++++++++++
 
 At the core of ``exekall`` is the expression engine. It is in charge of
@@ -141,7 +141,7 @@ chained, leading to a cascade of values for the same expression.
 Once an expression has been executed, all its values will get a UUID that can
 be used to uniquely refer to it, and track where it was used in the logs.
 
-EXPLOITING ARTIFACTS
+Exploiting artifacts
 ++++++++++++++++++++
 
 ``exekall run`` produces an artifact folder. The location can be set using
@@ -194,7 +194,7 @@ comparison method of the adaptor that was used when ``exekall run`` was
 executed. That function is expected to compare the expression values found in
 the databases, by matching values that have the same ID on both databases.
 
-ADDING NEW EXPRESSIONS
+Adding new expressions
 ++++++++++++++++++++++
 
 Since ``exekall run`` will discover expressions based on type annotations of
@@ -276,7 +276,7 @@ why. Most common issues are:
 
 .. _customize:
 
-CUSTOMIZING EXEKALL
+Customizing exekall
 +++++++++++++++++++
 
 The behavior of ``exekall`` can be customized by subclassing


### PR DESCRIPTION
The man page builder of Sphinx already takes care of that to align with
man pages conventions, and the non-capitalized output looks better in
html doc.