### PR TITLE
lisa.trace: Move Trace.get_peripheral_clock_effective_rate() into frequency analysis

### DIFF
--- a/lisa/analysis/frequency.py
+++ b/lisa/analysis/frequency.py
@@ -24,6 +24,7 @@ import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
 import pandas as pd
+import numpy as np
 
 from lisa.analysis.base import TraceAnalysisBase
 from lisa.utils import memoized
@@ -243,6 +244,40 @@ class FrequencyAnalysis(TraceAnalysisBase):
 
         return (df['frequency'] * df['delta']).sum() / timespan
 
+    def get_peripheral_clock_effective_rate(self, clk_name):
+        logger = self.get_logger()
+        if clk_name is None:
+            logger.warning('no specified clk_name in computing peripheral clock, returning None')
+            return
+        if not self.trace.has_events('clock_set_rate'):
+            logger.warning('Events [clock_set_rate] not found, returning None!')
+            return
+        rate_df = self.trace.df_events('clock_set_rate')
+        enable_df = self.trace.df_events('clock_enable')
+        disable_df = self.trace.df_events('clock_disable')
+        pd.set_option('display.expand_frame_repr', False)
+
+        freq = rate_df[rate_df.clk_name == clk_name]
+        if not enable_df.empty:
+            enables = enable_df[enable_df.clk_name == clk_name]
+        if not disable_df.empty:
+            disables = disable_df[disable_df.clk_name == clk_name]
+
+        freq = pd.concat([freq, enables, disables], sort=False).sort_index()
+        if freq.empty:
+            logger.warning('No events for clock ' + clk_name + ' found in trace')
+            return
+
+        freq['start'] = freq.index
+        freq['len'] = (freq.start - freq.start.shift()).fillna(0).shift(-1)
+        # The last value will be NaN, fix to be appropriate length
+        freq.loc[freq.index[-1], 'len'] = self.trace.end - freq.index[-1]
+
+        freq = freq.fillna(method='ffill')
+        freq['effective_rate'] = np.where(freq['state'] == 0, 0,
+                                          np.where(freq['state'] == 1, freq['rate'], float('nan')))
+        return freq
+
 ###############################################################################
 # Plotting Methods
 ###############################################################################
@@ -259,7 +294,7 @@ class FrequencyAnalysis(TraceAnalysisBase):
 
         :raises: KeyError
         """
-        freq = self.trace.get_peripheral_clock_effective_rate(clk)
+        freq = self.get_peripheral_clock_effective_rate(clk)
         if freq is None or freq.empty:
             self.get_logger().warning('no peripheral clock events found for clock')
             return

--- a/lisa/analysis/frequency.py
+++ b/lisa/analysis/frequency.py
@@ -244,7 +244,7 @@ class FrequencyAnalysis(TraceAnalysisBase):
 
         return (df['frequency'] * df['delta']).sum() / timespan
 
-    def get_peripheral_clock_effective_rate(self, clk_name):
+    def df_peripheral_clock_effective_rate(self, clk_name):
         logger = self.get_logger()
         if clk_name is None:
             logger.warning('no specified clk_name in computing peripheral clock, returning None')
@@ -294,7 +294,7 @@ class FrequencyAnalysis(TraceAnalysisBase):
 
         :raises: KeyError
         """
-        freq = self.get_peripheral_clock_effective_rate(clk)
+        freq = self.df_peripheral_clock_effective_rate(clk)
         if freq is None or freq.empty:
             self.get_logger().warning('no peripheral clock events found for clock')
             return

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -323,7 +323,7 @@ class TestTrace(TraceTestCase):
           <idle>-0 [000] 380335000000: clock_disable: bus_clk state=0 cpu_id=0
           <idle>-0 [004] 380339000000: cpu_idle:             state=1 cpu_id=4
         """)
-        df = trace.get_peripheral_clock_effective_rate(clk_name='bus_clk')
+        df = trace.analysis.frequency.df_peripheral_clock_effective_rate(clk_name='bus_clk')
         exp_effective_rate=[ float('NaN'), 750000000, 0.0, 750000000, 100000000, 0.0]
         effective_rate = df['effective_rate'].tolist()
         self.assertEqual(len(exp_effective_rate), len(effective_rate))


### PR DESCRIPTION
Move domain-specific functions into the corresponding analysis, where it
is used.