### PR TITLE
lisa.utils: Include replacement function doc URL in deprecation warning

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -1116,8 +1116,13 @@ def deprecate(msg=None, replaced_by=None, deprecated_in=None, removed_in=None):
 
         def make_msg(style=None):
             if replaced_by is not None:
-                replacement_msg = ', use {} instead'.format(
-                    getname(replaced_by, style=style)
+                try:
+                    doc_url = ' (see: {})'.format(get_doc_url(replaced_by))
+                except Exception:
+                    doc_url = ''
+
+                replacement_msg = ', use {} instead{}'.format(
+                    getname(replaced_by, style=style), doc_url,
                 )
             else:
                 replacement_msg = ''


### PR DESCRIPTION
Give a direct link to the doc of the new function to use when issuing a
deprecation warning.