### PR TITLE
lisa.tests.base: Add SimpleRTATestBundle

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1102,8 +1102,14 @@ class RTATestBundle(FtraceTestBundle):
         dmesg_coll.get_trace(dmesg_path)
         return trace_path
 
+
+class SimpleRTATestBundle(RTATestBundle):
+    """
+    Subclass of :class:`RTATestBundle` providing a default :meth:`_form_target`.
+    """
+
     @classmethod
-    def _from_target(cls, target:Target, *, res_dir:ArtifactPath=None, ftrace_coll:FtraceCollector=None) -> 'RTATestBundle':
+    def _from_target(cls, target:Target, *, res_dir:ArtifactPath=None, ftrace_coll:FtraceCollector=None) -> 'SimpleRTATestBundle':
         """
         Factory method to create a bundle using a live target
 

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -23,12 +23,12 @@ from lisa.utils import memoized, ArtifactPath
 from lisa.datautils import df_squash
 from lisa.trace import Trace, FtraceConf, FtraceCollector, requires_events
 from lisa.wlgen.rta import Periodic
-from lisa.tests.base import RTATestBundle, Result, ResultBundle, CannotCreateError, TestMetric
+from lisa.tests.base import SimpleRTATestBundle, Result, ResultBundle, CannotCreateError, TestMetric
 from lisa.target import Target
 from lisa.analysis.tasks import TasksAnalysis, TaskState
 from lisa.analysis.idle import IdleAnalysis
 
-class MisfitMigrationBase(RTATestBundle):
+class MisfitMigrationBase(SimpleRTATestBundle):
     """
     Abstract class for Misfit behavioural testing
 
@@ -285,7 +285,7 @@ class StaggeredFinishes(MisfitMigrationBase):
 
     @TasksAnalysis.df_task_states.used_events
     @_test_cpus_busy.used_events
-    @RTATestBundle.check_noisy_tasks(noise_threshold_pct=1)
+    @SimpleRTATestBundle.check_noisy_tasks(noise_threshold_pct=1)
     def test_throughput(self, allowed_idle_time_s=None) -> ResultBundle:
         """
         Test that big CPUs are not idle when there are misfit tasks to upmigrate


### PR DESCRIPTION
Having RTATestBundle._from_target() implemented in RTATestBundle breaks the
generality of RTATestBundle.from_target(), as it gains parameters specific to
RTATestBundle._from_target that will be expected to be available on
implementations of _from_target in all subclasses.

Splitting that feature in SimpleRTATestBundle allows clearing the way to
TestBundle.from_target(), which does not add unnecessary constraints on the
expected signature of downstream _from_target.