### PR TITLE
lisa.tests.base: Introduce RTATestBundle.rtapp_tasks property

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -579,9 +579,9 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
         sdf = trace.df_events('sched_switch')
 
         # Find when the first task starts running
-        rta_start = sdf[sdf.next_comm.isin(self.rtapp_profile.keys())].index[0]
+        rta_start = sdf[sdf.next_comm.isin(self.rtapp_tasks)].index[0]
         # Find when the last task stops running
-        rta_stop = sdf[sdf.prev_comm.isin(self.rtapp_profile.keys())].index[-1]
+        rta_stop = sdf[sdf.prev_comm.isin(self.rtapp_tasks)].index[-1]
 
         return (rta_start, rta_stop)
 
@@ -629,6 +629,14 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
         return self.get_rtapp_profile(self.plat_info)
 
     @property
+    def rtapp_tasks(self):
+        """
+        Sorted list of rtapp task names, as defined in ``rtapp_profile``
+        attribute.
+        """
+        return sorted(self.rtapp_profile.keys())
+
+    @property
     def cgroup_configuration(self):
         """
         Compute the cgroup configuration based on ``plat_info``
@@ -665,7 +673,7 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
         df = self.trace.analysis.tasks.df_tasks_runtime()
 
         # We don't want to account the test tasks
-        ignored_pids = list(map(self.trace.get_task_pid, self.rtapp_profile.keys()))
+        ignored_pids = list(map(self.trace.get_task_pid, self.rtapp_tasks))
 
         def compute_duration_pct(row):
             return row.runtime * 100 / self.trace.time_range

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -135,7 +135,7 @@ class EASBehaviour(RTATestBundle):
         :returns: A Pandas DataFrame with a column for each task, showing the
                   CPU that the task was "on" at each moment in time
         """
-        tasks = list(self.rtapp_profile.keys())
+        tasks = self.rtapp_tasks
 
         df = self.trace.ftrace.sched_switch.data_frame[['next_comm', '__cpu']]
         df = df[df['next_comm'].isin(tasks)]
@@ -265,7 +265,7 @@ class EASBehaviour(RTATestBundle):
         task_cpu_df = self._get_task_cpu_df()
         task_utils_df = self._get_expected_task_utils_df(nrg_model)
         task_utils_df.index = [time + self.trace.start for time in task_utils_df.index]
-        tasks = list(self.rtapp_profile.keys())
+        tasks = self.rtapp_tasks
 
         # Create a combined DataFrame with the utilization of a task and the CPU
         # it was running on at each moment. Looks like:

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -687,7 +687,7 @@ class PELTTask(LoadTrackingBase):
         """
         The name of the only task this test uses
         """
-        return list(self.rtapp_profile.keys())[0]
+        return self.rtapp_tasks[0]
 
     @LoadTrackingBase.get_task_sched_signal.used_events
     def get_task_sched_signal(self, cpu, signal):

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -127,7 +127,7 @@ class StaggeredFinishes(MisfitMigrationBase):
 
         sdf = sdf[self.trace.start + self.IDLING_DELAY_S * 0.9:]
 
-        for task in self.rtapp_profile.keys():
+        for task in self.rtapp_tasks:
             task_cpu = int(task.strip("{}_".format(self.task_prefix)))
             task_start = sdf[(sdf.next_comm == task) & (sdf["__cpu"] == task_cpu)].index[0]
             last_start = max(last_start, task_start)
@@ -197,7 +197,7 @@ class StaggeredFinishes(MisfitMigrationBase):
         sdf = self.trace.df_events('sched_switch')
         task_state_dfs = {
             task : self.trace.analysis.tasks.df_task_states(task)
-            for task in self.rtapp_profile.keys()
+            for task in self.rtapp_tasks
         }
 
         res = ResultBundle.from_bool(True)
@@ -314,7 +314,7 @@ class StaggeredFinishes(MisfitMigrationBase):
         :type allowed_idle_time_s: int
         """
         task_state_dfs = {}
-        for task in self.rtapp_profile.keys():
+        for task in self.rtapp_tasks:
             # This test is all about throughput: check that every time a task
             # runs on a little it's because bigs are busy
             df = self.trace.analysis.tasks.df_task_states(task)

--- a/lisa/tests/staging/sched_android.py
+++ b/lisa/tests/staging/sched_android.py
@@ -259,8 +259,8 @@ class SchedTunePlacementItem(SchedTuneItemBase):
         their time on CPUs that don't have enough capacity to serve their
         boost.
         """
-        assert len(self.rtapp_profile) == 1
-        task = list(self.rtapp_profile.keys())[0]
+        assert len(self.rtapp_tasks) == 1
+        task = self.rtapp_tasks[0]
         df = self.trace.analysis.tasks.df_task_total_residency(task)
 
         # Find CPUs without enough capacity to meet the boost


### PR DESCRIPTION
Make the client code more easilyu understandable than relying
rtapp_profile dict structure, and allow easier decoupling if needed.