### PR TITLE
Rework task selection

### DIFF
--- a/lisa/analysis/latency.py
+++ b/lisa/analysis/latency.py
@@ -208,7 +208,7 @@ class LatencyAnalysis(TraceAnalysisBase):
                 df.plot(ax=axis, style='+', label="Preemption")
 
 
-        axis.set_title("Latencies of task \"{}\"".format(task))
+        axis.set_title('Latencies of task "{}"'.format(task))
         axis.set_ylabel("Latency (s)")
         axis.legend()
         axis.set_xlim(self.trace.start, self.trace.end)
@@ -278,7 +278,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         axis.axvspan(0, threshold_s, facecolor=self.LATENCY_THRESHOLD_ZONE_COLOR,
                      alpha=0.5, label="{}ms threshold zone".format(threshold_ms));
 
-        axis.set_title("Latencies CDF of task \"{}\"".format(task))
+        axis.set_title('Latencies CDF of task "{}"'.format(task))
         axis.set_xlabel("Latency (s)")
         axis.set_ylabel("Latencies below the x value (%)")
         axis.legend()
@@ -311,7 +311,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         axis.axvspan(0, threshold_s, facecolor=self.LATENCY_THRESHOLD_ZONE_COLOR, alpha=0.5,
                      label="{}ms threshold zone".format(threshold_ms));
 
-        axis.set_title("Latencies histogram of task \"{}\"".format(task))
+        axis.set_title('Latencies histogram of task "{}"'.format(task))
         axis.set_xlabel("Latency (s)")
         axis.legend()
 
@@ -363,7 +363,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         if self.trace.has_events(plot_overutilized.used_events):
             plot_overutilized(axis=axis)
 
-        axis.set_title("Activation intervals of task \"{}\"".format(task))
+        axis.set_title('Activation intervals of task "{}"'.format(task))
 
         axis.set_xlim(self.trace.start, self.trace.end)
 
@@ -384,7 +384,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         if self.trace.has_events(plot_overutilized.used_events):
             plot_overutilized(axis=axis)
 
-        axis.set_title("Per-activation runtimes of task \"{}\"".format(task))
+        axis.set_title('Per-activation runtimes of task "{}"'.format(task))
 
         axis.set_xlim(self.trace.start, self.trace.end)
 

--- a/lisa/analysis/latency.py
+++ b/lisa/analysis/latency.py
@@ -45,7 +45,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         DataFrame of a task's wakeup latencies
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
 
         :returns: a :class:`pandas.DataFrame` with:
 
@@ -66,7 +66,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         DataFrame of a task's preemption latencies
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
 
         :returns: a :class:`pandas.DataFrame` with:
 
@@ -86,7 +86,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         DataFrame of a task's activations
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
 
         :returns: a :class:`pandas.DataFrame` with:
 
@@ -106,7 +106,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         DataFrame of task's runtime each time the task blocks
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
 
         :returns: a :class:`pandas.DataFrame` with:
 
@@ -178,7 +178,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         Plot the latencies of a task over time
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
 
         :param wakeup: Whether to plot wakeup latencies
         :type wakeup: bool
@@ -256,7 +256,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         Plot the latencies Cumulative Distribution Function of a task
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
 
         :param wakeup: Whether to plot wakeup latencies
         :type wakeup: bool
@@ -292,7 +292,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         Plot the latencies histogram of a task
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
 
         :param wakeup: Whether to plot wakeup latencies
         :type wakeup: bool
@@ -323,7 +323,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         Draw the task wakeup/preemption latencies as colored bands
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
         """
 
         wkl_df = self.df_latency_wakeup(task)
@@ -352,7 +352,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         Plot the :meth:`lisa.analysis.latency.LatencyAnalysis.df_activations` of a task
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
         """
 
         wkp_df = self.df_activations(task)
