### PR TITLE
exekall: Report import error in modules being imported

### DIFF
--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -636,7 +636,7 @@ def do_run(args, parser, run_parser, argv):
         # This might fail, since some adaptor options may introduce "fake"
         # positional arguments, since these options are not registered yet.
         with contextlib.suppress(ValueError, ImportError):
-            module_set.update(utils.import_modules([path]))
+            module_set.update(utils.import_modules([path], best_effort=True))
 
     # Look for a customization submodule in one of the parent packages of the
     # modules we specified on the command line.
@@ -660,6 +660,7 @@ def do_run(args, parser, run_parser, argv):
 
     # Re-import now that we are sure to have the correct list of sources
     module_set = utils.import_modules(args.python_files)
+
     # Make sure the module in which adaptor_cls is defined is used
     module_set.add(inspect.getmodule(adaptor_cls))
 


### PR DESCRIPTION
Import errors need to be ignored when parsing the command line the first time,
as some positional parameters could just belong to adaptor-specific options.
During that phase, importing must be done with a best-effort policy, so that
specifying a package name will result in importing as many submodules as
possible. This avoids not finding the adaptor just because an unrelated module
of the package failed to import with an ImportError.

Once the command line can be parsed unambiguously, modules can be imported
again. The modules that were imported successfully are reused, but the one that
failed to import will be imported again, and the exception will not be hidden at
this point.