### PR TITLE
lisa.tests.base: Call _from_target() using only keyword arguments.

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -417,7 +417,7 @@ class TestBundle(Serializable, abc.ABC):
             symlink=True,
         )
 
-        bundle = cls._from_target(target, res_dir, **kwargs)
+        bundle = cls._from_target(target=target, res_dir=res_dir, **kwargs)
 
         # We've created the bundle from the target, and have all of
         # the information we need to execute the test code. However,


### PR DESCRIPTION
This gives more flexibility in the order of parameters in implementations of
_from_target(), which is needed when some parameters could have a default value.