@@ -374,7 +374,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         Plot the :meth:`lisa.analysis.latency.LatencyAnalysis.df_runtimes` of a task
 
         :param task: The task's name or PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
         """
         df = self.df_runtimes(task)
 

--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -228,7 +228,9 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
         samples = samples.sort_values(ascending=False)
 
         top_df = pd.DataFrame(samples).rename(columns={"util" : "samples"})
-        top_df["comm"] = top_df.index.map(self.trace.get_task_by_pid)
+        def get_name(pid):
+            return self.trace.get_task_pid_names(pid)[-1]
+        top_df["comm"] = top_df.index.map(get_name)
 
         return top_df
 
@@ -338,7 +340,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
         df = df_refit_index(df, start, end)
 
         # Build task names (there could be multiple, during the task lifetime)
-        task_name = 'Task ({}:{})'.format(pid, self.trace.get_task_by_pid(pid))
+        task_name = 'Task ({}:{})'.format(pid, self.trace.get_task_pid_names(pid))
 
         def plotter(axis, local_fig):
             df["required_capacity"].plot(

--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -113,7 +113,6 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
 
         :type signal: str
         """
-        common_fields = ['cpu']
 
         if signal in ('util', 'load'):
             df = self._df_either_event(['sched_load_cfs_rq', 'sched_load_avg_cpu'])
@@ -122,7 +121,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
         else:
             raise ValueError('Signal "{}" not supported'.format(signal))
 
-        return df[[*common_fields, signal]]
+        return df[['cpu', signal]]
 
     @deprecate(replaced_by=df_cpus_signal, deprecated_in='2.0', removed_in='2.1')
     @requires_one_event_of('sched_load_cfs_rq', 'sched_load_avg_cpu')
@@ -160,11 +159,9 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
         """
         if signal in ('util', 'load', 'required_capacity'):
             df = self._df_either_event(['sched_load_se', 'sched_load_avg_task'])
-            common_fields = ['cpu', 'comm', 'pid']
 
         elif signal in ('util_est_enqueued', 'util_est_ewma'):
             df = self._df_uniformized_signal('sched_util_est_task')
-            common_fields = ['cpu', 'pid']
         else:
             raise ValueError('Signal "{}" not supported'.format(signal))
 
@@ -181,7 +178,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
                 return capacities[-1]
             df['required_capacity'] = df.util.map(fits_capacity)
 
-        return df[[*common_fields, signal]]
+        return df[['cpu', 'comm', 'pid', signal]]
 
     @deprecate(replaced_by=df_tasks_signal, deprecated_in='2.0', removed_in='2.1')
     @requires_one_event_of('sched_load_se', 'sched_load_avg_task')

--- a/lisa/analysis/tasks.py
+++ b/lisa/analysis/tasks.py
@@ -135,6 +135,12 @@ class TasksAnalysis(TraceAnalysisBase):
 
         return sorted(cpus)
 
+    def _get_task_pid_name(self, pid):
+        """
+        Get the last name the given PID had.
+        """
+        return self.trace.get_task_pid_names(pid)[-1]
+
 ###############################################################################
 # DataFrame Getter Methods
 ###############################################################################
@@ -153,7 +159,7 @@ class TasksAnalysis(TraceAnalysisBase):
 
         wakeups = df.groupby('pid').count()["comm"]
         df = pd.DataFrame(wakeups).rename(columns={"comm" : "wakeups"})
-        df["comm"] = df.index.map(self.trace.get_task_by_pid)
+        df["comm"] = df.index.map(self._get_task_pid_name)
 
         return df
 
@@ -208,7 +214,7 @@ class TasksAnalysis(TraceAnalysisBase):
             columns={'next_pid': 'pid', 'next_prio': 'prio'}, inplace=True)
 
         rt_tasks.set_index('pid', inplace=True)
-        rt_tasks['comm'] = rt_tasks.index.map(self.trace.get_task_by_pid)
+        rt_tasks['comm'] = rt_tasks.index.map(self._get_task_pid_name)
 
         return rt_tasks
 
@@ -402,7 +408,7 @@ class TasksAnalysis(TraceAnalysisBase):
 
         df.index.name = "pid"
         df.sort_values(by="runtime", ascending=False, inplace=True)
-        df.insert(0, "comm", df.index.map(self.trace.get_task_by_pid))
+        df.insert(0, "comm", df.index.map(self._get_task_pid_name))
 
         return df
 
@@ -456,7 +462,7 @@ class TasksAnalysis(TraceAnalysisBase):
         res_df = pd.DataFrame()
 
         for pid in [self.trace.get_task_pid(task) for task in tasks]:
-            task = self.trace.get_task_by_pid(pid)
+            task = self._get_task_pid_name(pid)
             mapping = {'runtime': '{}:[{}]'.format(pid, task)}
             _df = self.trace.analysis.tasks.df_task_total_residency(pid).T.rename(index=mapping)
             res_df = res_df.append(_df)

--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -24,6 +24,8 @@ import pandas as pd
 import scipy.integrate
 import scipy.signal
 
+from lisa.utils import TASK_COMM_MAX_LEN
+
 
 def series_refit_index(series, start=None, end=None, method='pre'):
     """
