### PR TITLE
Add exekall show subcommand

### DIFF
--- a/doc/man1/exekall.1
+++ b/doc/man1/exekall.1
@@ -41,7 +41,7 @@ discovered from Python PEP 484 parameter and return value annotations.
 .sp
 .nf
 .ft C
-usage: exekall [\-h] [\-\-debug] {run,merge,compare} ...
+usage: exekall [\-h] [\-\-debug] {run,merge,compare,show} ...
 
 Test runner
 
@@ -51,11 +51,11 @@ PATTERNS
     
 
 optional arguments:
-  \-h, \-\-help           show this help message and exit
-  \-\-debug              Show complete Python backtrace when exekall crashes.
+  \-h, \-\-help            show this help message and exit
+  \-\-debug               Show complete Python backtrace when exekall crashes.
 
 subcommands:
-  {run,merge,compare}
+  {run,merge,compare,show}
 
 .ft P
 .fi
@@ -192,6 +192,34 @@ arguments.
 
 positional arguments:
   db          DBs created using exekall run to compare.
+
+optional arguments:
+  \-h, \-\-help  show this help message and exit
+
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS exekall show
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+usage: exekall show [\-h] db
+
+Show the content of a ValueDB created by exekall \(ga\(garun\(ga\(ga
+
+Note that the adaptor in the customization module recorded in the database
+is able to add more parameters to \(ga\(gaexekall show\(ga\(ga. In order to get the
+complete set of options, please run \(ga\(gaexekall show DB \-\-help\(ga\(ga.
+
+Options part of a custom group will need to be passed after positional
+arguments.
+    
+
+positional arguments:
+  db          DB created using exekall run to show.
 
 optional arguments:
   \-h, \-\-help  show this help message and exit

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -587,6 +587,13 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
 
         return (rta_start, rta_stop)
 
+    @property
+    def trace_path(self):
+        """
+        Path to the ``trace-cmd report`` trace.dat file.
+        """
+        return os.path.join(self.res_dir, self.TRACE_PATH)
+
     # Guard before the cache, so we don't accidentally start depending on the
     # LRU cache for functionnal correctness.
     @non_recursive_property
@@ -604,8 +611,7 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
         allows updating the underlying path before it is actually loaded to
         match a different folder structure.
         """
-        path = os.path.join(self.res_dir, self.TRACE_PATH)
-        trace = Trace(path, self.plat_info, events=self.ftrace_conf["events"])
+        trace = Trace(self.trace_path, self.plat_info, events=self.ftrace_conf["events"])
         return trace.get_view(self.trace_window(trace))
 
     @property

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -21,6 +21,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from collections import OrderedDict
 import contextlib
 import inspect
+import io
 import logging
 import logging.config
 import functools
@@ -374,6 +375,18 @@ class Serializable(Loggable):
 
         with open(str(filepath), **kwargs) as fh:
             dumper(instance, fh)
+
+    @classmethod
+    def _to_yaml(cls, data):
+        buff = io.StringIO()
+        cls._yaml.dump(data, buff)
+        return buff.getvalue()
+
+    def to_yaml(self):
+        """
+        Return a YAML string with the serialized object.
+        """
+        return self._to_yaml(self)
 
     @classmethod
     def from_path(cls, filepath, fmt=None):

--- a/tools/exekall/doc/man/man.rst
+++ b/tools/exekall/doc/man/man.rst
@@ -39,6 +39,15 @@ exekall compare
 
    exekall compare --help
 
+exekall show
+------------
+
+.. run-command::
+   :ignore-error:
+   :literal:
+
+   exekall show --help
+
 exekall merge
 -------------
 

--- a/tools/exekall/exekall/_utils.py
+++ b/tools/exekall/exekall/_utils.py
@@ -107,7 +107,7 @@ def get_method_class(function):
         return None
     return eval(cls_name, function.__globals__)
 
-def get_name(obj, full_qual=True, qual=True):
+def get_name(obj, full_qual=True, qual=True, pretty=False):
     """
     Get a name for ``obj`` (function or class) that can be used in a generated
     script.
@@ -117,12 +117,30 @@ def get_name(obj, full_qual=True, qual=True):
 
     :param qual: Qualified name of the object
     :type qual: bool
+
+    :param pretty: If ``True``, will show a prettier name for some types,
+        although it is not guarnateed it will actually be a type name. For example,
+        ``type(None)`` will be shown as ``None`` instead of ``NoneType``.
+    :type pretty: bool
     """
     # full_qual enabled implies qual enabled
     _qual = qual or full_qual
     # qual disabled implies full_qual disabled
     full_qual = full_qual and qual
     qual = _qual
+
+    if qual:
+        _get_name = lambda x: x.__qualname__
+    else:
+        _get_name = lambda x: x.__name__
+
+    if pretty:
+        for prettier_obj in {None, NoValue}:
+            if obj == type(prettier_obj):
+                # For these types, qual=False or qual=True makes no difference
+                obj = prettier_obj
+                _get_name = lambda x: str(x)
+                break
 
     # Add the module's name in front of the name to get a fully
     # qualified name
@@ -135,11 +153,6 @@ def get_name(obj, full_qual=True, qual=True):
         )
     else:
         module_name = ''
-
-    if qual:
-        _get_name = lambda x: x.__qualname__
-    else:
-        _get_name = lambda x: x.__name__
 
     # Classmethods appear as bound method of classes. Since each subclass will
     # get a different bound method object, we want to reflect that in the

--- a/tools/exekall/exekall/customization.py
+++ b/tools/exekall/exekall/customization.py
@@ -147,6 +147,31 @@ class AdaptorBase:
         pass
 
     @staticmethod
+    def register_show_param(parser):
+        """
+        Register CLI parameters for the ``show`` subcommand.
+
+        :param parser: Parser of the ``show`` subcommand to add arguments onto.
+        :type parser: argparse.ArgumentParser
+        """
+        pass
+
+    def show_db(self, db):
+        """
+        Show the content of the database.
+
+        :param db: :class:`exekall.engine.ValueDB` to show.
+        :type db: exekall.engine.ValueDB
+
+        This is called by ``exekall show`` to actually do something useful.
+        """
+
+        root_expr_val_list = sorted(db.get_roots(), key=lambda expr_val: expr_val.uuid)
+        for i, froz_val in enumerate(root_expr_val_list):
+            print('{}) {}\n'.format(i, froz_val.format_structure(full_qual=False)))
+        return 0
+
+    @staticmethod
     def get_default_type_goal_pattern_set():
         """
         Returns a set of patterns that will be used as the default value for

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -699,7 +699,7 @@ class ExpressionBase(ExprHelpers):
 
     def __repr__(self):
         return '<Expression of {name} at {id}>'.format(
-            name=self.op.get_name(full_qual=True),
+            name=self.op.get_name(full_qual=True, pretty=True),
             id = hex(id(self))
         )
 
@@ -723,11 +723,11 @@ class ExpressionBase(ExprHelpers):
     @staticmethod
     def _format_structure_op_name(op):
         if isinstance(op, ConsumerOperator):
-            return op.get_name(full_qual=True)
+            return op.get_name(full_qual=True, pretty=True)
         elif isinstance(op, PrebuiltOperator):
             return '<provided>'
         else:
-            return op.get_name(full_qual=True)
+            return op.get_name(full_qual=True, pretty=True)
 
     def _format_structure(self, full_qual=True, indent=1):
         indent_str = 4 * ' ' * indent
@@ -735,7 +735,10 @@ class ExpressionBase(ExprHelpers):
         op_name = self._format_structure_op_name(self.op)
         out = '{op_name} ({value_type_name})'.format(
             op_name = op_name,
-            value_type_name = utils.get_name(self.op.value_type, full_qual=full_qual),
+            value_type_name = utils.get_name(self.op.value_type,
+                full_qual=full_qual,
+                pretty=True,
+            ),
         )
         if self.param_map:
             out += ':\n'+ indent_str + ('\n'+indent_str).join(
@@ -769,7 +772,10 @@ class ExpressionBase(ExprHelpers):
             uid=uid,
             op_name=op_name,
             reusable='(reusable)' if self.op.reusable else '(non-reusable)',
-            value_type_name=utils.get_name(self.op.value_type, full_qual=full_qual),
+            value_type_name=utils.get_name(self.op.value_type,
+                full_qual=full_qual,
+                pretty=True,
+            ),
             loc=src_loc,
         )]
         if self.param_map:
@@ -2414,9 +2420,9 @@ class Operator:
         """
         if style == 'rst':
             if self.is_factory_cls_method:
-                qualname = utils.get_name(self.value_type, full_qual=True)
+                qualname = utils.get_name(self.value_type, full_qual=True, pretty=True)
             else:
-                qualname = self.get_name(full_qual=True)
+                qualname = self.get_name(full_qual=True, pretty=True)
             name = self.get_id(full_qual=full_qual, qual=qual, style=None)
 
             if self.is_class:
@@ -2432,9 +2438,10 @@ class Operator:
             # Factory classmethods are replaced by the class name when not
             # asking for a qualified ID
             if not (qual or full_qual) and self.is_factory_cls_method:
-                return utils.get_name(self.value_type, full_qual=full_qual, qual=qual)
+                type_ = self.value_type
             else:
-                return self.get_name(full_qual=full_qual, qual=qual)
+                type_ = None
+            return utils.get_name(type_, full_qual=full_qual, qual=qual, pretty=True)
 
     @property
     def name(self):
@@ -3166,7 +3173,7 @@ class ExprValBase(ExprHelpers):
             params=params,
             joiner=':' + joiner if params else '',
             uuid=self.uuid,
-            type = utils.get_name(type(value), full_qual=full_qual),
+            type = utils.get_name(type(value), full_qual=full_qual, pretty=True),
         )
 
 


### PR DESCRIPTION
Allow showing the content of a ValueDB and exporting serialized objects:
```
# Show the value of an attribute of the object with the given UUID, or the object itself
$ exekall --debug show VALUE_DB.pickle.xz --show UUID_OF_A_RESULT.attribute
# Serialize an object or one of its attribute to the given PATH
$ exekall --debug show VALUE_DB.pickle.xz --serialize UUID_OF_A_RESULT.attribute PATH
```