### PR TITLE
lisa.utils: Make sphobjinv and IPython import optional

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -40,13 +40,17 @@ from weakref import WeakKeyDictionary
 import urllib.parse
 import warnings
 import textwrap
+import webbrowser
 
 import ruamel.yaml
 from ruamel.yaml import YAML
-import sphobjinv
 
-import webbrowser
-from IPython.display import IFrame
+# These modules may not be installed as they are only used for notebook usage
+try:
+    import sphobjinv
+    from IPython.display import IFrame
+except ModuleNotFoundError:
+    pass
 
 import lisa
 from lisa.version import version_tuple, parse_version, format_version


### PR DESCRIPTION
Since they many not be installed, only try to import them if they are
available.