@@ -562,7 +564,7 @@ def series_align_signal(ref, to_align, max_shift=None):
     # Compensate the shift
     return ref, to_align.shift(-shift)
 
-def df_filter_task_ids(df, task_ids, pid_col='pid', comm_col='comm', invert=False, comm_max_len=16):
+def df_filter_task_ids(df, task_ids, pid_col='pid', comm_col='comm', invert=False, comm_max_len=TASK_COMM_MAX_LEN):
     """
     Filter a dataframe using a list of :class:`lisa.trace.TaskID`
 

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -618,7 +618,7 @@ class Trace(Loggable, TraceBase):
         combinations, instead of raising an exception.
 
         :param task: Either the task name, the task PID, or a tuple ``(pid, comm)``
-        :type task: int or str or tuple(int, str) or TaskID
+        :type task: int or str or tuple(int, str)
 
         :param update: If a partially-filled :class:`TaskID` is passed (one of
             the fields set to ``None``), returns a complete :class`TaskID`
@@ -671,7 +671,7 @@ class Trace(Loggable, TraceBase):
         Helper that resolves a task PID or name to a :class:`TaskID`.
 
         :param task: Either the task name, the task PID, or a tuple ``(pid, comm)``
-        :type task: int or str or tuple(int, str) or TaskID
+        :type task: int or str or tuple(int, str)
 
         :param update: If a partially-filled :class:`TaskID` is passed (one of
             the fields set to ``None``), returns a complete :class`TaskID`
@@ -695,7 +695,7 @@ class Trace(Loggable, TraceBase):
         Helper that takes either a name or a PID and always returns a PID
 
         :param task: Either the task name or the task PID
-        :type task: int or str
+        :type task: int or str or tuple(int, str)
         """
         return self.get_task_id(task).pid
 

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -384,8 +384,6 @@ class Trace(Loggable, TraceBase):
         self.basetime = self._ftrace.basetime
 
         self._compute_timespan()
-        # Index PIDs and Task names
-        self._load_tasks_names()
 
         # Setup internal data reference to interesting events/dataframes
         self._sanitize_SchedLoadAvgCpu()
@@ -416,23 +414,44 @@ class Trace(Loggable, TraceBase):
             logger.debug(' - %s', evt)
         return available_events
 
-    def _load_tasks_names(self):
+    @memoized
+    def _get_task_maps(self):
         """
-        Try to load tasks names using one of the supported events.
+        Give the mapping from PID to task names, and the opposite.
+
+        The names or PIDs are listed in appearance order.
         """
-        def load(event, name_key, pid_key):
+        def load(event, name_col, pid_col):
             df = self.df_events(event)
-            self._scan_tasks(df, name_key=name_key, pid_key=pid_key)
+
+            def create_mapping(df, key_col, value_col):
+                return {
+                    k: list(df[df[key_col] == k][value_col].unique())
+                    for k in df[key_col].unique()
+                }
+
+            name_to_pid = create_mapping(df, name_col, pid_col)
+            pid_to_name = create_mapping(df, pid_col, name_col)
+
+            return (name_to_pid, pid_to_name)
+
 
         if 'sched_switch' in self.available_events:
-            load('sched_switch', 'prev_comm', 'prev_pid')
-            return
+            return load('sched_switch', 'prev_comm', 'prev_pid')
 
-        if 'sched_load_avg_task' in self.available_events:
-            load('sched_load_avg_task', 'comm', 'pid')
-            return
+        elif 'sched_load_avg_task' in self.available_events:
+            return load('sched_load_avg_task', 'comm', 'pid')
 
