### PR TITLE
Tracepoints module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .*
+!.gitignore
 *.pyc
 __pycache__
 *.egg-info

--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -91,3 +91,82 @@ again is needed.
   ``lisa-install`` was executed. If a modification is detected, it will ask the
   user to run ``lisa-install`` again, since a dependency might have been added,
   or a version requirement might have been updated.
+
+External dependencies
+=====================
+
+Kernel modules
+++++++++++++++
+
+The following modules are required to run Lisa tests against some kernels.
+
+sched_tp
+--------
+
+From Linux v5.3, sched_load_cfs_rq and sched_load_se tracepoints are present in
+mainline as bare tracepoints without any events in tracefs associated with
+them.
+
+To help expose these tracepoints (and any additional one we might require in
+the future) as trace events, an external module is required and is provided
+under the name of sched_tp in $LISA_HOME/tools/kmodules/sched_tp
+
+Building a module
++++++++++++++++++
+
+The process is standard Linux external module build step. Helper scripts are
+provides too.
+
+Build
+-----
+
+.. code-block:: sh
+
+  $LISA_HOME/tools/kmodules/build_module path/to/kenrel path/to/kmodule [path/to/install/modules]
+
+This will build the module against the provided kernel tree and install it in
+``path/to/install/module`` if provided otherwise install it in
+``$LISA_HOME/tools/kmodules``.
+
+Clean
+-----
+
+.. code-block:: sh
+
+  $LISA_HOME/tools/kmodules/clean_module path/to/kenrel path/to/kmodule
+
+Highly recommended to clean when switching kernel trees to avoid unintentional
+breakage for using stale binaries.
+
+Pushing the module into the target
+----------------------------------
+
+You need to push the module into your rootfs either by installing it directly
+there or use commands like ``scp`` to copy it into your device.
+
+.. code-block:: sh
+
+  scp -r $LISA_HOME/tools/kmoudles/lib username@ip:/
+
+Loading the module
+------------------
+
+On the target run:
+
+.. code-block:: sh
+
+  modprobe sched_tp
+
+Integrating the module in your kernel tree
+++++++++++++++++++++++++++++++++++++++++++
+
+If you're rebuilding your kernel tree anyway, it might be easier to integrate
+the module into your kernel tree as a built-in module so that it's always
+present.
+
+Integrate using provided patch
+------------------------------
+
+.. code-block:: sh
+
+  cd path/to/kernel && git am path/to/patch

--- a/tools/kmodules/.gitignore
+++ b/tools/kmodules/.gitignore
@@ -1,0 +1,5 @@
+modules.order
+Module.symvers
+*.ko
+*.mod.*
+*.o

--- a/tools/kmodules/build_module
+++ b/tools/kmodules/build_module
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eu
+
+KERNEL_SRC=`realpath "$1"`
+MODULE_SRC=`realpath "$2"`
+INSTALL_MOD_PATH=${3:-`dirname "$0"`}
+
+export INSTALL_MOD_PATH=`realpath "$INSTALL_MOD_PATH"`
+export ARCH=${ARCH:-arm64}
+
+case "$ARCH" in
+
+	arm64)
+		export CROSS_COMPILE=${CROSS_COMPILE:-aarch64-linux-gnu-}
+		;;
+	arm)
+		export CROSS_COMPILE=${CROSS_COMPILE:-arm-linux-gnueabi-}
+		;;
+	x86|x86_64)
+		;;
+	*)
+		echo "ERROR: Unknown ARCH=$ARCH"
+		exit 1
+		;;
+esac
+
+make -C "$KERNEL_SRC" M="$MODULE_SRC" modules
+make -C "$KERNEL_SRC" M="$MODULE_SRC" modules_install

