### PR TITLE
lisa-install: Fix typo in install-nbextensions

### DIFF
--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -178,7 +178,7 @@ function _lisa-install-nbextensions {
         echo "Installing jupyter lab extensions..."
         jupyter labextension install                    \
             @jupyter-widgets/jupyterlab-manager         \
-            jupyter-matplotlib                          \
+            jupyter-matplotlib
         return
     fi
 


### PR DESCRIPTION
An extra line-return escape character was preventing lisa-install to
complete.

Signed-off-by: Alessio Balsini <balsini@android.com>