-        self.get_logger().warning('Failed to load tasks names from trace events')
+        else:
+            raise RuntimeError('Failed to load tasks names, sched_switch or sched_load_avg_task events are needed')
+
+    @property
+    def _task_name_map(self):
+        return self._get_task_maps()[0]
+
+    @property
+    def _task_pid_map(self):
+        return self._get_task_maps()[1]
 
     def has_events(self, events):
         """
@@ -477,30 +496,7 @@ class Trace(Loggable, TraceBase):
         self.get_logger().debug('Trace contains events from %s to %s',
                                 self.start, self.end)
 
-    def _scan_tasks(self, df, name_key='comm', pid_key='pid'):
-        """
-        Extract tasks names and PIDs from the input data frame. The data frame
-        should contain a task name column and PID column.
-
-        :param df: data frame containing trace events from which tasks names
-            and PIDs will be extracted
-        :type df: :mod:`pandas.DataFrame`
-
-        :param name_key: The name of the dataframe columns containing task
-            names
-        :type name_key: str
-
-        :param pid_key: The name of the dataframe columns containing task PIDs
-        :type pid_key: str
-        """
-        df = df[[name_key, pid_key]]
-        self._tasks_by_pid = (df.drop_duplicates(subset=pid_key, keep='last')
-                .rename(columns={
-                    pid_key : 'PID',
-                    name_key : 'TaskName'})
-                .set_index('PID').sort_index())
-
-    def get_task_by_name(self, name):
+    def get_task_name_pids(self, name, ignore_fork=True):
         """
         Get the PIDs of all tasks with the specified name.
 
@@ -508,19 +504,60 @@ class Trace(Loggable, TraceBase):
         is generated it inherits the parent name and then its name is updated
         to represent what the task really is.
 
-        This API works under the assumption that a task name is updated at
-        most one time and it always considers the name a task had the last time
-        it has been scheduled for execution in the current trace.
-
         :param name: task name
         :type name: str
 
-        :return: a list of PID for tasks which name matches the required one,
+        :param ignore_fork: Hide the PIDs of tasks that initially had ``name``
+            but were later renamed. This is common for shell processes for
+            example, which fork a new task, inheriting the shell name, and then
+            being renamed with the final "real" task name
+        :type ignore_fork: bool
+
+        :return: a list of PID for tasks which name matches the required one.
+        """
+        pids = self._task_name_map[name]
+
+        if ignore_fork:
+            pids = [
+                pid
+                for pid in pids
+                # Only keep the PID if its last name was the name we are
+                # looking for.
+                if self._task_pid_map[pid][-1] == name
+            ]
+
+        return pids
+
+    @deprecate('This method has been deprecated and is an alias',
+        deprecated_in='2.0',
+        removed_in='2.1',
+        replaced_by=get_task_name_pids,
+    )
+    def get_task_by_name(self, name):
+        return self.get_task_name_pids(name, ignore_fork=True)
+
+    def get_task_pid_names(self, pid):
+        """
+        Get the all the names of the task(s) with the specified PID, in
+        appearance order.
+
+        The same PID can have different task names, mainly because once a task
+        is generated it inherits the parent name and then its name is
+        updated to represent what the task really is.
+
+        :param name: task PID
+        :type name: int
+
+        :return: the name of the task which PID matches the required one,
                  the last time they ran in the current trace
         """
-        return (self._tasks_by_pid[self._tasks_by_pid.TaskName == name]
-                    .index.tolist())
+        return self._task_pid_map[pid]
 
+    @deprecate('This function raises exceptions when faced with ambiguity instead of giving the choice to the user',
+        deprecated_in='2.0',
+        removed_in='2.1',
+        replaced_by=get_task_pid_names,
+    )
     def get_task_by_pid(self, pid):
         """
         Get the name of the task with the specified PID.
@@ -539,10 +576,14 @@ class Trace(Loggable, TraceBase):
         :return: the name of the task which PID matches the required one,
                  the last time they ran in the current trace
         """
-        try:
-            return self._tasks_by_pid.loc[pid].values[0]
-        except KeyError:
-            return None
+        name_list = self.get_task_pid_names(pid)
+
+        if len(name_list) > 2:
+            raise RuntimeError('The PID {} had more than two names in its life: {}'.format(
+                pid, name_list,
+            ))
+
+        return name_list[-1]
 
     def get_task_pid(self, task):
         """