--- a/tools/kmodules/clean_module
+++ b/tools/kmodules/clean_module
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eu
+
+KERNEL_SRC=`realpath "$1"`
+MODULE_SRC=`realpath "$2"`
+
+export ARCH=${ARCH:-arm64}
+
+case "$ARCH" in
+
+	arm64)
+		export CROSS_COMPILE=${CROSS_COMPILE:-aarch64-linux-gnu-}
+		;;
+	arm)
+		export CROSS_COMPILE=${CROSS_COMPILE:-arm-linux-gnueabi-}
+		;;
+	x86|x86_64)
+		;;
+	*)
+		echo "ERROR: Unknown ARCH=$ARCH"
+		exit 1
+		;;
+esac
+
+make -C "$KERNEL_SRC" M="$MODULE_SRC" clean

--- a/tools/kmodules/sched_tp/0001-sched-add-a-module-to-convert-tp-into-events.patch
+++ b/tools/kmodules/sched_tp/0001-sched-add-a-module-to-convert-tp-into-events.patch
@@ -1,0 +1,315 @@
+From fbb3f083f135b6e43eb7a71adc8ee850f408558b Mon Sep 17 00:00:00 2001
+From: Qais Yousef <qais.yousef@arm.com>
+Date: Fri, 24 May 2019 15:10:46 +0100
+Subject: [PATCH] sched: add a module to convert tp into events
+
+The module is always compiled as built-in except for !CONFIG_SMP
+where the targeted tracepoints don't exist/make sense.
+
+It creates a set of sched events in tracefs that are required to run
+Lisa tests.
+
+Signed-off-by: Qais Yousef <qais.yousef@arm.com>
+---
+ kernel/sched/Makefile       |   3 +
+ kernel/sched/sched_events.h | 134 ++++++++++++++++++++++++++++++++++++
+ kernel/sched/sched_tp.c     | 132 +++++++++++++++++++++++++++++++++++
+ 3 files changed, 269 insertions(+)
+ create mode 100644 kernel/sched/sched_events.h
+ create mode 100644 kernel/sched/sched_tp.c
+
+diff --git a/kernel/sched/Makefile b/kernel/sched/Makefile
+index 21fb5a5662b5..dbcb46d51509 100644
+--- a/kernel/sched/Makefile
++++ b/kernel/sched/Makefile
+@@ -20,6 +20,9 @@ obj-y += core.o loadavg.o clock.o cputime.o
+ obj-y += idle.o fair.o rt.o deadline.o
+ obj-y += wait.o wait_bit.o swait.o completion.o
+ 
++obj-$(CONFIG_SMP) += sched_tp.o
++CFLAGS_sched_tp.o := -I$(src)
++
+ obj-$(CONFIG_SMP) += cpupri.o cpudeadline.o topology.o stop_task.o pelt.o
+ obj-$(CONFIG_SCHED_AUTOGROUP) += autogroup.o
+ obj-$(CONFIG_SCHEDSTATS) += stats.o
+diff --git a/kernel/sched/sched_events.h b/kernel/sched/sched_events.h
+new file mode 100644
+index 000000000000..06c16e6ac1b3
+--- /dev/null
++++ b/kernel/sched/sched_events.h
+@@ -0,0 +1,134 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#undef TRACE_SYSTEM
++#define TRACE_SYSTEM sched
++
++#if !defined(_SCHED_EVENTS_H) || defined(TRACE_HEADER_MULTI_READ)
++#define _SCHED_EVENTS_H
++
++#define PATH_SIZE		128
++#define SPAN_SIZE		128/4	/* assuming a max of 128 cpu system! */
++
++#include <linux/tracepoint.h>
++
++TRACE_EVENT(sched_load_cfs_rq,
++
++	TP_PROTO(int cpu, char *path, const struct sched_avg *avg),
++
++	TP_ARGS(cpu, path, avg),
++
++	TP_STRUCT__entry(
++		__field(	int,		cpu			)
++		__array(	char,		path,	PATH_SIZE	)
++		__field(	unsigned long,	load			)
++		__field(	unsigned long,	rbl_load		)
++		__field(	unsigned long,	util			)
++	),
++
++	TP_fast_assign(
++		__entry->cpu		= cpu;
++		strlcpy(__entry->path, path, PATH_SIZE);
++		__entry->load		= avg->load_avg;
++		__entry->rbl_load	= avg->runnable_load_avg;
++		__entry->util		= avg->util_avg;
++	),
++
++	TP_printk("cpu=%d path=%s load=%lu rbl_load=%lu util=%lu",
++		  __entry->cpu, __entry->path, __entry->load,
++		  __entry->rbl_load,__entry->util)
++);
++
++DECLARE_EVENT_CLASS(sched_pelt_rq_template,
++
++	TP_PROTO(int cpu, const struct sched_avg *avg),
++
++	TP_ARGS(cpu, avg),
++
++	TP_STRUCT__entry(
++		__field(	int,		cpu			)
++		__field(	unsigned long,	load			)
++		__field(	unsigned long,	rbl_load		)
++		__field(	unsigned long,	util			)
++	),
++
++	TP_fast_assign(
++		__entry->cpu		= cpu;
++		__entry->load		= avg->load_avg;
++		__entry->rbl_load	= avg->runnable_load_avg;
++		__entry->util		= avg->util_avg;
++	),
++
++	TP_printk("cpu=%d load=%lu rbl_load=%lu util=%lu",
++		  __entry->cpu, __entry->load,
++		  __entry->rbl_load,__entry->util)
++);
++
++DEFINE_EVENT(sched_pelt_rq_template, sched_pelt_rt,
++	TP_PROTO(int cpu, const struct sched_avg *avg),
++	TP_ARGS(cpu, avg));
++
++DEFINE_EVENT(sched_pelt_rq_template, sched_pelt_dl,
++	TP_PROTO(int cpu, const struct sched_avg *avg),
++	TP_ARGS(cpu, avg));
++
++DEFINE_EVENT(sched_pelt_rq_template, sched_pelt_irq,
++	TP_PROTO(int cpu, const struct sched_avg *avg),
++	TP_ARGS(cpu, avg));
++
++TRACE_EVENT(sched_load_se,
++
++	TP_PROTO(int cpu, char *path, char *comm, int pid, const struct sched_avg *avg),
++
++	TP_ARGS(cpu, path, comm, pid, avg),
++
++	TP_STRUCT__entry(
++		__field(	int,		cpu			)
++		__array(	char,		path,	PATH_SIZE	)
++		__array(	char,		comm,	TASK_COMM_LEN	)
++		__field(	int,		pid			)
++		__field(	unsigned long,	load			)
++		__field(	unsigned long,	rbl_load		)
++		__field(	unsigned long,	util			)
++	),
++
++	TP_fast_assign(
++		__entry->cpu		= cpu;
++		strlcpy(__entry->path, path, PATH_SIZE);
++		strlcpy(__entry->comm, comm, TASK_COMM_LEN);
++		__entry->pid		= pid;
++		__entry->load		= avg->load_avg;
++		__entry->rbl_load	= avg->runnable_load_avg;
++		__entry->util		= avg->util_avg;
++	),
++
++	TP_printk("cpu=%d path=%s comm=%s pid=%d load=%lu rbl_load=%lu util=%lu",
++		  __entry->cpu, __entry->path, __entry->comm, __entry->pid,
++		  __entry->load, __entry->rbl_load,__entry->util)
++);
++
++TRACE_EVENT(sched_overutilized,
++
++	TP_PROTO(int overutilized, char *span),
++
++	TP_ARGS(overutilized, span),
++
++	TP_STRUCT__entry(
++		__field(	int,		overutilized		)
++		__array(	char,		span,	SPAN_SIZE	)
++	),
++
++	TP_fast_assign(
++		__entry->overutilized	= overutilized;
++		strlcpy(__entry->span, span, SPAN_SIZE);
++	),
++
++	TP_printk("overutilized=%d span=0x%s",
++		  __entry->overutilized, __entry->span)
++);
++
++#endif /* _SCHED_EVENTS_H */
++
++/* This part must be outside protection */
++#undef TRACE_INCLUDE_PATH
++#define TRACE_INCLUDE_PATH .
++#define TRACE_INCLUDE_FILE sched_events
++#include <trace/define_trace.h>
+diff --git a/kernel/sched/sched_tp.c b/kernel/sched/sched_tp.c
+new file mode 100644
+index 000000000000..290fd149b885
+--- /dev/null
++++ b/kernel/sched/sched_tp.c
+@@ -0,0 +1,132 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#include <linux/module.h>
++
++#include <linux/sched.h>
++#include <trace/events/sched.h>
++
++#define CREATE_TRACE_POINTS
++#include "sched_events.h"
++
++static inline struct cfs_rq *get_group_cfs_rq(struct sched_entity *se)
++{
++#ifdef CONFIG_FAIR_GROUP_SCHED
++	return se->my_q;
++#else
++	return NULL;
++#endif
++}
++
++static void sched_pelt_cfs(void *data, struct cfs_rq *cfs_rq)
++{
++	if (trace_sched_load_cfs_rq_enabled()) {
++		const struct sched_avg *avg;
++		char path[PATH_SIZE];
++		int cpu;
++
++		avg = sched_trace_cfs_rq_avg(cfs_rq);
++		sched_trace_cfs_rq_path(cfs_rq, path, PATH_SIZE);
++		cpu = sched_trace_cfs_rq_cpu(cfs_rq);
++
++		trace_sched_load_cfs_rq(cpu, path, avg);
++	}
++}
++
++static void sched_pelt_rt(void *data, struct rq *rq)
++{
++	if (trace_sched_pelt_rt_enabled()) {
++		const struct sched_avg *avg = sched_trace_rq_avg_rt(rq);
++		int cpu = sched_trace_rq_cpu(rq);
++
++		if (!avg)
++			return;
++
++		trace_sched_pelt_rt(cpu, avg);
++	}
++}
++
++static void sched_pelt_dl(void *data, struct rq *rq)
++{
++	if (trace_sched_pelt_dl_enabled()) {
++		const struct sched_avg *avg = sched_trace_rq_avg_dl(rq);
++		int cpu = sched_trace_rq_cpu(rq);
++
++		if (!avg)
++			return;
++
++		trace_sched_pelt_dl(cpu, avg);
++	}
++}
++
++static void sched_pelt_irq(void *data, struct rq *rq)
++{
++	if (trace_sched_pelt_irq_enabled()){
++		const struct sched_avg *avg = sched_trace_rq_avg_irq(rq);
++		int cpu = sched_trace_rq_cpu(rq);
++
++		if (!avg)
++			return;
++
++		trace_sched_pelt_irq(cpu, avg);
++	}
++}
++
++static void sched_pelt_se(void *data, struct sched_entity *se)
++{
++	if (trace_sched_load_se_enabled()) {
++		void *gcfs_rq = get_group_cfs_rq(se);
++		void *cfs_rq = se->cfs_rq;
++		struct task_struct *p;
++		char path[PATH_SIZE];
++		char *comm;
++		pid_t pid;
++		int cpu;
++
++		sched_trace_cfs_rq_path(gcfs_rq, path, PATH_SIZE);
++		cpu = sched_trace_cfs_rq_cpu(cfs_rq);
++
++		p = gcfs_rq ? NULL : container_of(se, struct task_struct, se);
++		comm = p ? p->comm : "(null)";
++		pid = p ? p->pid : -1;
++
++		trace_sched_load_se(cpu, path, comm, pid, &se->avg);
++	}
++}
++
++static void sched_overutilized(void *data, struct root_domain *rd, bool overutilized)
++{
++	if (trace_sched_overutilized_enabled()) {
++		char span[SPAN_SIZE];
++
++		cpumap_print_to_pagebuf(false, span, sched_trace_rd_span(rd));
++
++		trace_sched_overutilized(overutilized, span);
++	}
++}
++
++static int sched_tp_init(void)
++{
++	register_trace_pelt_cfs_tp(sched_pelt_cfs, NULL);
++	register_trace_pelt_rt_tp(sched_pelt_rt, NULL);
++	register_trace_pelt_dl_tp(sched_pelt_dl, NULL);
++	register_trace_pelt_irq_tp(sched_pelt_irq, NULL);
++	register_trace_pelt_se_tp(sched_pelt_se, NULL);
++	register_trace_sched_overutilized_tp(sched_overutilized, NULL);
++
++	return 0;
++}
++
++void sched_tp_finish(void)
++{
++	unregister_trace_pelt_cfs_tp(sched_pelt_cfs, NULL);
++	unregister_trace_pelt_rt_tp(sched_pelt_rt, NULL);
++	unregister_trace_pelt_dl_tp(sched_pelt_dl, NULL);
++	unregister_trace_pelt_irq_tp(sched_pelt_irq, NULL);
++	unregister_trace_pelt_se_tp(sched_pelt_se, NULL);
++	unregister_trace_sched_overutilized_tp(sched_overutilized, NULL);
++}
++
++
++module_init(sched_tp_init);
++module_exit(sched_tp_finish);
++
++MODULE_LICENSE("GPL");
+-- 
+2.17.1
+

