### PR TITLE
lisa.trace: Shield against trace-cmd command name reporting issue

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -62,11 +62,18 @@ class TaskID(namedtuple('TaskID', ('pid', 'comm'))):
     # Prevent creation of a __dict__. This allows a more compact representation
     __slots__ = []
 
+    def __init__(self, *args, **kwargs):
+        # TODO: remove that once this trace-cmd issue is solved in one way or another:
+        # https://bugzilla.kernel.org/show_bug.cgi?id=204979
+        if self.comm == '<...>':
+            raise ValueError('Invalid comm name "<...>"')
+
     def __str__(self):
         if self.pid is not None and self.comm is not None:
             return '{}:{}'.format(self.pid, self.comm)
         else:
             return str(self.comm if self.comm is not None else self.pid)
+
 
 class TraceBase(abc.ABC):
     """


### PR DESCRIPTION
trace-cmd sometimes does not show the command name when raw-parsing the
sched_switch and sched_wakeup events. Instead, it reports "<...>".

Make that an illegal value for TaskID.comm, so that we catch the issue as early
as possible, without going through every dataframe created by df_events(). Note
that the issue can appear for other events as well, although it's expected that
it will always appear for sched_switch/sched_wakeup. Checking at this level
should therefore be enough to catch traces with that issue.

trace-cmd bug report: https://bugzilla.kernel.org/show_bug.cgi?id=204979