### PR TITLE
lisa.tests.base: Display Metrics' unit even when the value is a Mapping

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -54,10 +54,11 @@ class TestMetric:
 
     def __str__(self):
         if isinstance(self.data, Mapping):
-            return '{{{}}}'.format(', '.join(
-                ["{}={}".format(name, data) for name, data in self.data.items()]))
+            result = '{{{}}}'.format(', '.join(
+                "{}={}".format(name, data) for name, data in self.data.items()))
+        else:
+            result = str(self.data)
 
-        result = str(self.data)
         if self.units:
             result += ' ' + self.units
 


### PR DESCRIPTION
It is sometimes useful to keep the unit displayed (if defined), even if the
value is not something scalar.