### PR TITLE
lisa.conf: Check for mandatory args in check_init_param()

### DIFF
--- a/lisa/energy_meter.py
+++ b/lisa/energy_meter.py
@@ -90,12 +90,12 @@ class EnergyMeter(Loggable, Configurable):
 
         cls.get_logger('{} energy meter configuration:\n{}'.format(cls.name, conf))
         kwargs = cls.conf_to_init_kwargs(conf)
+        kwargs.update({
+            'target': target,
+            'res_dir': res_dir,
+        })
         cls.check_init_param(**kwargs)
-        return cls(
-            target=target,
-            res_dir=res_dir,
-            **kwargs,
-        )
+        return cls(**kwargs)
 
     @abc.abstractmethod
     def name():

--- a/lisa/target.py
+++ b/lisa/target.py
@@ -313,6 +313,7 @@ class Target(Loggable, HideExekallID, Configurable):
         devlib_platform = devlib_platform_cls(**devlib_platform_kwargs)
         kwargs['devlib_platform'] = devlib_platform
 
+        cls.check_init_param(**kwargs)
         return cls(**kwargs)
 
     @classmethod

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -1466,6 +1466,7 @@ class FtraceCollector(devlib.FtraceCollector, Loggable, Configurable):
 
     def __init__(self, target, events=[], functions=[], buffer_size=10240, autoreport=False, **kwargs):
         kwargs.update(dict(
+            target=target,
             events=events,
             functions=functions,
             buffer_size=buffer_size,
@@ -1473,7 +1474,7 @@ class FtraceCollector(devlib.FtraceCollector, Loggable, Configurable):
         ))
         self.check_init_param(**kwargs)
 
-        super().__init__(target, **kwargs)
+        super().__init__(**kwargs)
         # Ensure we have trace-cmd on the target
         self.target.install_tools(['trace-cmd'])
 
@@ -1490,7 +1491,9 @@ class FtraceCollector(devlib.FtraceCollector, Loggable, Configurable):
         """
         cls.get_logger().info('Ftrace configuration:\n{}'.format(conf))
         kwargs = cls.conf_to_init_kwargs(conf)
-        return cls(target, **kwargs)
+        kwargs['target'] = target
+        cls.check_init_param(**kwargs)
+        return cls(**kwargs)
 
     @classmethod
     def from_user_conf(cls, target, base_conf=None, user_conf=None, merged_src='merged'):


### PR DESCRIPTION
Make sure that all mandatory args have a value, and raise an exception
is it's not the case with the path in the configuration.

For example, if `kind` key is missing in `TargetConf`, the following message will appear when running with `exekall`:
```
EXCEPTION (KeyError): 'Missing mandatory keys: target-conf/kind'
```