### PR TITLE
lisa.analysis.load_tracking: Fix column dropping

### DIFF
--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -82,7 +82,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
             df = df[df.path == "/"]
 
         to_drop = self._columns_to_drop(event)
-        df.drop(columns=to_drop, inplace=True)
+        df.drop(columns=to_drop, inplace=True, errors='ignore')
 
         return df
 


### PR DESCRIPTION
Drop columns that are existing and ignore when the column we try to drop
does not exist.