### PR TITLE
rta: Don't force running rta as root for calibration

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -345,7 +345,7 @@ class RTA(Workload):
                                  profile={'task1': calib_task},
                                  calibration="CPU{}".format(cpu),
                                  res_dir=res_dir)
-            rta.run(as_root=True)
+            rta.run()
 
             for line in rta.output.split('\n'):
                 pload_match = re.search(pload_regexp, line)


### PR DESCRIPTION
You don't need to run it as root. I have tested it on an unrooted phone.