### PR TITLE
lisa.energy_model: Fix missing @classmethod

### DIFF
--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -1207,6 +1207,7 @@ class LegacyEnergyModel(EnergyModel):
                    root_power_domain=root_pd,
                    freq_domains=freq_domains)
 
+    @classmethod
     def _find_core_groups(cls, target):
         """
         Read the core_siblings masks for each CPU from sysfs


### PR DESCRIPTION
@classmethod decorator got lost in a previous refactoring.