### PR TITLE
lisa.utils: Replace ModuleNotFoundError with ImportError

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -50,7 +50,8 @@ from ruamel.yaml import YAML
 try:
     import sphobjinv
     from IPython.display import IFrame
-except ModuleNotFoundError:
+# ModuleNotFoundError does not exist in Python < 3.6
+except ImportError:
     pass
 
 import lisa

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -2564,10 +2564,16 @@ def import_file(script_name, name=None):
     return module
 
 def import_files(src_files):
+    try:
+        import_excep = ModuleNotFoundError
+    # ModuleNotFoundError does not exists in Python < 3.6
+    except NameError:
+        import_excep = ImportError
+
     for src in src_files:
         try:
             import_file(src)
-        except (ModuleNotFoundError, FileNotFoundError) as e:
+        except (import_excep, FileNotFoundError) as e:
             pass
 
 def get_subclasses(cls):


### PR DESCRIPTION
ModuleNotFoundError is more precise, but was only introduced in Python 3.6.