### PR TITLE
Fix batch-rebase

### DIFF
--- a/tools/batch-rebase
+++ b/tools/batch-rebase
@@ -349,7 +349,13 @@ def rerere_autocommit(repo):
         try:
             git(['cherry-pick', '--continue'])
         except subprocess.CalledProcessError:
-            continue
+            # If there is no cherry-pick in progress, just exit the loop
+            try:
+                git(['show-ref', '--verify', '--quiet', 'ORIG_HEAD'])
+            except subprocess.CalledProcessError:
+                break
+            else:
+                continue
         else:
             break
 


### PR DESCRIPTION
Avoid an infinite loop when a cherry pick would lead to an empty commit at the
boundary of the cherry-picked range.