### PR TITLE
lisa.analysis.frequency: Fix domain coherency check

### DIFF
--- a/lisa/analysis/frequency.py
+++ b/lisa/analysis/frequency.py
@@ -63,7 +63,7 @@ class FrequencyAnalysis(TraceAnalysisBase):
         for domain in domains:
             # restrict the domain to what we care. Other CPUs may have garbage
             # data, but the caller is not going to look at it anyway.
-            domain = set(domain) - set(cpus)
+            domain = set(domain) & set(cpus)
             if len(domain) < 2:
                 continue
 


### PR DESCRIPTION
Fix typo in set() operations, leading to no check being carried in the default
case.