### PR TITLE
doc: Disable sphinx.ext.viewcode

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,7 +129,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.imgmath',
-    'sphinx.ext.viewcode',
+    #  'sphinx.ext.viewcode',
     'sphinx.ext.inheritance_diagram',
     'sphinxcontrib.plantuml',
 ]


### PR DESCRIPTION
This extension provides the syntax-highlighted HTML pages containing
plain Python code, which clutters the search box results. Since nobody
is really using that feature, disable it.