### PR TITLE
lisa.exekall_customize: Fix NoValue handling in exekall compare

### DIFF
--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -235,8 +235,17 @@ comparison. Can be repeated.""")
         alpha = self.args.alpha / 100
         show_non_significant = self.args.non_significant
 
+        def get_roots(db):
+            return {
+                froz_val
+                for froz_val in db.get_roots()
+                # Filter-out NoValue so it does not get counted as a failure,
+                # since bool(NoValue) is False
+                if froz_val.value is not NoValue
+            }
+
         result_list_old, result_list_new = [
-            db.get_roots()
+            get_roots(db)
             for db in db_list
         ]
 

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -2364,12 +2364,13 @@ class LISATestStep(ShellStep):
                 for db in {entry['db'] for entry in entry_list}
             ]
 
-            with contextlib.suppress(FileNotFoundError):
-                existing_db = ValueDB.from_path(export_db)
-                db_list.append(existing_db)
+            if db_list:
+                with contextlib.suppress(FileNotFoundError):
+                    existing_db = ValueDB.from_path(export_db)
+                    db_list.append(existing_db)
 
-            merged_db = ValueDB.merge(db_list)
-            merged_db.to_path(export_db, optimize=False)
+                merged_db = ValueDB.merge(db_list)
+                merged_db.to_path(export_db, optimize=False)
 
         return out
 


### PR DESCRIPTION
Avoid counting NoValue as a failure, since we don't want exceptions to
pollute the regression tables.