### PR TITLE
lisa.tests.base: Create the TraceView in RTATestBundle.trace instead …

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -880,14 +880,23 @@ class RTATestBundle(FtraceTestBundle):
         """
         return self.get_cgroup_configuration(self.plat_info)
 
-    def get_trace(self, **kwargs):
+    @non_recursive_property
+    @memoized
+    def trace(self):
         """
         :returns: a :class:`lisa.trace.TraceView` cropped to fit the ``rt-app``
             tasks.
 
-        :Keyword arguments: forwarded to :class:`lisa.trace.Trace`.
+        All events specified in ``ftrace_conf`` are parsed from the trace,
+        so it is suitable for direct use in methods.
+
+        Having the trace as a property lets us defer the loading of the actual
+        trace to when it is first used. Also, this prevents it from being
+        serialized when calling :meth:`lisa.utils.Serializable.to_path` and
+        allows updating the underlying path before it is actually loaded to
+        match a different folder structure.
         """
-        trace = Trace(self.trace_path, self.plat_info, **kwargs)
+        trace = self.get_trace(events=self.ftrace_conf["events"])
         return trace.get_view(self.trace_window(trace))
 
     @TasksAnalysis.df_tasks_runtime.used_events


### PR DESCRIPTION
…of get_trace()

This allows trace_window() to call get_trace() without fearing infinite
recursion. Since all test code is using the "trace" property, the fact that
RTATestBundle.get_trace() will not return the view fitting the rtapp tasks is
not a real issue. Also, get_trace() keeps a semantic of being a "bare" trace,
without extra class-specific filtering on top.