### PR TITLE
unchecked @requires_events(check=False)

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -35,7 +35,7 @@ from lisa.analysis.tasks import TasksAnalysis
 from lisa.trace import Trace
 from lisa.wlgen.rta import RTA
 
-from lisa.utils import Serializable, memoized, ArtifactPath
+from lisa.utils import Serializable, memoized, ArtifactPath, non_recursive_property
 from lisa.trace import FtraceCollector, FtraceConf
 
 class TestMetric:
@@ -475,10 +475,12 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
 
         return (rta_start, rta_stop)
 
+    # Guard before the cache, so we don't accidentally start depending on the
+    # LRU cache for functionnal correctness.
+    @non_recursive_property
     # Use LRU cache instead of memoized, to avoid caching the trace forever, in
     # case the thread is manipulating a large number of TestBundles without
     # deleting them.
-    @property
     @functools.lru_cache(maxsize=30, typed=True)
     def trace(self):
         """

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -32,7 +32,7 @@ import copy
 from devlib.trace.dmesg import DmesgCollector
 
 from lisa.analysis.tasks import TasksAnalysis
-from lisa.trace import Trace
+from lisa.trace import Trace, requires_events
 from lisa.wlgen.rta import RTA
 
 from lisa.utils import Serializable, memoized, ArtifactPath, non_recursive_property
@@ -450,6 +450,7 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
       the associated task will be ignored in the noise accounting.
     """
 
+    @requires_events('sched_switch')
     def trace_window(self, trace):
         """
         The time window to consider for this :class:`RTATestBundle`

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -465,7 +465,8 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
 
         .. warning::
 
-          Don't call ``self.trace`` in here unless you like infinite recursion.
+          Calling ``self.trace`` here will raise an :exc:`AttributeError`
+          exception, to avoid entering infinite recursion.
         """
         sdf = trace.df_events('sched_switch')
 


### PR DESCRIPTION
Allows using requires_events() decorator without enabling the runtime check.
This fixes the infinite loop with the `trace` property and `trace_window()` method exposed in https://github.com/ARM-software/lisa/pull/829