### PR TITLE
Remove `from_target` boilerplate definitions

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -33,6 +33,7 @@ import copy
 from lisa.analysis.tasks import TasksAnalysis
 from lisa.trace import Trace, requires_events, TaskID
 from lisa.wlgen.rta import RTA
+from lisa.target import Target
 
 from lisa.utils import (
     Serializable, memoized, ArtifactPath, non_recursive_property,
@@ -974,7 +975,13 @@ class RTATestBundle(TestBundle, metaclass=RTATestBundleMeta):
         return trace_path
 
     @classmethod
-    def _from_target(cls, target, *, res_dir, ftrace_coll=None):
+    def _from_target(cls, target:Target, *, res_dir:ArtifactPath=None, ftrace_coll:FtraceCollector=None) -> 'RTATestBundle':
+        """
+        Factory method to create a bundle using a live target
+
+        This will execute the rt-app workload described in
+        :meth:`~lisa.tests.base.RTATestBundle.get_rtapp_profile`
+        """
         plat_info = target.plat_info
         rtapp_profile = cls.get_rtapp_profile(plat_info)
         cgroup_config = cls.get_cgroup_configuration(plat_info)

--- a/lisa/tests/cpufreq/sanity.py
+++ b/lisa/tests/cpufreq/sanity.py
@@ -35,7 +35,17 @@ class UserspaceSanity(TestBundle):
         self.cpu_work = cpu_work
 
     @classmethod
-    def _from_target(cls, target, res_dir, freq_count_limit):
+    def _from_target(cls, target:Target, *, res_dir:ArtifactPath=None,
+                     freq_count_limit=5) -> 'UserspaceSanity':
+        """
+        Factory method to create a bundle using a live target
+
+        :param freq_count_limit: The maximum amount of frequencies to test
+        :type freq_count_limit: int
+
+        This will run Sysbench at different frequencies using the userspace
+        governor
+        """
         cpu_work = {}
         sysbench = Sysbench(target, "sysbench", res_dir)
 
@@ -55,20 +65,6 @@ class UserspaceSanity(TestBundle):
                     cpu_work[cpu][freq] = sysbench.output.nr_events
 
         return cls(res_dir, target.plat_info, cpu_work)
-
-    @classmethod
-    def from_target(cls, target:Target, res_dir:ArtifactPath=None,
-                     freq_count_limit=5) -> 'UserspaceSanity':
-        """
-        Factory method to create a bundle using a live target
-
-        :param freq_count_limit: The maximum amount of frequencies to test
-        :type freq_count_limit: int
-
-        This will run Sysbench at different frequencies using the userspace
-        governor
-        """
-        return super().from_target(target, res_dir, freq_count_limit=freq_count_limit)
 
     def test_performance_sanity(self) -> ResultBundle:
         """

--- a/lisa/tests/hotplug/torture.py
+++ b/lisa/tests/hotplug/torture.py
@@ -137,8 +137,27 @@ class HotplugBase(TestBundle):
         return script
 
     @classmethod
-    def _from_target(cls, target, res_dir, seed, nr_operations, sleep_min_ms,
-                      sleep_max_ms, max_cpus_off):
+    def _from_target(cls, target:Target, *, res_dir:ArtifactPath=None, seed=None,
+                     nr_operations=100, sleep_min_ms=10, sleep_max_ms=100,
+                     max_cpus_off=sys.maxsize) -> 'HotplugBase':
+        """
+        :param seed: Seed of the RNG used to create the hotplug sequences
+        :type seed: int
+
+        :param nr_operations: Number of operations in the sequence
+        :type nr_operations: int
+
+        :param sleep_min_ms: Minimum sleep duration between hotplug operations
+        :type sleep_min_ms: int
+
+        :param sleep_max_ms: Maximum sleep duration between hotplug operations
+          (0 would lead to no sleep)
+        :type sleep_max_ms: int
+
+        :param max_cpus_off: Maximum number of CPUs hotplugged out at any given
+          moment
+        :type max_cpus_off: int
+        """
 
         # Instantiate a generator so we can change the seed without any global
         # effect
@@ -173,34 +192,6 @@ class HotplugBase(TestBundle):
         live_cpus = target.list_online_cpus() if target_alive else []
 
         return cls(target.plat_info, target_alive, hotpluggable_cpus, live_cpus)
-
-    @classmethod
-    def from_target(cls, target:Target, res_dir:ArtifactPath=None, seed=None,
-                     nr_operations=100, sleep_min_ms=10, sleep_max_ms=100,
-                     max_cpus_off=sys.maxsize) -> 'HotplugBase':
-        """
-        :param seed: Seed of the RNG used to create the hotplug sequences
-        :type seed: int
-
-        :param nr_operations: Number of operations in the sequence
-        :type nr_operations: int
-
-        :param sleep_min_ms: Minimum sleep duration between hotplug operations
-        :type sleep_min_ms: int
-
-        :param sleep_max_ms: Maximum sleep duration between hotplug operations
-          (0 would lead to no sleep)
-        :type sleep_max_ms: int
-
-        :param max_cpus_off: Maximum number of CPUs hotplugged out at any given
-          moment
-        :type max_cpus_off: int
-        """
-        # This is just boilerplate but it lets us document parameters
-        return super().from_target(
-            target, res_dir, seed=seed, nr_operations=nr_operations,
-            sleep_min_ms=sleep_min_ms, sleep_max_ms=sleep_max_ms,
-            max_cpus_off=max_cpus_off)
 
     def test_target_alive(self) -> ResultBundle:
         """

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -65,7 +65,13 @@ class EASBehaviour(RTATestBundle):
             raise CannotCreateError("Energy model not available")
 
     @classmethod
-    def _from_target(cls, target, res_dir, ftrace_coll=None):
+    def _from_target(cls, target:Target, *, res_dir:ArtifactPath=None, ftrace_coll:FtraceCollector=None) -> 'EASBehaviour':
+        """
+        Factory method to create a bundle using a live target
+
+        This will execute the rt-app workload described in
+        :meth:`lisa.tests.base.RTATestBundle.get_rtapp_profile`
+        """
         plat_info = target.plat_info
         rtapp_profile = cls.get_rtapp_profile(plat_info)
 
@@ -76,16 +82,6 @@ class EASBehaviour(RTATestBundle):
                 cls._run_rtapp(target, res_dir, rtapp_profile, ftrace_coll=ftrace_coll)
 
         return cls(res_dir, plat_info)
-
-    @classmethod
-    def from_target(cls, target:Target, res_dir:ArtifactPath=None, ftrace_coll:FtraceCollector=None) -> 'EASBehaviour':
-        """
-        Factory method to create a bundle using a live target
-
-        This will execute the rt-app workload described in
-        :meth:`lisa.tests.base.RTATestBundle.get_rtapp_profile`
-        """
-        return super().from_target(target, res_dir, ftrace_coll=ftrace_coll)
 
     def _get_expected_task_utils_df(self, nrg_model):
         """

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -66,16 +66,6 @@ class MisfitMigrationBase(RTATestBundle):
         HZ = plat_info['kernel']['config']['CONFIG_HZ']
         return ((HZ * plat_info['cpus-count']) // 10) * (1. / HZ)
 
-    @classmethod
-    def from_target(cls, target:Target, res_dir:ArtifactPath=None, ftrace_coll:FtraceCollector=None) -> 'MisfitMigrationBase':
-        """
-        Factory method to create a bundle using a live target
-
-        This will execute the rt-app workload described in
-        :meth:`~lisa.tests.base.RTATestBundle.get_rtapp_profile`
-        """
-        return super().from_target(target, res_dir, ftrace_coll=ftrace_coll)
-
 class StaggeredFinishes(MisfitMigrationBase):
     """
     One 100% task per CPU, with staggered completion times.

--- a/lisa/tests/scheduler/sanity.py
+++ b/lisa/tests/scheduler/sanity.py
@@ -37,7 +37,10 @@ class CapacitySanity(TestBundle):
         self.capacity_work = capacity_work
 
     @classmethod
-    def _from_target(cls, target, res_dir):
+    def _from_target(cls, target:Target, *, res_dir:ArtifactPath=None) -> 'CapacitySanity':
+        """
+        Factory method to create a bundle using a live target
+        """
         with target.cpufreq.use_governor("performance"):
             sysbench = Sysbench(target, "sysbench", res_dir)
 
@@ -52,13 +55,6 @@ class CapacitySanity(TestBundle):
                 capa_work[capa] = min(capa_work[capa], sysbench.output.nr_events)
 
         return cls(res_dir, target.plat_info, capa_work)
-
-    @classmethod
-    def from_target(cls, target:Target, res_dir:ArtifactPath=None) -> 'CapacitySanity':
-        """
-        Factory method to create a bundle using a live target
-        """
-        return super().from_target(target, res_dir)
 
     def test_capacity_sanity(self) -> ResultBundle:
         """

--- a/lisa/tests/staging/sched_android.py
+++ b/lisa/tests/staging/sched_android.py
@@ -60,16 +60,7 @@ class SchedTuneItemBase(RTATestBundle):
     @classmethod
     # Not annotated, to prevent exekall from picking it up. See
     # SchedTuneBase.from_target
-    def from_target(cls, target, boost, prefer_idle, res_dir=None, ftrace_coll=None):
-        """
-        .. warning:: `res_dir` is at the end of the parameter list, unlike most
-            other `from_target` where it is the second one.
-        """
-        return super().from_target(target, res_dir, boost=boost,
-                prefer_idle=prefer_idle, ftrace_coll=ftrace_coll)
-
-    @classmethod
-    def _from_target(cls, target, res_dir, boost, prefer_idle, ftrace_coll=None):
+    def _from_target(cls, target, *, res_dir, boost, prefer_idle, ftrace_coll=None):
         plat_info = target.plat_info
         rtapp_profile = cls.get_rtapp_profile(plat_info)
         cgroup_config = cls.get_cgroup_configuration(plat_info, boost, prefer_idle)
@@ -91,15 +82,11 @@ class SchedTuneBase(TestBundle):
         self.test_bundles = test_bundles
 
     @classmethod
-    def from_target(cls, target:Target, res_dir:ArtifactPath=None,
+    def _from_target(cls, target:Target, *, res_dir:ArtifactPath=None,
             ftrace_coll:FtraceCollector=None) -> 'SchedTuneBase':
         """
         Creates a SchedTuneBase bundle from the target.
         """
-        return super().from_target(target, res_dir, ftrace_coll=ftrace_coll)
-
-    @classmethod
-    def _from_target(cls, target, res_dir, ftrace_coll):
         return cls(res_dir, target.plat_info,
             list(cls._create_test_bundles(target, res_dir, ftrace_coll))
         )
@@ -127,7 +114,12 @@ class SchedTuneBase(TestBundle):
         logger = cls.get_logger()
         logger.info('Running {} with boost={}, prefer_idle={}'.format(
                     item_cls.__name__, boost, prefer_idle))
-        return item_cls.from_target(target, boost, prefer_idle, res_dir=item_dir, ftrace_coll=ftrace_coll)
+        return item_cls.from_target(target,
+            boost=boost,
+            prefer_idle=prefer_idle,
+            res_dir=item_dir,
+            ftrace_coll=ftrace_coll
+        )
 
 
 class SchedTuneFreqItem(SchedTuneItemBase):

--- a/tests/test_test_bundle.py
+++ b/tests/test_test_bundle.py
@@ -30,7 +30,7 @@ class DummyTestBundle(TestBundle):
         self.shell_output = shell_output
 
     @classmethod
-    def _from_target(cls, target, res_dir):
+    def _from_target(cls, target, *, res_dir) -> 'DummyTestBundle':
         output = target.execute('echo $((21+21))').split()
         return cls(res_dir, output)
 


### PR DESCRIPTION
Add `TestBundleMeta` metaclass to generate the shim automatically, by moving the annotations of `_from_target` to a shim `from_target`