### PR TITLE
lisa-buildroot-update-kernel-config: Fix call from arbitrary folder

### DIFF
--- a/tools/lisa-buildroot-update-kernel-config
+++ b/tools/lisa-buildroot-update-kernel-config
@@ -74,4 +74,6 @@ tee "$fragment" << EOF
 CONFIG_INITRAMFS_SOURCE="$ROOTFS"
 EOF
 
+# merge_config.sh seems to have issue if called from other working directories
+cd "$KERNEL_DIR" &&
 KCONFIG_CONFIG="$KERNEL_CONFIG" "$KERNEL_DIR/scripts/kconfig/merge_config.sh" "$KERNEL_CONFIG" "$fragment"


### PR DESCRIPTION
cd to the kernel tree before calling merge_config.sh