--- a/tools/kmodules/sched_tp/Makefile
+++ b/tools/kmodules/sched_tp/Makefile
@@ -1,0 +1,3 @@
+obj-m += sched_tp.o
+
+EXTRA_CFLAGS = -I$(src)

--- a/tools/kmodules/sched_tp/sched_events.h
+++ b/tools/kmodules/sched_tp/sched_events.h
@@ -1,0 +1,134 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM sched
+
+#if !defined(_SCHED_EVENTS_H) || defined(TRACE_HEADER_MULTI_READ)
+#define _SCHED_EVENTS_H
+
+#define PATH_SIZE		64
+#define SPAN_SIZE		NR_CPUS/4
+
+#include <linux/tracepoint.h>
+
+TRACE_EVENT(sched_load_cfs_rq,
+
+	TP_PROTO(int cpu, char *path, const struct sched_avg *avg),
+
+	TP_ARGS(cpu, path, avg),
+
+	TP_STRUCT__entry(
+		__field(	int,		cpu			)
+		__array(	char,		path,	PATH_SIZE	)
+		__field(	unsigned long,	load			)
+		__field(	unsigned long,	rbl_load		)
+		__field(	unsigned long,	util			)
+	),
+
+	TP_fast_assign(
+		__entry->cpu		= cpu;
+		strlcpy(__entry->path, path, PATH_SIZE);
+		__entry->load		= avg->load_avg;
+		__entry->rbl_load	= avg->runnable_load_avg;
+		__entry->util		= avg->util_avg;
+	),
+
+	TP_printk("cpu=%d path=%s load=%lu rbl_load=%lu util=%lu",
+		  __entry->cpu, __entry->path, __entry->load,
+		  __entry->rbl_load,__entry->util)
+);
+
+DECLARE_EVENT_CLASS(sched_pelt_rq_template,
+
+	TP_PROTO(int cpu, const struct sched_avg *avg),
+
+	TP_ARGS(cpu, avg),
+
+	TP_STRUCT__entry(
+		__field(	int,		cpu			)
+		__field(	unsigned long,	load			)
+		__field(	unsigned long,	rbl_load		)
+		__field(	unsigned long,	util			)
+	),
+
+	TP_fast_assign(
+		__entry->cpu		= cpu;
+		__entry->load		= avg->load_avg;
+		__entry->rbl_load	= avg->runnable_load_avg;
+		__entry->util		= avg->util_avg;
+	),
+
+	TP_printk("cpu=%d load=%lu rbl_load=%lu util=%lu",
+		  __entry->cpu, __entry->load,
+		  __entry->rbl_load,__entry->util)
+);
+
+DEFINE_EVENT(sched_pelt_rq_template, sched_pelt_rt,
+	TP_PROTO(int cpu, const struct sched_avg *avg),
+	TP_ARGS(cpu, avg));
+
+DEFINE_EVENT(sched_pelt_rq_template, sched_pelt_dl,
+	TP_PROTO(int cpu, const struct sched_avg *avg),
+	TP_ARGS(cpu, avg));
+
+DEFINE_EVENT(sched_pelt_rq_template, sched_pelt_irq,
+	TP_PROTO(int cpu, const struct sched_avg *avg),
+	TP_ARGS(cpu, avg));
+
+TRACE_EVENT(sched_load_se,
+
+	TP_PROTO(int cpu, char *path, char *comm, int pid, const struct sched_avg *avg),
+
+	TP_ARGS(cpu, path, comm, pid, avg),
+
+	TP_STRUCT__entry(
+		__field(	int,		cpu			)
+		__array(	char,		path,	PATH_SIZE	)
+		__array(	char,		comm,	TASK_COMM_LEN	)
+		__field(	int,		pid			)
+		__field(	unsigned long,	load			)
+		__field(	unsigned long,	rbl_load		)
+		__field(	unsigned long,	util			)
+	),
+
+	TP_fast_assign(
+		__entry->cpu		= cpu;
+		strlcpy(__entry->path, path, PATH_SIZE);
+		strlcpy(__entry->comm, comm, TASK_COMM_LEN);
+		__entry->pid		= pid;
+		__entry->load		= avg->load_avg;
+		__entry->rbl_load	= avg->runnable_load_avg;
+		__entry->util		= avg->util_avg;
+	),
+
+	TP_printk("cpu=%d path=%s comm=%s pid=%d load=%lu rbl_load=%lu util=%lu",
+		  __entry->cpu, __entry->path, __entry->comm, __entry->pid,
+		  __entry->load, __entry->rbl_load,__entry->util)
+);
+
+TRACE_EVENT(sched_overutilized,
+
+	TP_PROTO(int overutilized, char *span),
+
+	TP_ARGS(overutilized, span),
+
+	TP_STRUCT__entry(
+		__field(	int,		overutilized		)
+		__array(	char,		span,	SPAN_SIZE	)
+	),
+
+	TP_fast_assign(
+		__entry->overutilized	= overutilized;
+		strlcpy(__entry->span, span, SPAN_SIZE);
+	),
+
+	TP_printk("overutilized=%d span=0x%s",
+		  __entry->overutilized, __entry->span)
+);
+
+#endif /* _SCHED_EVENTS_H */
+
+/* This part must be outside protection */
+#undef TRACE_INCLUDE_PATH
+#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_FILE sched_events
+#include <trace/define_trace.h>

