### PR TITLE
lisa: remove imports of pylab

### DIFF
--- a/lisa/analysis/frequency.py
+++ b/lisa/analysis/frequency.py
@@ -23,7 +23,6 @@ import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
 import pandas as pd
-import pylab as pl
 
 from lisa.analysis.base import TraceAnalysisBase
 from lisa.utils import memoized
@@ -283,7 +282,7 @@ class FrequencyAnalysis(TraceAnalysisBase):
         state_axis.set_xlim(self.trace.start, self.trace.end)
 
         figname = os.path.join(self.trace.plots_dir, '{}{}.png'.format(self.trace.plots_prefix, clk))
-        pl.savefig(figname, bbox_inches='tight')
+        plt.savefig(figname, bbox_inches='tight')
 
 
     @requires_events('cpu_frequency')

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -22,7 +22,6 @@ import abc
 
 import pandas as pd
 import matplotlib.pyplot as plt
-import pylab as pl
 
 from bart.common.Utils import area_under_curve
 from devlib.target import KernelVersion
@@ -196,7 +195,7 @@ class EASBehaviour(RTATestBundle):
                 prev = time
 
         figname = os.path.join(self.res_dir, 'expected_placement.png')
-        pl.savefig(figname, bbox_inches='tight')
+        plt.savefig(figname, bbox_inches='tight')
         plt.close()
 
     def _get_expected_power_df(self, nrg_model, capacity_margin_pct):

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -22,7 +22,6 @@ import itertools
 from statistics import mean
 
 import matplotlib.pyplot as plt
-import pylab as pl
 
 from bart.common.Utils import select_window, area_under_curve
 from bart.sched import pelt
@@ -805,7 +804,7 @@ class PELTTask(LoadTrackingBase):
                              requested_duty_cycle)
 
         figname = os.path.join(self.res_dir, '{}_behaviour.png'.format(signal_name))
-        pl.savefig(figname, bbox_inches='tight')
+        plt.savefig(figname, bbox_inches='tight')
         plt.close()
 
         # Compare actual PELT signal with the simulated one


### PR DESCRIPTION
Since pylab is actually a re-export of matplotlib.pylab, itself
re-exporting names from other matplotlib and numpy modules, let's refer
to the modules the functions are actually defined in. In our case, it's
only `savefig()` defined in matplotlib.pyplot.