### PR TITLE
tools: batch-rebase: Handle conflict while cherry picking last commit…

### DIFF
--- a/tools/batch-rebase
+++ b/tools/batch-rebase
@@ -19,11 +19,9 @@
 
 import shlex
 import argparse
-import os
 import subprocess
 import sys
-from collections import OrderedDict
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 import tempfile
 from pathlib import Path
 import datetime
@@ -31,6 +29,7 @@ import shutil
 import functools
 import textwrap
 import logging
+import contextlib
 
 from lisa.conf import SimpleMultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc, StrList
 
@@ -239,8 +238,11 @@ def _do_cherry_pick(repo, conf, persistent_tags, tags_suffix):
             info('Please commit all files before running batch-rebase resume')
             return (True, persistent_refs)
 
-        # Finish cherry picking the topic with the conflict
-        git(['cherry-pick', '--continue'])
+        # Finish cherry picking the topic with the conflict.
+        # If the commit was the last in the topic, this will fail as the `git
+        # commit` issued by the user finished the cherry-picking session.
+        with contextlib.suppress(subprocess.CalledProcessError):
+            git(['cherry-pick', '--continue'])
 
         tag_name = add_tag(resume_topic)
         persistent_refs.add(tag_name)


### PR DESCRIPTION
… of topic

The cherry-picking session will be finished by git when committing the conflict
resolution if that was the last commit of the topic. This will make a subsequent
`git cherry-pick --continue` fail, which can be safely ignored.