--- a/tools/kmodules/sched_tp/sched_tp.c
+++ b/tools/kmodules/sched_tp/sched_tp.c
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/module.h>
+
+#include <linux/sched.h>
+#include <trace/events/sched.h>
+
+#define CREATE_TRACE_POINTS
+#include "sched_events.h"
+
+static inline struct cfs_rq *get_group_cfs_rq(struct sched_entity *se)
+{
+#ifdef CONFIG_FAIR_GROUP_SCHED
+	return se->my_q;
+#else
+	return NULL;
+#endif
+}
+
+static void sched_pelt_cfs(void *data, struct cfs_rq *cfs_rq)
+{
+	if (trace_sched_load_cfs_rq_enabled()) {
+		const struct sched_avg *avg;
+		char path[PATH_SIZE];
+		int cpu;
+
+		avg = sched_trace_cfs_rq_avg(cfs_rq);
+		sched_trace_cfs_rq_path(cfs_rq, path, PATH_SIZE);
+		cpu = sched_trace_cfs_rq_cpu(cfs_rq);
+
+		trace_sched_load_cfs_rq(cpu, path, avg);
+	}
+}
+
+static void sched_pelt_rt(void *data, struct rq *rq)
+{
+	if (trace_sched_pelt_rt_enabled()) {
+		const struct sched_avg *avg = sched_trace_rq_avg_rt(rq);
+		int cpu = sched_trace_rq_cpu(rq);
+
+		if (!avg)
+			return;
+
+		trace_sched_pelt_rt(cpu, avg);
+	}
+}
+
+static void sched_pelt_dl(void *data, struct rq *rq)
+{
+	if (trace_sched_pelt_dl_enabled()) {
+		const struct sched_avg *avg = sched_trace_rq_avg_dl(rq);
+		int cpu = sched_trace_rq_cpu(rq);
+
+		if (!avg)
+			return;
+
+		trace_sched_pelt_dl(cpu, avg);
+	}
+}
+
+static void sched_pelt_irq(void *data, struct rq *rq)
+{
+	if (trace_sched_pelt_irq_enabled()){
+		const struct sched_avg *avg = sched_trace_rq_avg_irq(rq);
+		int cpu = sched_trace_rq_cpu(rq);
+
+		if (!avg)
+			return;
+
+		trace_sched_pelt_irq(cpu, avg);
+	}
+}
+
+static void sched_pelt_se(void *data, struct sched_entity *se)
+{
+	if (trace_sched_load_se_enabled()) {
+		void *gcfs_rq = get_group_cfs_rq(se);
+		void *cfs_rq = se->cfs_rq;
+		struct task_struct *p;
+		char path[PATH_SIZE];
+		char *comm;
+		pid_t pid;
+		int cpu;
+
+		sched_trace_cfs_rq_path(gcfs_rq, path, PATH_SIZE);
+		cpu = sched_trace_cfs_rq_cpu(cfs_rq);
+
+		p = gcfs_rq ? NULL : container_of(se, struct task_struct, se);
+		comm = p ? p->comm : "(null)";
+		pid = p ? p->pid : -1;
+
+		trace_sched_load_se(cpu, path, comm, pid, &se->avg);
+	}
+}
+
+static void sched_overutilized(void *data, struct root_domain * rd, bool overutilized)
+{
+	if (trace_sched_overutilized_enabled()) {
+		char span[SPAN_SIZE];
+
+		cpumap_print_to_pagebuf(false, span, sched_trace_rd_span(rd));
+
+		trace_sched_overutilized(overutilized, span);
+	}
+}
+
+static int sched_tp_init(void)
+{
+	register_trace_pelt_cfs_tp(sched_pelt_cfs, NULL);
+	register_trace_pelt_rt_tp(sched_pelt_rt, NULL);
+	register_trace_pelt_dl_tp(sched_pelt_dl, NULL);
+	register_trace_pelt_irq_tp(sched_pelt_irq, NULL);
+	register_trace_pelt_se_tp(sched_pelt_se, NULL);
+	register_trace_sched_overutilized_tp(sched_overutilized, NULL);
+
+	return 0;
+}
+
+void sched_tp_finish(void)
+{
+	unregister_trace_pelt_cfs_tp(sched_pelt_cfs, NULL);
+	unregister_trace_pelt_rt_tp(sched_pelt_rt, NULL);
+	unregister_trace_pelt_dl_tp(sched_pelt_dl, NULL);
+	unregister_trace_pelt_irq_tp(sched_pelt_irq, NULL);
+	unregister_trace_pelt_se_tp(sched_pelt_se, NULL);
+	unregister_trace_sched_overutilized_tp(sched_overutilized, NULL);
+}
+
+
+module_init(sched_tp_init);
+module_exit(sched_tp_finish);
+
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Add some infrastructure to allow building, installing, loading and unload a module and add a new sched_tp module which would be required to run Lisa tests against mainline kernel when the new bare tracepoints (ie: don't have TRACE_EVENTs on top/associated with them) land there.