### PR TITLE
Cleanup EM loading

### DIFF
--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -22,7 +22,7 @@ import operator
 import warnings
 import re
 
-from lisa.utils import Loggable, Serializable, memoized, groupby, get_subclasses, deprecate
+from lisa.utils import Loggable, Serializable, memoized, groupby, get_subclasses, deprecate, grouper
 
 import pandas as pd
 import numpy as np
@@ -30,15 +30,6 @@ import numpy as np
 from devlib.utils.misc import mask_to_list, ranges_to_list
 from devlib.exception import TargetStableError
 from trappy.stats.grammar import Parser
-
-#TODO: This should be moved into a utility library somewhere if its useful elsewhere
-from itertools import zip_longest
-def grouper(iterable, n, fillvalue=None):
-    """Collect data into fixed-length chunks or blocks"""
-    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
-    # Since the same iterator is used, it will yield a new item every time zip call next() on it
-    args = [iter(iterable)] * n
-    return zip_longest(*args, fillvalue=fillvalue)
 
 """Classes for modeling and estimating energy usage of CPU systems"""
 

--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -22,7 +22,7 @@ import operator
 import warnings
 import re
 
-from lisa.utils import Loggable, Serializable, memoized, groupby, get_subclasses
+from lisa.utils import Loggable, Serializable, memoized, groupby, get_subclasses, deprecate
 
 import pandas as pd
 import numpy as np
@@ -805,11 +805,27 @@ class EnergyModel(Serializable, Loggable):
         .. seealso:: :meth:`LinuxEnergyModel.from_target`
            and :meth:`LegacyEnergyModel.from_target`
         """
-        logger = cls.get_logger('EMReader')
+        logger = cls.get_logger('from_target')
 
         subcls = cls._find_subcls(target)
         logger.info('Attempting to load EM using {}'.format(subcls.__name__))
         return subcls.from_target(target)
+
+    @deprecate(replaced_by='lisa.energy_model.LinuxEnergyModel.from_target', deprecated_in='2.0', removed_in='2.1')
+    @staticmethod
+    def from_debugfsEM_target(*args, **kwargs):
+        """
+        See :meth:`LinuxEnergyModel.from_target`
+        """
+        return LinuxEnergyModel.from_target(*args, **kwargs)
+
+    @deprecate(replaced_by='lisa.energy_model.LegacyEnergyModel.from_target', deprecated_in='2.0', removed_in='2.1')
+    @staticmethod
+    def from_sd_target(*args, **kwargs):
+        """
+        See :meth:`LegacyEnergyModel.from_target`
+        """
+        return LegacyEnergyModel.from_target(*args, **kwargs)
 
     def estimate_from_trace(self, trace):
         """

--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -1000,19 +1000,22 @@ class LinuxEnergyModel(EnergyModel):
 
     @staticmethod
     def _simple_em_root(target, pd_attr, cpu_to_pd):
-        # pd_attr is a dict tree like this
-        # {
-        #   "pd0": {
-        #       "capacity": [236, 301, 367, 406, 446 ],
-        #       "frequency": [ 450000, 575000, 700000, 775000, 850000 ],
-        #       "power": [ 42, 58, 79, 97, 119 ]
-        #   },
-        #   "pd1": {
-        #       "capacity": [ 418, 581, 744, 884, 1024 ],
-        #       "frequency": [ 450000, 625000, 800000, 950000, 1100000 ],
-        #       "power": [ 160, 239, 343, 454, 583 ]
-        #   }
-        # }
+        """
+        ``pd_attr`` is a dict tree like this ::
+
+            {
+                "pd0": {
+                    "capacity": [236, 301, 367, 406, 446 ],
+                    "frequency": [ 450000, 575000, 700000, 775000, 850000 ],
+                    "power": [ 42, 58, 79, 97, 119 ]
+                },
+                "pd1": {
+                    "capacity": [ 418, 581, 744, 884, 1024 ],
+                    "frequency": [ 450000, 625000, 800000, 950000, 1100000 ],
+                    "power": [ 160, 239, 343, 454, 583 ]
+                }
+            }
+        """
         def simple_read_idle_states(cpu, target):
             # idle states are not supported in the simple model
             # record 0 power for them all, but name them according to target

--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -73,7 +73,7 @@ def read_multiple_oneline_files(target, glob_patterns):
     if len(contents) != len(paths):
         raise RuntimeError('File count mismatch while reading multiple files')
 
-    return dict(list(zip(paths, contents)))
+    return dict(zip(paths, contents))
 
 class EnergyModelCapacityError(Exception):
     """Used by :meth:`EnergyModel.get_optimal_placements`"""
@@ -181,7 +181,7 @@ class EnergyModelNode(_CpuTree):
 
         def is_monotonic(l, decreasing=False):
             op = operator.ge if decreasing else operator.le
-            return all(op(a, b) for a, b in list(zip(l, l[1:])))
+            return all(op(a, b) for a, b in zip(l, l[1:]))
 
         if active_states:
             # Sanity check for active_states's frequencies
@@ -729,7 +729,7 @@ class EnergyModel(Serializable, Loggable):
         candidates = {}
         excluded = []
         for cpus in product(self.cpus, repeat=len(tasks)):
-            placement = {task: cpu for task, cpu in list(zip(tasks, cpus))}
+            placement = {task: cpu for task, cpu in zip(tasks, cpus)}
 
             util = [0 for _ in self.cpus]
             for task, cpu in list(placement.items()):
@@ -1158,7 +1158,7 @@ class LegacyEnergyModel(EnergyModel):
                           for c, p in map(lambda x: (x[0],x[-1]), grouper(cap_states_strs, em_member_count))]
 
             freqs = target.cpufreq.list_frequencies(cpu)
-            return OrderedDict(list(zip(sorted(freqs), cap_states)))
+            return OrderedDict(zip(sorted(freqs), cap_states))
 
         def read_idle_states(cpu, domain_level):
             idle_states_path = sge_path(cpu, domain_level, 0, 'idle_states')
@@ -1168,7 +1168,7 @@ class LegacyEnergyModel(EnergyModel):
             names = [s.name for s in target.cpuidle.get_states(cpu)]
             # idle_states is a list of power values in increasing order of
             # idle-depth/decreasing order of power.
-            return OrderedDict(list(zip(names, [int(p) for p in idle_states_strs])))
+            return OrderedDict(zip(names, [int(p) for p in idle_states_strs]))
 
         # Read the CPU-level data from sched_domain level 0
         cpus = list(range(target.number_of_cpus))

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -644,6 +644,17 @@ def groupby(iterable, key=None):
     iterable = sorted(iterable, key=key)
     return itertools.groupby(iterable, key=key)
 
+
+def grouper(iterable, n, fillvalue=None):
+    """
+    Collect data into fixed-length chunks or blocks
+    """
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
+    # Since the same iterator is used, it will yield a new item every time zip
+    # call next() on it
+    args = [iter(iterable)] * n
+    return itertools.zip_longest(*args, fillvalue=fillvalue)
+
 def group_by_value(mapping, key_sort=lambda x: x):
     """
     Group a mapping by its values


### PR DESCRIPTION
Add `LinuxEnergyModel(EnergyModel)` and `LegacyEnergyModel(EnergyModel)` sublcasses of EnergyModel, so that each of them can implement their own `from_target()` and `check_from_target()` methods. 

`EnergyModel.from_target()` autodetects the appropriate subclass to use, so it's completely transparent.

This split can allow separate implementation of other methods as well, notably the ones dealing with idle states, allowing for potential speed-up in LinuxEnergyModel since this class registers a 0 cost for idle states/