@@ -552,15 +593,15 @@ class Trace(Loggable, TraceBase):
         :type task: int or str
         """
         if isinstance(task, str):
-            pid_list = self.get_task_by_name(task)
-
-            if not pid_list:
-                raise ValueError('trace does not have any task named "{}".format(task)')
+            try:
+                pid_list = self._task_name_map[task]
+            except IndexError:
+                raise ValueError('trace does not have any task named "{}"'.format(task))
 
             if len(pid_list) > 1:
-                self.get_logger().warning(
-                    "More than one PID found for task {}, "
-                    "using the first one ({})".format(task, pid_list[0]))
+                raise RuntimeError('More than one PID found for task "{}": {}'.format(
+                    task, pid_list,
+                ))
 
             pid = pid_list[0]
         else:
@@ -568,15 +609,14 @@ class Trace(Loggable, TraceBase):
 
         return pid
 
-
     def get_tasks(self):
         """
         Get a dictionary of all the tasks in the Trace.
 
-        :return: a dictionary which maps each PID to the corresponding task
-                 name
+        :return: a dictionary which maps each PID to the corresponding list of
+                 task name
         """
-        return self._tasks_by_pid.TaskName.to_dict()
+        return self._task_pid_map
 
     def show(self):
         """

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -45,6 +45,7 @@ from lisa.utils import Loggable, HideExekallID, memoized, deduplicate, deprecate
 from lisa.platforms.platinfo import PlatformInfo
 from lisa.conf import SimpleMultiSrcConf, KeyDesc, TopLevelKeyDesc, StrList, Configurable
 
+
 class TaskID(namedtuple('TaskID', ('pid', 'comm'))):
     """
     Unique identifier of a logical task in a :class:`Trace`.

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -68,6 +68,13 @@ The detected location of your LISA installation
 RESULT_DIR = 'results'
 LATEST_LINK = 'results_latest'
 
+TASK_COMM_MAX_LEN = 16 - 1
+"""
+Value of ``TASK_COMM_LEN - 1`` macro in the kernel, to account for ``\0``
+terminator.
+"""
+
+
 class Loggable:
     """
     A simple class for uniformly named loggers

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -23,7 +23,7 @@ import sys
 from collections import OrderedDict
 
 from lisa.wlgen.workload import Workload
-from lisa.utils import Loggable
+from lisa.utils import Loggable, TASK_COMM_MAX_LEN
 
 class RTA(Workload):
     """
@@ -163,7 +163,7 @@ class RTA(Workload):
         # limits the task name to 16 characters including the terminal '\0'.
         too_long_tids = sorted((
             tid for tid in profile.keys()
-            if len(tid) > 15
+            if len(tid) > TASK_COMM_MAX_LEN
         ))
         if too_long_tids:
             raise ValueError(

--- a/tools/exekall/exekall/utils.py
+++ b/tools/exekall/exekall/utils.py
@@ -88,6 +88,13 @@ def _get_callable_set(module, visited_obj_set, verbose):
                     e=e,
                 ))
                 continue
+            # If some annotations fail to resolve
+            except NameError as e:
+                log_f('callable with unresolvable annotations will not be used: {e}'.format(
+                    callable=get_name(callable_),
+                    e=e,
+                ))
+                continue
             # If something goes wrong, that means it is not properly annotated
             # so we just ignore it
             except (AttributeError, ValueError, KeyError, engine.AnnotationError):


### PR DESCRIPTION
Fix #926

Make the task selection/resolution methods more consistent and strict when used with task name or task PID. This assumes that the simple comm/PID interface is only meant for non-ambigous cases.

Introduce a new way of selecting tasks by using `TaskID(pid, comm)` named tuples. It allows disambiguation in tricky cases. This include:
* when just specifying a comm or a PID is ambiguous, you can specify both to remove ambiguity
* when a specific PID is of interest regardless its task comm (or the opposit), the irrelevant field can be set to ``None``. This gives an explicit way of avoiding the exception that would be raised when specifying an PID or comm alone (i.e. not in a tuple).