### PR TITLE
utils: Make memoize() use a weakref for the first parameter

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -597,10 +597,7 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
     # Guard before the cache, so we don't accidentally start depending on the
     # LRU cache for functionnal correctness.
     @non_recursive_property
-    # Use LRU cache instead of memoized, to avoid caching the trace forever, in
-    # case the thread is manipulating a large number of TestBundles without
-    # deleting them.
-    @functools.lru_cache(maxsize=30, typed=True)
+    @memoized
     def trace(self):
         """
         :returns: a :class:`lisa.trace.TraceView`


### PR DESCRIPTION
When used on methods, this avoids keeping a reference over the instances
alive forever even when nothing else apart from the cache needs it
anymore.