### PR TITLE
lisa/tests: misfit: Fix rt-app naming issue

### DIFF
--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -118,9 +118,15 @@ class StaggeredFinishes(MisfitMigrationBase):
 
         sdf = sdf[self.trace.start + self.IDLING_DELAY_S * 0.9:]
 
-        for task in self.rtapp_tasks:
-            task_cpu = int(task.strip("{}_".format(self.task_prefix)))
-            task_start = sdf[(sdf.next_comm == task) & (sdf["__cpu"] == task_cpu)].index[0]
+        # Find out when all tasks started executing on their designated CPU
+        for task, profile in self.rtapp_profile.items():
+            task_cpu = profile.phases[0].cpus[0]
+
+            names = self.rtapp_tasks_map[task]
+            assert len(names) == 1
+            name = names[0]
+
+            task_start = sdf[(sdf.next_comm == name) & (sdf["__cpu"] == task_cpu)].index[0]
             last_start = max(last_start, task_start)
 
         self.start_time = last_start


### PR DESCRIPTION
Rt-app task naming was changed with the introduction of the fork
functionality, and this was reflected in

  5b066eef0578 ("lisa.tests.base: Introduce RTATestBundle.rtapp_tasks property")

The misfit test case uses the name of the task to figure out on which
CPU it is initially pinned, which is somewhat icky (and now broken with
the task naming change). Look at the full fledged profile to figure this
out instead.


Briefly tested on a H960 with the latest integration branch:
```
################################################################################
[EXEKALL][2019-09-18 12:53:26,537] INFO  Artifacts dir: /data/work/lisa/results/20190918_12:49:12_1a273d9cd97c42fab8b7195bee0b317f
[EXEKALL][2019-09-18 12:53:26,537] INFO  Result summary:
StaggeredFinishes[board=hikey960]:test_dmesg        FAILED: {dmesg output=
crit: [481.849941] hisi_thermal fff30000.tsensor: sensor <1> THERMAL ALARM: 65370 > 65000
crit: [483.044989] hisi_thermal fff30000.tsensor: sensor <1> THERMAL ALARM stopped: 60860 < 65000}

StaggeredFinishes[board=hikey960]:test_preempt_time PASSED: ...
StaggeredFinishes[board=hikey960]:test_throughput   PASSED: ...
```