### PR TITLE
lisa.wlgen.rta: Fix race condition in RTA workload execution

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -22,6 +22,7 @@ import re
 import sys
 from collections import OrderedDict
 import copy
+import uuid
 
 from lisa.wlgen.workload import Workload
 from lisa.utils import Loggable, ArtifactPath, TASK_COMM_MAX_LEN
@@ -63,7 +64,8 @@ class RTA(Workload):
             json_file = '{}.json'.format(self.name)
 
         self.local_json = ArtifactPath.join(self.res_dir, json_file)
-        self.remote_json = self.target.path.join(self.run_dir, json_file)
+        remote_json_file = '{}_{}'.format(uuid.uuid4(), json_file)
+        self.remote_json = self.target.path.join(self.run_dir, remote_json_file)
 
         rta_cmd = self.target.which('rt-app')
         if not rta_cmd:


### PR DESCRIPTION
The rtapp JSON config file is pushed to the target in `RTA.__init__`, but is only
used when RTA.run() is called. Since the name is not unique, something else
could have modified the file in between, leading to the wrong workload to be
executed.

Fix that by prepending a UUID to the remote filename, so that there is a
one-to-one mapping between remote conf files and RTA() instances.