### PR TITLE
lisa.trace: Check Trappy behavior

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -374,6 +374,10 @@ class Trace(Loggable, TraceBase):
         self._ftrace = trace_class(path, scope="custom", events=self.events,
                                   normalize_time=normalize_time)
 
+        # trappy sometimes decides to be "clever" and overrules the path to be
+        # used, even though it was specifically asked for a given file path
+        assert path == self._ftrace.trace_path
+
         # Check for events available on the parsed trace
         self.available_events = self._check_available_events()
         if not self.available_events:


### PR DESCRIPTION
Make sure Trappy actually loaded the trace it was asked for, and not something
else. If that assertion fails, it's probably because a trace.txt was asked for,
and a trace.dat exists in the same folder.