### PR TITLE
lisa: platinfo: Add kernel/cmdline key

### DIFF
--- a/lisa/platforms/platinfo.py
+++ b/lisa/platforms/platinfo.py
@@ -58,6 +58,7 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
         LevelKeyDesc('kernel', 'Kernel-related information', (
             KeyDesc('version', '', [KernelVersion]),
             KernelConfigKeyDesc('config', '', [TypedKernelConfig]),
+            KeyDesc('cmdline', 'Content of /proc/cmdline', [str]),
         )),
         KeyDesc('nrg-model', 'Energy model object', [EnergyModel]),
         KeyDesc('cpu-capacities', 'Dictionary of CPU ID to capacity value', [IntIntDict]),
@@ -85,6 +86,7 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
             'kernel': {
                 'version': target.kernel_version,
                 'config': target.config.typed_config,
+                'cmdline': target.read_value('/proc/cmdline'),
             },
             'abi': target.abi,
             'os': target.os,


### PR DESCRIPTION
Record the kernel's cmdline so we have it in the logs and it becomes
available to other helpers to know what to expect from dmesg output.