### PR TITLE
lisa.tests.cpufreq.sanity: Use separate res_dir for each sysbench inv…

### DIFF
--- a/lisa/energy_meter.py
+++ b/lisa/energy_meter.py
@@ -475,7 +475,7 @@ class ACME(EnergyMeter):
             ch_id = self._channels[channel]
 
             # Setup CSV file to collect samples for this channel
-            csv_file = os.path.join(self._res_dir, 'samples_{}.csv'.format(channel))
+            csv_file = ArtifactPath.join(self._res_dir, 'samples_{}.csv'.format(channel))
 
             # Start a dedicated iio-capture instance for this channel
             self._iio[ch_id] = Popen(['stdbuf', '-i0', '-o0', '-e0',
@@ -570,10 +570,8 @@ class ACME(EnergyMeter):
             logger.debug(self._str(channel))
             logger.debug(nrg)
 
-            # Save CSV samples file to out_dir
-            os.system('mv {} {}'.format(
-                os.path.join(self._res_dir, 'samples_{}.csv'.format(channel)),
-                out_dir))
+            src = os.path.join(self._res_dir, 'samples_{}.csv'.format(channel))
+            shutil.move(src, out_dir)
 
             # Add channel's energy to return results
             channels_nrg['{}'.format(channel)] = nrg['energy']

--- a/lisa/target.py
+++ b/lisa/target.py
@@ -275,7 +275,7 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
         # initialized. Expensive computations are deferred so they will only be
         # computed when actually needed.
 
-        rta_calib_res_dir = os.path.join(self._res_dir, 'rta_calib')
+        rta_calib_res_dir = ArtifactPath.join(self._res_dir, 'rta_calib')
         os.makedirs(rta_calib_res_dir)
         self.plat_info.add_target_src(self, rta_calib_res_dir, fallback=True)
 

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -638,7 +638,7 @@ class TestBundle(Serializable, ExekallTaggable, abc.ABC, metaclass=TestBundleMet
 
     @classmethod
     def _filepath(cls, res_dir):
-        return os.path.join(res_dir, "{}.yaml".format(cls.__qualname__))
+        return ArtifactPath.join(res_dir, "{}.yaml".format(cls.__qualname__))
 
     @classmethod
     def from_dir(cls, res_dir, update_res_dir=True):
@@ -808,7 +808,7 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
         """
         Path to the ``trace-cmd report`` trace.dat file.
         """
-        return os.path.join(self.res_dir, self.TRACE_PATH)
+        return ArtifactPath.join(self.res_dir, self.TRACE_PATH)
 
     # Guard before the cache, so we don't accidentally start depending on the
     # LRU cache for functionnal correctness.
@@ -1058,8 +1058,8 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
         wload = RTA.by_profile(target, "rta_{}".format(cls.__name__.lower()),
                                profile, res_dir=res_dir)
 
-        trace_path = os.path.join(res_dir, cls.TRACE_PATH)
-        dmesg_path = os.path.join(res_dir, cls.DMESG_PATH)
+        trace_path = ArtifactPath.join(res_dir, cls.TRACE_PATH)
+        dmesg_path = ArtifactPath.join(res_dir, cls.DMESG_PATH)
         ftrace_coll = ftrace_coll or FtraceCollector.from_conf(target, cls.ftrace_conf)
         dmesg_coll = DmesgCollector(target)
 

--- a/lisa/tests/cpufreq/sanity.py
+++ b/lisa/tests/cpufreq/sanity.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 
 from lisa.tests.base import Result, ResultBundle, TestBundle
 from lisa.wlgen.sysbench import Sysbench
@@ -47,7 +48,6 @@ class UserspaceSanity(TestBundle):
         governor
         """
         cpu_work = {}
-        sysbench = Sysbench(target, "sysbench", res_dir)
 
         with target.cpufreq.use_governor("userspace"):
             for domain in target.cpufreq.iter_domains():
@@ -60,6 +60,10 @@ class UserspaceSanity(TestBundle):
                                   (1 if len(freqs) % 2 else 0)]
 
                 for freq in freqs:
+                    sysbench_res_dir = os.path.join(res_dir, 'CPU{}@{}'.format(cpu, freq))
+                    os.makedirs(sysbench_res_dir)
+                    sysbench = Sysbench(target, "sysbench", sysbench_res_dir)
+
                     target.cpufreq.set_frequency(cpu, freq)
                     sysbench.run(cpus=[cpu], max_duration_s=1)
                     cpu_work[cpu][freq] = sysbench.output.nr_events

--- a/lisa/tests/cpufreq/sanity.py
+++ b/lisa/tests/cpufreq/sanity.py
@@ -19,21 +19,61 @@ import os
 from lisa.tests.base import Result, ResultBundle, TestBundle
 from lisa.wlgen.sysbench import Sysbench
 from lisa.target import Target
-from lisa.utils import ArtifactPath
+from lisa.utils import ArtifactPath, groupby, nullcontext
+from lisa.analysis.tasks import TasksAnalysis
+
+class UserspaceSanityItem(TestBundle):
+    """
+    Record the number of sysbench events on a given CPU at a given frequency.
+    """
+
+    def __init__(self, res_dir, plat_info, cpu, freq, work):
+        super().__init__(res_dir, plat_info)
+
+        self.cpu = cpu
+        self.freq = freq
+        self.work = work
+
+    @classmethod
+    def _from_target(cls, target:Target, *, res_dir:ArtifactPath, cpu, freq, switch_governor=True,) -> 'UserspaceSanityItem':
+        """
+        Create a :class:`UserspaceSanityItem` from a live :class:`lisa.target.Target`.
+
+        :param cpu: CPU to run on.
+        :type cpu: int
+
+        :param freq: Frequency to run at.
+        :type freq: int
+
+        :param switch_governor: Switch the governor to userspace, and undo it at the end.
+            If that has been done in advance, not doing it for every item saves substantial time.
+        :type switch_governor: bool
+        """
+
+
+        sysbench = Sysbench(target, "sysbench", res_dir)
+
+        cm = target.cpufreq.use_governor('userspace') if switch_governor else nullcontext()
+        with cm:
+            target.cpufreq.set_frequency(cpu, freq)
+            sysbench.run(cpus=[cpu], max_duration_s=1)
+
+        work = sysbench.output.nr_events
+        return cls(res_dir, target.plat_info, cpu, freq, work)
+
 
 class UserspaceSanity(TestBundle):
     """
     A class for making sure the userspace governor behaves sanely
 
-    :param cpu_work: A description of the amount of work done on one CPU of
-      each frequency domain ({cpu : {freq : work}}
-    :type cpu_work: dict
+    :param sanity_items: A list of :class:`UserspaceSanityItem`.
+    :type sanity_items: list(UserspaceSanityItem)
     """
 
-    def __init__(self, res_dir, plat_info, cpu_work):
+    def __init__(self, res_dir, plat_info, sanity_items):
         super().__init__(res_dir, plat_info)
 
-        self.cpu_work = cpu_work
+        self.sanity_items = sanity_items
 
     @classmethod
     def _from_target(cls, target:Target, *, res_dir:ArtifactPath=None,
@@ -47,28 +87,34 @@ class UserspaceSanity(TestBundle):
         This will run Sysbench at different frequencies using the userspace
         governor
         """
-        cpu_work = {}
+        sanity_items = []
 
+        plat_info = target.plat_info
         with target.cpufreq.use_governor("userspace"):
-            for domain in target.cpufreq.iter_domains():
+            for domain in plat_info['freq-domains']:
                 cpu = domain[0]
-                cpu_work[cpu] = {}
-                freqs = target.cpufreq.list_frequencies(cpu)
+                freqs = plat_info['freqs'][cpu]
 
                 if len(freqs) > freq_count_limit:
                     freqs = freqs[::len(freqs) // freq_count_limit +
-                                  (1 if len(freqs) % 2 else 0)]
+                                    (1 if len(freqs) % 2 else 0)]
 
                 for freq in freqs:
-                    sysbench_res_dir = ArtifactPath.join(res_dir, 'CPU{}@{}'.format(cpu, freq))
-                    os.makedirs(sysbench_res_dir)
-                    sysbench = Sysbench(target, "sysbench", sysbench_res_dir)
+                    item_res_dir = ArtifactPath.join(res_dir, 'CPU{}@{}'.format(cpu, freq))
+                    os.makedirs(item_res_dir)
+                    item = UserspaceSanityItem.from_target(
+                        target=target,
+                        cpu=cpu,
+                        freq=freq,
+                        res_dir=item_res_dir,
+                        # We already did that once and for all, so that we
+                        # don't spend too much time endlessly switching back
+                        # and forth between governors
+                        switch_governor=False,
+                    )
+                    sanity_items.append(item)
 
-                    target.cpufreq.set_frequency(cpu, freq)
-                    sysbench.run(cpus=[cpu], max_duration_s=1)
-                    cpu_work[cpu][freq] = sysbench.output.nr_events
-
-        return cls(res_dir, target.plat_info, cpu_work)
+        return cls(res_dir, plat_info, sanity_items)
 
     def test_performance_sanity(self) -> ResultBundle:
         """
@@ -76,14 +122,31 @@ class UserspaceSanity(TestBundle):
         """
         res = ResultBundle.from_bool(True)
 
-        for cpu, freq_work in self.cpu_work.items():
-            sorted_freqs = sorted(freq_work.keys())
-            work = [freq_work[freq] for freq in sorted_freqs]
+        cpu_items = {
+            cpu: {
+                # We expect only one item per frequency
+                item.freq: item
+                for item in freq_items
+            }
+            for cpu, freq_items in groupby(self.sanity_items, key=lambda item: item.cpu)
+        }
 
-            if not work == sorted(work):
-                res.result = Result.FAILED
+        failed = []
+        passed = True
+        for cpu, freq_items in cpu_items.items():
+            sorted_items = sorted(freq_items.values(), key=lambda item: item.freq)
+            work = [item.work for item in sorted_items]
+            if work != sorted(work):
+                passed = False
+                failed.append(cpu)
 
-            res.add_metric("CPU{} work".format(cpu), freq_work)
+        res = ResultBundle.from_bool(passed)
+        work_metric = {
+            cpu: {freq: item.work for freq, item in freq_items.items()}
+            for cpu, freq_items in cpu_items.items()
+        }
+        res.add_metric('CPUs work', work_metric)
+        res.add_metric('Failed CPUs', failed)
 
         return res
 

--- a/lisa/tests/cpufreq/sanity.py
+++ b/lisa/tests/cpufreq/sanity.py
@@ -60,7 +60,7 @@ class UserspaceSanity(TestBundle):
                                   (1 if len(freqs) % 2 else 0)]
 
                 for freq in freqs:
-                    sysbench_res_dir = os.path.join(res_dir, 'CPU{}@{}'.format(cpu, freq))
+                    sysbench_res_dir = ArtifactPath.join(res_dir, 'CPU{}@{}'.format(cpu, freq))
                     os.makedirs(sysbench_res_dir)
                     sysbench = Sysbench(target, "sysbench", sysbench_res_dir)
 

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -190,7 +190,7 @@ class EASBehaviour(RTATestBundle):
 
                 prev = time
 
-        figname = os.path.join(self.res_dir, 'expected_placement.png')
+        figname = ArtifactPath.join(self.res_dir, 'expected_placement.png')
         plt.savefig(figname, bbox_inches='tight')
         plt.close()
 

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -798,7 +798,7 @@ class PELTTask(LoadTrackingBase):
         self._plot_behaviour(axes[1], sim_df.pelt_value, "Expected signal",
                              requested_duty_cycle)
 
-        figname = os.path.join(self.res_dir, '{}_behaviour.png'.format(signal_name))
+        figname = ArtifactPath.join(self.res_dir, '{}_behaviour.png'.format(signal_name))
         plt.savefig(figname, bbox_inches='tight')
         plt.close()
 

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 import copy
 
 from lisa.wlgen.workload import Workload
-from lisa.utils import Loggable, TASK_COMM_MAX_LEN
+from lisa.utils import Loggable, ArtifactPath, TASK_COMM_MAX_LEN
 
 class RTA(Workload):
     """
@@ -62,7 +62,7 @@ class RTA(Workload):
         if not json_file:
             json_file = '{}.json'.format(self.name)
 
-        self.local_json = os.path.join(self.res_dir, json_file)
+        self.local_json = ArtifactPath.join(self.res_dir, json_file)
         self.remote_json = self.target.path.join(self.run_dir, json_file)
 
         rta_cmd = self.target.which('rt-app')

--- a/lisa/wlgen/workload.py
+++ b/lisa/wlgen/workload.py
@@ -20,7 +20,7 @@ import os
 
 from devlib.utils.misc import list_to_mask
 
-from lisa.utils import Loggable
+from lisa.utils import Loggable, ArtifactPath
 
 class Workload(Loggable):
     """
@@ -139,7 +139,7 @@ class Workload(Loggable):
             self.output = target.execute(_command, as_root=as_root, timeout=timeout)
             logger.info("Execution complete")
 
-            logfile = os.path.join(self.res_dir, 'output.log')
+            logfile = ArtifactPath.join(self.res_dir, 'output.log')
             logger.debug('Saving stdout to %s...', logfile)
 
             with open(logfile, 'w') as ofile:


### PR DESCRIPTION
…ocation

Avoid overwriting output.log files when using a single res_dir. Fix that by
making a separate res_dir for each invocations.