### PR TITLE
jupyter lab: Enable %matplotlib widget

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
             "ipython",
             "jupyterlab",
             "ipywidgets",
+            "ipympl", # For %matplotlib widget under jupyter lab
         ],
 
         "doc": [

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -175,8 +175,10 @@ function _lisa-install-nbextensions {
     which jupyter &>/dev/null || return
     if which node &>/dev/null; then
         echo
-        echo "Enabling ipywidget extensions..."
-        jupyter labextension install @jupyter-widgets/jupyterlab-manager
+        echo "Installing jupyter lab extensions..."
+        jupyter labextension install                    \
+            @jupyter-widgets/jupyterlab-manager         \
+            jupyter-matplotlib                          \
         return
     fi
 


### PR DESCRIPTION
Allow using "%matplotlib widget" magic in jupyter lab notebooks, which
gives what used to be enabled by "%matplotlib notebook" in legacy
notebooks. This allows zooming and panning on the plots interactively.