### PR TITLE
doc: Add utils.show_doc()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
             "jupyterlab",
             "ipywidgets",
             "ipympl", # For %matplotlib widget under jupyter lab
+            "sphobjinv", # To open intersphinx inventories
         ],
 
         "doc": [


### PR DESCRIPTION
Calling utils.show_doc() from a Jupyter notebook opens an IFrame with
online LISA documentation.

EDIT: ReadTheDocs exposes the intersphinx inventory, so no need to build anything locally.

![image](https://user-images.githubusercontent.com/23336875/59517395-6ff70900-8ebb-11e9-8f34-b673dcd16789.png)
