### PR TITLE
lisa/tests: whitelist the mhu noise to a 1.5% threshold

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -548,6 +548,9 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
         0 : 100,
         # Feeble boards like Juno/TC2 spend a while in sugov
         r"^sugov:\d+$" : 5,
+        # The mailbox controller (MHU), now threaded, creates work that sometimes
+        # exceeds the 1% threshold.
+        r"^irq/\d+-mhu_link$": 1.5
     }
     """
     PID/comm specific tuning for :meth:`test_noisy_tasks`


### PR DESCRIPTION
The MHU controller interrupts, now threaded, will be detected as noise
that sometimes exceeds the 1% default threshold. This is often not much
higher than 1%, so let's allow 1.5% of time to be spent it its interrupt
handlers.

Signed-off-by: Ionela Voinescu <ionela.voinescu@arm.com>