### PR TITLE
lisa.trace: Fix Trace.add_events_deltas() on empty dataframe

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -92,8 +92,6 @@ class TraceBase(abc.ABC):
         This method only really makes sense for events tracking an on/off state
         (e.g. overutilized, idle)
         """
-        if df.empty:
-            return df
 
         if col_name in df.columns:
             raise RuntimeError("Column {} is already present in the dataframe".
@@ -103,10 +101,12 @@ class TraceBase(abc.ABC):
             df = df.copy()
 
         df[col_name] = df.index
-        df[col_name] = df[col_name].diff().shift(-1)
-        # Fix the last event, which will have a NaN duration
-        # Set duration to trace_end - last_event
-        df.loc[df.index[-1], col_name] = self.end - df.index[-1]
+
+        if not df.empty:
+            df[col_name] = df[col_name].diff().shift(-1)
+            # Fix the last event, which will have a NaN duration
+            # Set duration to trace_end - last_event
+            df.loc[df.index[-1], col_name] = self.end - df.index[-1]
 
         return df
 


### PR DESCRIPTION
Make sure to always add the delta column, even on empty dataframe. The
caller can then manipulate the dataframe in the same way wether empty or
not, and only operations like plotting will fail, with an explicit
error.