### PR TITLE
lisa.tests.base: Minor cleanup

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -933,19 +933,19 @@ class RTATestBundle(FtraceTestBundle):
             for prefix in self.rtapp_profile.keys()
         }
 
-        comms = list(itertools.chain.from_iterable(trace.get_tasks().values()))
+        comms = set(itertools.chain.from_iterable(trace.get_tasks().values()))
         task_map = {
-        	prefix: [
-        		comm
-         		for comm in comms
-        		if re.match(regexp, comm)
-        	]
-        	for prefix, regexp in prefix_regexps.items()
+            prefix: sorted(
+                comm
+                for comm in comms
+                if re.match(regexp, comm)
+            )
+            for prefix, regexp in prefix_regexps.items()
         }
 
         missing = set(self.rtapp_profile.keys()) - task_map.keys()
         if missing:
-        	 raise RuntimeError("Missing tasks matching the following rt-app profile names: {}"
+            raise RuntimeError("Missing tasks matching the following rt-app profile names: {}"
                                 .format(', '.join(missing)))
         return task_map
 


### PR DESCRIPTION
* Use spaces for indentation instead of tabs
* Sort the inner lists of rtapp_tasks_map to have stable output suitable for
  display.
* Use a set instead of a list for the comms, so we avoid matching the regex
  multiple times against the same comm, and we avoid having duplicates in the
  inner list of rtapp_tasks_map.