### PR TITLE
lisa.exekall_customize: Add utils.ExekallTaggable and dispatch tag de…

### DIFF
--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -28,7 +28,7 @@ from collections import OrderedDict, namedtuple
 from lisa.target import Target, TargetConf
 from lisa.trace import FtraceCollector, FtraceConf
 from lisa.platforms.platinfo import PlatformInfo
-from lisa.utils import HideExekallID, Loggable, ArtifactPath, get_subclasses, groupby, Serializable, get_nested_key
+from lisa.utils import HideExekallID, Loggable, ArtifactPath, get_subclasses, groupby, Serializable, get_nested_key, ExekallTaggable
 from lisa.conf import MultiSrcConf
 from lisa.tests.base import TestBundle, ResultBundleBase, Result, RTATestBundle
 from lisa.tests.scheduler.load_tracking import InvarianceItem
@@ -517,14 +517,8 @@ comparison. Can be repeated.""")
 
     @classmethod
     def get_tags(cls, value):
-        tags = {}
-        if isinstance(value, Target):
-            tags['board'] = value.name
-        elif isinstance(value, InvarianceItem):
-            if value.cpu is not None:
-                tags['cpu'] = '{}@{}'.format(value.cpu, value.freq)
-        elif isinstance(value, TestBundle):
-            tags['board'] = value.plat_info.get('name')
+        if isinstance(value, ExekallTaggable):
+            tags = value.get_tags()
         else:
             tags = super().get_tags(value)
 

--- a/lisa/target.py
+++ b/lisa/target.py
@@ -38,7 +38,7 @@ from devlib.platform.gem5 import Gem5SimulationPlatform
 
 import lisa.assets
 from lisa.wlgen.rta import RTA
-from lisa.utils import Loggable, HideExekallID, resolve_dotted_name, get_subclasses, import_all_submodules, LISA_HOME, RESULT_DIR, LATEST_LINK, ASSETS_PATH, setup_logging, ArtifactPath, nullcontext
+from lisa.utils import Loggable, HideExekallID, resolve_dotted_name, get_subclasses, import_all_submodules, LISA_HOME, RESULT_DIR, LATEST_LINK, ASSETS_PATH, setup_logging, ArtifactPath, nullcontext, ExekallTaggable
 from lisa.conf import SimpleMultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc, StrList, Configurable
 
 from lisa.platforms.platinfo import PlatformInfo
@@ -146,7 +146,7 @@ class TargetConf(SimpleMultiSrcConf, HideExekallID):
         }
     }
 
-class Target(Loggable, HideExekallID, Configurable):
+class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
     """
     Wrap :class:`devlib.target.Target` to provide additional features on top of
     it.
@@ -775,6 +775,9 @@ class Target(Loggable, HideExekallID, Configurable):
             for domain in self.target.cpufreq.iter_domains():
                 self.target.cpuidle.enable_all(domain[0])
 
+
+    def get_tags(self):
+        return {'board': self.name}
 
 class Gem5SimulationPlatformWrapper(Gem5SimulationPlatform):
     def __init__(self, system, simulator, **kwargs):

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -37,7 +37,7 @@ from lisa.target import Target
 
 from lisa.utils import (
     Serializable, memoized, ArtifactPath, non_recursive_property,
-    LayeredMapping, update_wrapper_doc
+    LayeredMapping, update_wrapper_doc, ExekallTaggable,
 )
 from lisa.datautils import df_filter_task_ids
 from lisa.trace import FtraceCollector, FtraceConf, DmesgCollector
@@ -359,7 +359,7 @@ class TestBundleMeta(abc.ABCMeta):
 
         return new_cls
 
