### PR TITLE
devlib usage update to use new features

### DIFF
--- a/lisa/target.py
+++ b/lisa/target.py
@@ -115,7 +115,7 @@ class TargetConf(SimpleMultiSrcConf, HideExekallID):
         KeyDesc('kind', 'Target kind. Can be "linux" (ssh) or "android" (adb)', [str]),
 
         KeyDesc('host', 'Hostname or IP address of the host', [str, None]),
-        KeyDesc('username', 'SSH username', [str, None]),
+        KeyDesc('username', 'SSH username. On ADB connections, "root" username will root adb upon target connection', [str, None]),
         PasswordKeyDesc('password', 'SSH password', [str, None]),
         KeyDesc('port', 'SSH or ADB server port', [int, None]),
         KeyDesc('device', 'ADB device. Takes precedence over "host"', [str, None]),
@@ -516,6 +516,7 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
                 device = 'DEFAULT'
 
             conn_settings['device'] = device
+            conn_settings['adb_as_root'] = (username == 'root')
 
         elif kind == 'linux':
             logger.debug('Setting up Linux target...')
@@ -601,9 +602,6 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
         logger.debug('  workdir: %s', target.working_directory)
 
         target.setup()
-
-        if isinstance(target, devlib.AndroidTarget):
-            target.adb_root(force=True)
 
         # Verify that all the required modules have been initialized
         for module in devlib_module_list:

--- a/lisa/target.py
+++ b/lisa/target.py
@@ -544,7 +544,7 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
 
         logger.info('%s %s target connection settings:', kind, name)
         for key, val in conn_settings.items():
-            logger.info('%10s : %s', key, val)
+            logger.info('    %s: %s', key, val)
 
         ########################################################################
         # Devlib Platform configuration

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -867,11 +867,7 @@ class DmesgTestBundle(TestBundle):
         :class:`devlib.trace.dmesg.KernelLogEntry`.
         """
         with open(self.dmesg_path) as f:
-            return [
-                KernelLogEntry.from_str(line)
-                for line in f.read().splitlines()
-                if line.strip()
-            ]
+            return list(KernelLogEntry.from_dmesg_output(f.read()))
 
     def test_dmesg(self, level='warn', facility=None) -> ResultBundle:
         """


### PR DESCRIPTION
Couple of things to update in LISA to make use of new devlib features:

* Remove some duplication in dmesg output parsing
* Root adb upon connection before loading the devlib modules. Modules that need root access will work even if the device is not already rooted at the time the target connects.

Depends on https://github.com/ARM-software/lisa/pull/1072