### PR TITLE
Allow plotting utilest signals

### DIFF
--- a/lisa/__init__.py
+++ b/lisa/__init__.py
@@ -1,3 +1,21 @@
 from lisa.version import __version__
 
+import warnings
+# Raise an exception when a deprecated API is used from within a lisa.*
+# submodule. This ensures that we don't use any deprecated APIs internally, so
+# they are only kept for external backward compatibility purposes.
+warnings.filterwarnings(
+    action='error',
+    category=DeprecationWarning,
+    module=r'{}\..*'.format(__name__),
+)
+
+# When the deprecated APIs are used from __main__ (script or notebook), always
+# show the warning
+warnings.filterwarnings(
+    action='always',
+    category=DeprecationWarning,
+    module=r'__main__',
+)
+
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -65,7 +65,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
     def _df_uniformized_signal(self, event):
         df = self.trace.df_events(event)
 
-        df = df.rename(columns=self._columns_renaming(event))
+        df = df.rename(columns=self._columns_renaming(event), copy=True)
 
         if event == 'sched_load_se':
             df = df[df.path == "(null)"]
@@ -74,7 +74,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
             df = df[df.path == "/"]
 
         to_drop = self._columns_to_drop(event)
-        df = df[[col for col in df.columns if col not in to_drop]]
+        df.drop(columns=to_drop, inplace=True)
 
         return df
 

--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -20,7 +20,8 @@
 import pandas as pd
 
 from lisa.analysis.base import TraceAnalysisBase
-from lisa.trace import requires_one_event_of
+from lisa.analysis.status import StatusAnalysis
+from lisa.trace import requires_one_event_of, may_use_events
 
 
 class LoadTrackingAnalysis(TraceAnalysisBase):
@@ -163,6 +164,10 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
 
         return top_df
 
+    @may_use_events(
+        StatusAnalysis.plot_overutilized.used_events,
+        'cpu_capacity',
+    )
     @df_cpus_signals.used_events
     def plot_cpus_signals(self, cpus=None, **kwargs):
         """

--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -169,12 +169,15 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
         'cpu_capacity',
     )
     @df_cpus_signals.used_events
-    def plot_cpus_signals(self, cpus=None, **kwargs):
+    def plot_cpus_signals(self, cpus=None, signals=['util', 'load'], **kwargs):
         """
         Plot the CPU-related load-tracking signals
 
         :param cpus: list of CPUs to be plotted
         :type cpus: list(int)
+
+        :param signals: List of signals to plot.
+        :type signals: list(str)
 
         .. seealso:: :meth:`lisa.analysis.base.AnalysisHelpers.do_plot`
         """
@@ -189,8 +192,8 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
                 axis.set_title('CPU{}'.format(cpu))
                 df = cpus_df[cpus_df["__cpu"] == cpu]
 
-                df[['util']].plot(ax=axis, drawstyle='steps-post', alpha=0.4)
-                df[['load']].plot(ax=axis, drawstyle='steps-post', alpha=0.4)
+                for signal in signals:
+                    df[[signal]].plot(ax=axis, drawstyle='steps-post', alpha=0.4)
 
                 self.trace.analysis.cpus.plot_orig_capacity(cpu, axis=axis)
 

--- a/lisa/version.py
+++ b/lisa/version.py
@@ -15,4 +15,12 @@
 # limitations under the License.
 #
 
-__version__ = 2.0
+version_tuple = (2, 0)
+
+def format_version(version):
+    return '.'.join(str(part) for part in version)
+
+def parse_version(version):
+     return tuple(int(part) for part in version.split('.'))
+
+__version__ = format_version(version_tuple)


### PR DESCRIPTION
* Add may_use_events() decorator to supplement requires_events() and requires_one_event_of()
* Add `LoadTrackingAnalysis.df_(cpus|task)_signal` to replace `df_(cpus|task)_signals()`
* Allow plotting `util_est_enqueued` signals in `LoadTrackingAnalysis.plot_(cpus|task)_signals`
* Allow selecting signals to plot in `LoadTrackingAnalysis.plot_cpus_signals` to mirror the `task` variant of the method

EDIT:
* Add `utils.deprecate()` decorator and treat deprecation as errors in `lisa`  and warnings in `__main__`