### PR TITLE
Make RTATestBundle.trace useable for by analysis methods

### DIFF
--- a/lisa/analysis/base.py
+++ b/lisa/analysis/base.py
@@ -22,7 +22,7 @@ import mimetypes
 import matplotlib.pyplot as plt
 from cycler import cycler
 
-from lisa.utils import Loggable
+from lisa.utils import Loggable, get_subclasses
 
 # Colorblind-friendly cycle, see https://gist.github.com/thriveth/8560036
 COLOR_CYCLES = [
@@ -204,5 +204,16 @@ class TraceAnalysisBase(AnalysisHelpers):
         """
         default_dir = self.trace.plots_dir
         return self._save_plot(figure, default_dir, filepath, img_format)
+
+    @classmethod
+    def get_analysis_classes(cls):
+        return {
+            subcls.name: subcls
+            for subcls in get_subclasses(cls)
+            # Classes without a "name" attribute directly defined in their
+            # scope will not get registered. That allows having unnamed
+            # intermediate base classes that are not meant to be exposed.
+            if 'name' in subcls.__dict__
+        }
 
 # vim :set tabstop=4 shiftwidth=4 expandtab textwidth=80

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -605,13 +605,25 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
         """
         :returns: a :class:`lisa.trace.TraceView`
 
+        All events specified in ``ftrace_conf`` are parsed from the trace,
+        so it is suitable for direct use in methods.
+
         Having the trace as a property lets us defer the loading of the actual
         trace to when it is first used. Also, this prevents it from being
         serialized when calling :meth:`lisa.utils.Serializable.to_path` and
         allows updating the underlying path before it is actually loaded to
         match a different folder structure.
         """
-        trace = Trace(self.trace_path, self.plat_info, events=self.ftrace_conf["events"])
+        return self.get_trace(events=self.ftrace_conf["events"])
+
+    def get_trace(self, **kwargs):
+        """
+        :returns: a :class:`lisa.trace.TraceView` cropped to fit the ``rt-app``
+            tasks.
+
+        :Keyword arguments: forwarded to :class:`lisa.trace.Trace`.
+        """
+        trace = Trace(self.trace_path, self.plat_info, **kwargs)
         return trace.get_view(self.trace_window(trace))
 
     @property

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -757,7 +757,7 @@ def non_recursive_property(f):
     def wrapper(self, *args, **kwargs):
         if _get(self):
             raise AttributeError('Recursive access to property "{}.{}" while computing its value'.format(
-                type(self), f.__qualname__,
+                self.__class__.__qualname__, f.__name__,
             ))
 
         try:


### PR DESCRIPTION
Load all the events that are useful to analysis classes from the trace, so that they can be manipulated without any manual settings.