### PR TITLE
lisa.utils: Remove lisa.utils.LayeredMapping

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -39,7 +39,7 @@ from lisa.target import Target
 
 from lisa.utils import (
     Serializable, memoized, ArtifactPath, non_recursive_property,
-    LayeredMapping, update_wrapper_doc, ExekallTaggable,
+    update_wrapper_doc, ExekallTaggable,
 )
 from lisa.datautils import df_filter_task_ids
 from lisa.trace import FtraceCollector, FtraceConf, DmesgCollector
@@ -241,12 +241,14 @@ class AggregatedResultBundle(ResultBundleBase):
         Merge the context of all the aggregated bundles, with priority given to
         last in the list.
         """
-        base = ChainMap(
+        bases = [
             result_bundle.context
             for result_bundle in self.result_bundles
-        )
+        ]
+        # All writes will be done in that layer
+        bases.append(self.extra_context)
 
-        return LayeredMapping(base, self.extra_context)
+        return ChainMap(*bases)
 
     @property
     def result(self):
@@ -305,7 +307,7 @@ class AggregatedResultBundle(ResultBundleBase):
                 if res_bundle.result is Result.FAILED
             ])
         top = self.extra_metrics
-        return LayeredMapping(base, top)
+        return ChainMap(base, top)
 
 
 class CannotCreateError(RuntimeError):

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -867,54 +867,6 @@ def non_recursive_property(f):
 
     return property(wrapper)
 
-class LayeredMapping(MutableMapping):
-    """
-    A layered mutable mapping that allows setting values in a ``top`` layer,
-    while values from ``base`` layer cannot be modified.
-
-    :param base: Base layer that will be read-only
-    :type base: collections.abc.Mapping
-
-    :param top: Top layer that will be read-write and have priority over
-        ``base``.
-    :type base: collections.abc.MutableMapping
-    """
-    def __init__(self, base, top=None):
-        self.base = base
-        self.top = top if top is not None else {}
-
-    @property
-    def _merged(self):
-        merged = dict(self.base)
-        merged.update(self.top)
-        return merged
-
-    def __getitem__(self, key):
-        return self._merged[key]
-
-    def __setitem__(self, key, val):
-        self.top[key] = val
-
-    def __delitem__(self, key):
-        del self.top[key]
-
-    def __iter__(self):
-        return iter(self._merged)
-
-    def __len__(self):
-        return len(self._merged)
-
-    def __str__(self):
-        return str(self._merged)
-
-    def __copy__(self):
-        # Shallow copy of underlying dict, so that they can be modified
-        # independently. Otherwise, any mutation on the LayeredMapping would
-        # impact the original top layer.
-        return LayeredMapping(
-            base=copy.copy(self.base),
-            top=copy.copy(self.top),
-        )
 
 def get_short_doc(obj):
     """


### PR DESCRIPTION
Since collections.ChainMap does the same thing but better, remove LayeredMapping.