### PR TITLE
install: Make DBus-related packages optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ server.url
 /tools/wa_user_directory/dependencies
 /src/buildroot
 _build
+custom_requirements.txt
+extra_requirements.txt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure(2) do |config|
     do
         echo unset $LC  >> /home/vagrant/.bashrc
     done
-    echo 'export LISA_VENV_PATH=$LISA_VENV_PATH' >> /home/vagrant/.bashrc
+    echo "export LISA_VENV_PATH=$LISA_VENV_PATH" >> /home/vagrant/.bashrc
     echo 'source init_env' >> /home/vagrant/.bashrc
 
     # Trigger the creation of a venv and check that everything works well

--- a/devmode_requirements.txt
+++ b/devmode_requirements.txt
@@ -15,4 +15,4 @@
 -e ./external/workload-automation/
 -e ./[notebook,doc,test]
 
--e ./tools/bisector[dbus]
+-e ./tools/bisector

--- a/install_base.sh
+++ b/install_base.sh
@@ -135,10 +135,6 @@ apt_packages=(
     python3-venv
     python3-setuptools
     python3-tk
-    gobject-introspection
-    libcairo2-dev
-    libgirepository1.0-dev
-    gir1.2-gtk-3.0
 )
 
 # pacman-based distributions like Archlinux or its derivatives