-class TestBundle(Serializable, abc.ABC, metaclass=TestBundleMeta):
+class TestBundle(Serializable, ExekallTaggable, abc.ABC, metaclass=TestBundleMeta):
     """
     A LISA test bundle.
 
@@ -457,6 +457,12 @@ class TestBundle(Serializable, abc.ABC, metaclass=TestBundleMeta):
         # See exekall_customization.LISAAdaptor.load_db
         self.res_dir = res_dir
         self.plat_info = plat_info
+
+    def get_tags(self):
+        try:
+            return {'board': self.plat_info['name']}
+        except KeyError:
+            return {}
 
     @classmethod
     @abc.abstractmethod

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -33,7 +33,7 @@ from lisa.tests.base import (
     RTATestBundle, CannotCreateError
 )
 from lisa.target import Target
-from lisa.utils import ArtifactPath, groupby
+from lisa.utils import ArtifactPath, groupby, ExekallTaggable
 from lisa.datautils import series_integrate, series_mean, df_window
 from lisa.wlgen.rta import Periodic, RTATask
 from lisa.trace import FtraceConf, FtraceCollector, requires_events
@@ -216,7 +216,7 @@ class LoadTrackingBase(RTATestBundle, LoadTrackingHelpers):
         delta = target * allowed_delta_pct / 100
         return target - delta <= value <= target + delta
 
-class InvarianceItem(LoadTrackingBase):
+class InvarianceItem(LoadTrackingBase, ExekallTaggable):
     """
     Basic check for CPU and frequency invariant load and utilization tracking
 
@@ -241,6 +241,9 @@ class InvarianceItem(LoadTrackingBase):
     @property
     def rtapp_profile(self):
         return self.get_rtapp_profile(self.plat_info, cpu=self.cpu, freq=self.freq)
+
+    def get_tags(self):
+        return {'cpu': '{}@{}'.format(self.cpu, self.freq)}
 
     @classmethod
     def get_rtapp_profile(cls, plat_info, cpu, freq):

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -1340,4 +1340,19 @@ def nullcontext(enter_result=None):
     yield enter_result
 
 
+class ExekallTaggable:
+    """
+    Allows tagging the objects produced in exekall expressions ID.
+
+    .. seealso:: :ref:`exekall expression ID<exekall-expression-id>`
+    """
+
+    @abc.abstractmethod
+    def get_tags(self):
+        """
+        :return: Dictionary of tags and tag values
+        :rtype: dict(str, object)
+        """
+        return {}
+
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/tools/exekall/doc/man/man.rst
+++ b/tools/exekall/doc/man/man.rst
@@ -79,7 +79,7 @@ implicitly to keep consistent expressions.
 
 The adaptor found in the customization module of the python sources you are
 using can add extra options to ``exekall run``, which are shown in ``--help``
-only when these sources are specified as well. 
+only when these sources are specified as well.
 
 Expression engine
 +++++++++++++++++
@@ -87,7 +87,10 @@ Expression engine
 At the core of ``exekall`` is the expression engine. It is in charge of
 building sensible sequences of calls out of python-level annotations (see PEP
 484), and then executing them. An expression is a graph where each node has
-named *parameters* that point to other nodes. 
+named *parameters* that point to other nodes.
+
+
+.. _exekall-expression-id:
 
 Expression ID
 -------------
@@ -101,7 +104,7 @@ Each expression has an associated ID that is derived from its structure. The rul
       (name of a Python callable), followed by a
       parenthesis-enclosed list of parameters ID, excluding the first
       parameter. The code :code:`f(p1=g(), p2=h(k()))` has the ID
-      ``g:f(p2=k:h)``. 
+      ``g:f(p2=k:h)``.
    3. Expression values can have named tags attached to them. When displaying
       the ID of such a value, the tag would be inserted right after the
       operator name, inside brackets. The value returned by ``g`` tagged with a
@@ -181,7 +184,7 @@ expression itself. Having that level allows merging artifact folders together
 and avoids conflict in case two different expressions share the same ID.
 
 Inside that folder, the following files can be found:
-   
+
    * **STRUCTURE** which contains the structure of the expression. Each
      operator is described by its callable name, its return type, and its
      parameters. Parameters are recursively defined the same way. An **svg** or
@@ -194,7 +197,7 @@ Inside that folder, the following files can be found:
      gives the option to the user to not re-execute some part of the code, but
      load a serialized value instead.
    * Artifact folders allocated by some operators.
-   
+
 exekall compare
 ---------------
 
@@ -295,4 +298,3 @@ modules that are explicitly passed to ``exekall run``.  This allows adding
 extra options to ``exekall run`` and ``compare``, tag values in IDs, change the
 set of callables that will be hidden from the ID and define what type is
 considered to provide reusable values by the engine among other things.
-


### PR DESCRIPTION
…finitions

Instead of having the tags "hardcoded" in the glue, dispatch them in their
respective class by inheriting from ExekallTaggable and defining a custom
get_tags() method.

This allows putting all the class-related information in the class itself.