### PR TITLE
lisa.wlgen.rta: Correctly quote shell commands

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -21,6 +21,7 @@ import os
 import re
 import sys
 from collections import OrderedDict
+from shlex import quote
 import copy
 
 from lisa.wlgen.workload import Workload
@@ -69,7 +70,7 @@ class RTA(Workload):
         if not rta_cmd:
             raise RuntimeError("No rt-app executable found on the target")
 
-        self.command = '{0:s} {1:s} 2>&1'.format(rta_cmd, self.remote_json)
+        self.command = '{0:s} {1:s} 2>&1'.format(quote(rta_cmd), quote(self.remote_json))
 
     def _late_init(self, calibration=None, tasks_names=None):
         """

--- a/lisa/wlgen/workload.py
+++ b/lisa/wlgen/workload.py
@@ -17,6 +17,7 @@
 
 import logging
 import os
+from shlex import quote
 
 from devlib.utils.misc import list_to_mask
 
@@ -56,7 +57,7 @@ class Workload(Loggable):
                 self.command = "echo"
 
             def run(self, cpus=None, cgroup=None, background=False, as_root=False, value=42):
-                self.command = "{} {}".format(self.command, value)
+                self.command = "{} {}".format(self.command, shlex.quote(value))
                 super().run(cpus, cgroup, background, as_root)
 
     **Usage example**::
@@ -125,7 +126,7 @@ class Workload(Loggable):
                 raise RuntimeError("Could not find 'taskset' executable on the target")
 
             cpumask = list_to_mask(cpus)
-            taskset_cmd = '{} 0x{:x}'.format(taskset_bin, cpumask)
+            taskset_cmd = '{} {}'.format(quote(taskset_bin), quote('0x{:x}'.format(cpumask)))
             _command = '{} {}'.format(taskset_cmd, _command)
 
         if cgroup:


### PR DESCRIPTION
Make sure that all elements of the shell commands are quoted as they should.