### PR TITLE
doc: Align documentation of all var keyword args

### DIFF
--- a/lisa/analysis/base.py
+++ b/lisa/analysis/base.py
@@ -277,9 +277,8 @@ class AnalysisHelpers(Loggable, abc.ABC):
                     document, or ``rst`` for a reStructuredText output.
                 :type output: str or None
 
-                :param kwargs: keyword arguments forwarded to
+                :Variable keyword arguments: Forwarded to
                     :meth:`~lisa.analysis.base.AnalysisHelpers.setup_plot`
-                :type kwargs: dict
                 """),
                 remove_params=['local_fig'],
                 include_kwargs=True,

--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -418,7 +418,7 @@ def series_mean(y, x=None, **kwargs):
         used. Note that `y` and `x` are expected to have the same index.
     :type y: pandas.DataFrame or None
 
-    :keyword arguments: Passed to :func:`series_integrate`.
+    :Variable keyword arguments: Forwarded to :func:`series_integrate`.
     """
     x = _resolve_x(y, x)
     integral = series_integrate(y, x, **kwargs)

--- a/lisa/regression.py
+++ b/lisa/regression.py
@@ -253,7 +253,8 @@ def compute_regressions(old_list, new_list, remove_tags=[], **kwargs):
         different "board" tag for example.
     :type remove_tags: list(str)
 
-    :param kwargs: extra :meth:`RegressionResult.from_result_list` parameters
+    :Variable keyword arguments: Forwarded to
+        :meth:`RegressionResult.from_result_list`.
     """
 
     def dedup_list(froz_val_list, excluded_froz_val_list):

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -839,7 +839,7 @@ class FtraceTestBundle(TestBundle, metaclass=FtraceTestBundleMeta):
         """
         :returns: a :class:`lisa.trace.Trace` collected in the standard location.
 
-        :Keyword arguments: forwarded to :class:`lisa.trace.Trace`.
+        :Variable keyword arguments: Forwarded to :class:`lisa.trace.Trace`.
         """
         return Trace(self.trace_path, self.plat_info, **kwargs)
 

--- a/lisa/wlgen/sysbench.py
+++ b/lisa/wlgen/sysbench.py
@@ -87,9 +87,9 @@ class Sysbench(Workload):
         :param: max_requests: Maximum number of event requests
         :type max_requests: int
 
-        :Keyword arguments: Additionnal arguments required by the specific
-          test (run ``sysbench --test=<test> help``). Due to Python limitations,
-          use ``_`` instead of ``-`` for argument naming.
+        :Variable keyword arguments: Forwarded on sysbench command line. Run
+            ``sysbench --test=<test> help`` for available parameters. Character
+            ``_`` in parameter names is replaced by ``-``.
 
         The standard output will be saved into a file in ``self.res_dir``
         """

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -917,7 +917,7 @@ def call_process(cmd, *args, merge_stderr=True, **kwargs):
     :param cmd: name of the command to run
     :param args: command line arguments passed to the command
     :param merge_stderr: merge stderr with stdout.
-    :param kwargs: parameters passed to :func:`subprocess.check_output`
+    :Variable keyword arguments: Forwarded to :func:`subprocess.check_output`
     """
     cmd = tuple(str(arg) for arg in cmd)
     if merge_stderr:

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -486,9 +486,8 @@ class ValueDB:
         """
         Get all :class:`FrozenExprVal` contained in this database.
 
-        :param kwargs: Keyword arguments forwarded to
+        :Variable keyword arguments: Forwarded to
             :meth:`ValueDB.get_by_predicate`
-        :type kwargs: dict
         """
         return self.get_by_predicate(lambda froz_val: True, **kwargs)
 
@@ -504,9 +503,8 @@ class ValueDB:
             ``isinstance``, otherwise an exact type check is done using ``is``.
         :type include_subclasses: bool
 
-        :param kwargs: Keyword arguments forwarded to
+        :Variable keyword arguments: Forwarded to
             :meth:`ValueDB.get_by_predicate`
-        :type kwargs: dict
 
         .. note:: If a subexpressions had a :class:`exekall._utils.NoValue`
             value, it will not be selected as type matching is done on the
@@ -534,9 +532,8 @@ class ValueDB:
             qualified ID.
         :type full_qual: bool
 
-        :param kwargs: Keyword arguments forwarded to
+        :Variable keyword arguments: Forwarded to
             :meth:`ValueDB.get_by_predicate`
-        :type kwargs: dict
         """
         def predicate(froz_val):
             return utils.match_name(
@@ -986,8 +983,7 @@ class ExpressionBase(ExprHelpers):
         """
         Return a script equivalent to that :class:`ExpressionBase`.
 
-        :param kwargs: Keyword arguments forwarded to :meth:`get_all_script`.
-        :type kwargs: dict
+        :Variable keyword arguments: Forwarded to :meth:`get_all_script`.
         """
         return self.get_all_script([self], *args, **kwargs)
 
@@ -1501,8 +1497,7 @@ class ComputableExpression(ExpressionBase):
         """
         Build an instance from an :class:`ExpressionBase`
 
-        :param kwargs: Keyword arguments forwarded to ``__init__``
-        :type kwargs: dict
+        :Variable keyword arguments: Forwarded to ``__init__``
         """
         param_map = OrderedDict(
             (param, cls.from_expr(param_expr))
@@ -1594,9 +1589,7 @@ class ComputableExpression(ExpressionBase):
         :param expr_list: List of expressions to execute
         :type expr_list: list(ExpressionBase)
 
-        :param kwargs: Keyword arguments forwarded to
-            :meth:`execute`.
-        :type kwargs: dict
+        :Variable keyword arguments: Forwarded to :meth:`execute`.
 
         .. seealso: :meth:`execute` and
             :meth:`from_expr_list`.
@@ -2721,9 +2714,7 @@ class PrebuiltOperator(Operator):
     :param id_: ID of the operator.
     :type id_: str or None
 
-    :param kwargs: Keyword arguments forwarded to :class:`Operator`
-        constructor.
-    :type kwargs: dict
+    :Variable keyword arguments: Forwarded to :class:`Operator` constructor.
     """
     def __init__(self, obj_type, obj_list, id_=None, **kwargs):
         obj_list_ = list()
@@ -3398,9 +3389,8 @@ class FrozenExprValSeq(collections.abc.Sequence):
         """
         Build a :class:`FrozenExprValSeq` from an :class:`ExprValSeq`.
 
-        :param kwargs: Keyword arguments forwarded to
+        :Variable keyword arguments: Forwarded to
             :meth:`FrozenExprVal.from_expr_val`.
-        :type kwargs: dict
         """
         return cls(
             froz_val_list=[
@@ -3423,10 +3413,7 @@ class FrozenExprValSeq(collections.abc.Sequence):
             :class:`ExprVal` from.
         :type expr_list: list(ComputableExpression)
 
-        :param kwargs: Keyword arguments forwarded to
-            :meth:`from_expr_val_seq`.
-        :type kwargs: dict
-
+        :Variable keyword arguments: Forwarded to :meth:`from_expr_val_seq`.
         """
         expr_val_seq_list = utils.flatten_seq(expr.expr_val_seq_list for expr in expr_list)
         return [


### PR DESCRIPTION
Adopt a consistent style for documenting variable keyword arguments
(**kwargs) throughout LISA. Documenting them as "keyword argument" is
misleading since most of the keyword arguments are not covered by that,
only the variable ones.