@@ -152,7 +148,6 @@ pacman_packages=(
     python
     python-pip
     python-setuptools
-    gobject-introspection
 
     # These packages can be installed from AUR
     # kernelshark
@@ -197,7 +192,7 @@ if [[ ! -z "$package_manager" ]] && ! test_os_release NAME "$expected_distro"; t
 fi
 
 usage() {
-    echo "Usage: $0 [--help] [--cleanup-android-sdk] [--install-android-tools] [--install-android-platform-tools] [--install-doc-extras] [--install-nodejs] [--install-all]"
+    echo "Usage: $0 [--help] [--cleanup-android-sdk] [--install-android-tools] [--install-android-platform-tools] [--install-doc-extras] [--install-nodejs] [--install-bisector-dbus] [--install-all]"
     cat << EOF
 
 Install distribution packages and other bits that don't fit in the Python
@@ -258,6 +253,21 @@ for arg in "$@"; do
             apt_packages+=(nodejs npm)
             pacman_packages+=(nodejs npm)
         fi
+        handled=1;
+        ;;&
+
+    "--install-bisector-dbus" | "--install-all")
+        apt_packages+=(
+            gobject-introspection
+            # Some of that seems to only be needed on some version of Ubuntu.
+            # GTK/Glib does not shine on packaging side, so ere on the side of
+            # caution and install all the things that seem to avoid issues ...
+            libcairo2-dev
+            libgirepository1.0-dev
+            gir1.2-gtk-3.0
+        )
+        # plantuml can be installed from the AUR
+        pacman_packages+=(gobject-introspection)
         handled=1;
         ;;&
 

--- a/install_base.sh
+++ b/install_base.sh
@@ -96,12 +96,12 @@ install_nodejs_snap() {
     if ! which snap >/dev/null 2>&1; then
         echo 'Snap not installed on that system, not installing nodejs'
         return 1
-    elif snap list >/dev/null 2>&1; then
+    elif ! snap list >/dev/null 2>&1; then
         echo 'Snap not usable on that system, not installing nodejs'
         return 1
     else
         echo "Installing snap nodejs package ..."
-        snap install node --classic --channel=8
+        sudo snap install node --classic --channel=8
     fi
 }
 
@@ -263,6 +263,7 @@ for arg in "$@"; do
         # NodeJS v8+ is required, Ubuntu 16.04 LTS supports only an older version.
         # As a special case we can install it as a snap package
         if test_os_release NAME Ubuntu && test_os_release VERSION_ID 16.04; then
+            apt_packages+=(snapd)
             install_functions+=(install_nodejs_snap)
         else
             apt_packages+=(nodejs npm)

--- a/install_base.sh
+++ b/install_base.sh
@@ -116,7 +116,7 @@ install_pacman() {
     sudo pacman -Sy --needed --noconfirm "${pacman_packages[@]}"
 }
 
-set -eu
+set -u
 
 # APT-based distributions like Ubuntu or Debian
 apt_packages=(
@@ -309,10 +309,15 @@ ret=0
 for _func in "${ordered_functions[@]}"; do
     for func in "${install_functions[@]}"; do
         if [[ $func == $_func ]]; then
-           # If one hook returns non-zero, we keep going but return an overall failure
-           # code
-            $func || ret=$?
-            echo
+            # If one hook returns non-zero, we keep going but return an overall failure
+            # code
+            $func; _ret=$?
+            if [[ $_ret != 0 ]]; then
+                ret=$_ret
+                echo "Stage $func failed with exit code $ret" >&2
+            else
+                echo "Stage $func succeeded" >&2
+            fi
         fi
     done
 done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ./tools/exekall
 ./[notebook,doc,test]
-./tools/bisector[dbus]
+./tools/bisector

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -232,10 +232,13 @@ function lisa-install {
         # This set of requirements will install all the shipped dependencies
         # in editable mode
         local requirements='devmode_requirements.txt'
+        local extra_requirements='devmode_extra_requirements.txt'
+
     else
         # This one will install the packages that are developed here, but will
         # take the external dependencies from PyPI
         local requirements='requirements.txt'
+        local extra_requirements='extra_requirements.txt'
     fi
 
     echo
@@ -254,6 +257,13 @@ function lisa-install {
         echo "Installing requirements from $custom_requirements ..."
         echo
         _lisa-python -m pip install -r "$custom_requirements" "$@"
+    fi
+
+    if [[ -e "$extra_requirements" ]]; then
+        echo
+        echo "Installing extra requirements from $extra_requirements ..."
+        echo
+        _lisa-python -m pip install -r "$extra_requirements" "$@"
     fi
 
     # Make sure the shell has taken into account the new content of directories

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -231,15 +231,25 @@ function lisa-install {
     if [[ "$LISA_DEVMODE" == 1 ]]; then
         # This set of requirements will install all the shipped dependencies
         # in editable mode
-        local requirements='devmode_requirements.txt'
-        local extra_requirements='devmode_extra_requirements.txt'
-
+        local requirements=(
+            devmode_requirements.txt
+            devmode_extra_requirements.txt
+        )
     else
         # This one will install the packages that are developed here, but will
         # take the external dependencies from PyPI
-        local requirements='requirements.txt'
-        local extra_requirements='extra_requirements.txt'
+        local requirements=(
+            requirements.txt
+            extra_requirements.txt
+        )
     fi
+    requirements+=(custom_requirements.txt)
+
+    pip_options=()
+    for f in "${requirements[@]}"; do
+        f="$LISA_HOME/$f"
+        [[ -e "$f" ]] && pip_options+=(-r "$f")
+    done
 
     echo
     echo "Installing LISA packages ..."
@@ -249,22 +259,7 @@ function lisa-install {
     # system's site-packages location. This ensures we use up to date packages,
     # and that the installation process will give the same result on all
     # machines at a given point in time.
-    (cd "$LISA_HOME" && _lisa-python -m pip install --no-cache-dir -r "$LISA_HOME/$requirements" "$@")
-
-    local custom_requirements="$LISA_HOME/custom_requirements.txt"
-    if [[ -e "$custom_requirements" ]]; then
-        echo
-        echo "Installing requirements from $custom_requirements ..."
-        echo
-        _lisa-python -m pip install -r "$custom_requirements" "$@"
-    fi
-
-    if [[ -e "$extra_requirements" ]]; then
-        echo
-        echo "Installing extra requirements from $extra_requirements ..."
-        echo
-        _lisa-python -m pip install -r "$extra_requirements" "$@"
-    fi
+    (cd "$LISA_HOME" && _lisa-python -m pip install --no-cache-dir "${pip_options[@]}" "$@")
 
     # Make sure the shell has taken into account the new content of directories
     # listed in $PATH.


### PR DESCRIPTION
Installing Glib seems to pull a lot of things that are not cleanly packaged,
leading to a range of cryptic errors at install time. Since bisector uses GLib's
DBus bindings, do not install that optional feature by default.

Also allow install_base.sh to register extra requirements for pip, to be installed by lisa-install. This gives a way of enabling an optional feature when running ./install_base.sh, without having to also add a way of specifying that for lisa-install.