### PR TITLE
lisa.tests.cpufreq.sanity: Fix trailing comma

### DIFF
--- a/lisa/tests/cpufreq/sanity.py
+++ b/lisa/tests/cpufreq/sanity.py
@@ -35,7 +35,7 @@ class UserspaceSanityItem(TestBundle):
         self.work = work
 
     @classmethod
-    def _from_target(cls, target:Target, *, res_dir:ArtifactPath, cpu, freq, switch_governor=True,) -> 'UserspaceSanityItem':
+    def _from_target(cls, target:Target, *, res_dir:ArtifactPath, cpu, freq, switch_governor=True) -> 'UserspaceSanityItem':
         """
         Create a :class:`UserspaceSanityItem` from a live :class:`lisa.target.Target`.
 


### PR DESCRIPTION
Python < 3.7 is picky on where trailing comma are allowed.