### PR TITLE
Wlgen uclamp support

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -491,11 +491,11 @@ class Phase(Loggable):
 
             logger.info(' | duration %.6f [s] (%d loops)',
                              duration/1e6, cloops)
-            logger.info(' |  period   %6d [us], duty_cycle %3d %%',
+            logger.info(' | period    %7d [us], duty_cycle %3d %%',
                              period, self.duty_cycle_pct)
-            logger.info(' |  run_time %6d [us], sleep_time %6d [us]',
+            logger.info(' | run_time  %7d [us], sleep_time %6d [us]',
                              running_time, sleep_time)
-
+            
             phase['loop'] = cloops
             phase['run'] = running_time
             phase['timer'] = {'ref': task_name, 'period': period}


### PR DESCRIPTION
This patch adds the ability to set clamp values for RTATask objects. Additional parameters are added to the constructors of RTATask classes which allow one to provide functions as arguments which are used to compute the desired clamp value for a given phase of the task. Example usage is provided in [this notebook](https://gist.github.com/Jaime-VH/c70acebef1977ee1c2e1c9a1f2256695)