### PR TITLE
lisa.wlgen: CD into run_dir when running the command

### DIFF
--- a/lisa/wlgen/workload.py
+++ b/lisa/wlgen/workload.py
@@ -166,6 +166,8 @@ class Workload(Loggable):
         if cgroup:
             _command = target.cgroups.run_into_cmd(cgroup, _command)
 
+        _command = 'cd {} && {}'.format(quote(self.run_dir), _command)
+
         logger.info("Execution start: %s", _command)
 
         if background:


### PR DESCRIPTION
Otherwise, rt-app will try to create a log file wherever it's executing from.
Similar behavior can be expected for other binaries, so let's just cd into the
right directory before executing.