### PR TITLE
lisa.analysis.tasks: Fix TaskAnalysis.plot_task_activation()

### DIFF
--- a/lisa/analysis/tasks.py
+++ b/lisa/analysis/tasks.py
@@ -779,6 +779,8 @@ class TasksAnalysis(TraceAnalysisBase):
         """
 
         def plotter(axis, local_fig):
+            nonlocal active_value, sleep_value
+
             # Adapt the steps height to the existing limits. This allows
             # re-using an existing axis that already contains some data.
             min_lim, max_lim = axis.get_ylim()


### PR DESCRIPTION
Add nonlocal declaration since the variable is assigned to in a closure,
while refering to a name bound in an outer scope.