### PR TITLE
lisa.exekall_customize: Error for empty TestBundle.ftrace_conf['events']

### DIFF
--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -71,8 +71,16 @@ class ExekallArtifactPath(ArtifactPath, NonReusable):
 class ExekallFtraceCollector(FtraceCollector, HideExekallID):
     @staticmethod
     def _get_consumer_conf(consumer):
+        attr = 'ftrace_conf'
         consumer_cls = get_method_class(consumer)
-        conf = getattr(consumer_cls, 'ftrace_conf', FtraceConf())
+        conf = getattr(consumer_cls, attr, FtraceConf())
+        # This is not strictly speaking forbidden but in the current situation,
+        # there is no legitimate use case where it could happen, and it is very
+        # likely that it comes from a design issue in the class
+        if not conf['events'] and issubclass(consumer_cls, TestBundle):
+            raise ValueError("Empty events list in {}.{}".format(
+                consumer_cls.__qualname__, attr,
+            ))
         return conf
 
     @classmethod


### PR DESCRIPTION
There is no case where an FtraceCollector is requested to exekall
by a TestBundle subclass without providing any events to collect.
Therefore, it currently indicates a design issue, that would otherwise
trigger a cryptic error in trace-cmd itself.

Such design issue can arise for aggregation+item class pairs, where
exekall only knows about the aggregation class, but this class is an
empty shell and does not provide a useful FtraceConf. In that case, the
link must be manually made by adding ftrace_conf class attribute equal
to the one from the item class.

Catch the issue when we can display relevant context and raise an
exception.