### PR TITLE
lisa.target: Avoid freezing the main process on LocalLinuxTarget

### DIFF
--- a/lisa/target.py
+++ b/lisa/target.py
@@ -692,7 +692,12 @@ class Target(Loggable, HideExekallID, Configurable):
             cm = nullcontext
 
         else:
-            exclude = self.CRITICAL_TASKS[self.target.os]
+            exclude = copy.copy(self.CRITICAL_TASKS[self.target.os])
+
+            # Do not freeze the process in charge of de-freezing, otherwise we
+            # will freeze to death and a machine hard reboot will be required
+            if isinstance(self.target, devlib.LocalLinuxTarget):
+                exclude.append(str(os.getpid()))
 
             @contextlib.contextmanager
             def cm():


### PR DESCRIPTION
This allows using the freezing feature on the host, while still being able to
unfreeze at the end. Output usually freezes as well if it comes in a virtual
terminal, but otherwise, things do work.