### PR TITLE
doc: refresh built manpages

### DIFF
--- a/doc/man1/lisa.1
+++ b/doc/man1/lisa.1
@@ -208,7 +208,7 @@ _
 T{
 LISA_HOST_ABI
 T}	T{
-Add some shell utilities to the PATH based on the host ABI. Priority
+Add some shell utilities to the PATH, based on the host ABI. Priority
 is determined by LISA_USE_SYSTEM_BIN
 T}	T{
 x86_64


### PR DESCRIPTION
A previous commit updated an env var doc without refreshing the manpage.