### PR TITLE
load_tracking: rewrite get_task_duty_cycle_pct

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -25,7 +25,6 @@ from statistics import mean
 import matplotlib.pyplot as plt
 
 from bart.sched import pelt
-from bart.sched.SchedAssert import SchedAssert
 
 from trappy.stats.Topology import Topology
 
@@ -121,11 +120,11 @@ class LoadTrackingHelpers:
 
     @classmethod
     def get_task_duty_cycle_pct(cls, trace, task_name, cpu):
-        window = cls.get_task_window(trace, task_name, cpu)
 
-        top = Topology()
-        top.add_to_level('cpu', [[cpu]])
-        return SchedAssert(trace._ftrace, top, execname=task_name).getDutyCycle(window)
+        df = trace.analysis.tasks.df_task_total_residency(task_name)
+        run_time = df['runtime'][cpu]
+
+        return (run_time * 100) / trace.time_range
 
     @staticmethod
     def get_task_window(trace, task_name, cpu=None):


### PR DESCRIPTION
Rewrite get_task_duty_cycle_pct using task analysis methods. It seems
that the Bart method for obtaining a tasks's run time on a CPU
sometimes fails to provide a correct value.

Given that we're using task analysis methods on all other tests with this
function being the only one remaining using a Bart (SchedAssert) method,
rewrite this function to use a more reliable method to obtain a task's
run time.

Signed-off-by: Ionela Voinescu <ionela.voinescu@arm.com>