### PR TITLE
lisa.tests: Ban usage of rtapp_profile.keys() to filter traces

### DIFF
--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -102,9 +102,14 @@ class EASBehaviour(RTATestBundle):
             else:
                 transitions[time][task] = util
 
+        task_maps = self.rtapp_tasks_map
+
         # First we'll build a dict D {time: {task_name: util}} where D[t][n] is
         # the expected utilization of task n from time t.
         for task, params in self.rtapp_profile.items():
+            task_list = tasks_map[task]
+            assert len(task_list) == 1
+            task = task_list[0]
             # time = self.get_start_time(experiment) + params.get('delay', 0)
             time = params.delay_s
             add_transition(time, task, 0)

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -350,7 +350,7 @@ class InvarianceItem(LoadTrackingBase, ExekallTaggable):
 
         capacity = self._get_freq_capa(self.cpu, self.freq, self.plat_info)
 
-        for name, task in self.rtapp_profile.items():
+        for name in self.rtapp_tasks:
             ok, exp_util, signal_mean = self._test_task_signal(
                 signal_name, allowed_error_pct, self.trace, self.cpu, name, capacity)
 


### PR DESCRIPTION
In recent versions of rtapp, the name a task will get during execution is not
the one specified, in order to distinguish between forked tasks.
`self.rtapp_tasks` is a property of RTATestBundle that allows getting the names
as they appear in the trace, which is therefore suitable for filtering.