### PR TITLE
wlgen: Avoid list with unstable order

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -92,7 +92,7 @@ class RTA(Workload):
                     tasks_names = list(desc["tasks"].keys())
 
         self.calibration = calibration
-        self.tasks = tasks_names
+        self.tasks = sorted(tasks_names)
 
         # Move configuration file to target
         self.target.push(self.local_json, self.remote_json)


### PR DESCRIPTION
List with order that can vary from one execution to another can easily
creep into user-visible data, with quite annoying consequences like
inability to diff the output between one run and another or other random
presentation artifacts.