### PR TITLE
lisa.utils: Fix deprecate() on classes for Python < 3.6

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -1165,8 +1165,10 @@ def deprecate(msg=None, replaced_by=None, deprecated_in=None, removed_in=None, p
             # Warn on instance creation
             obj.__new__ = wrap_func(obj.__new__)
             # Will show the warning when the class is subclassed
-            # in Python >= 3.6
-            obj.__init_subclass__ = wrap_func(obj.__init_subclass__)
+            # in Python >= 3.6 . Earlier versions of Python don't have
+            # object.__init_subclass__
+            if hasattr(obj, '__init_subclass__'):
+                obj.__init_subclass__ = wrap_func(obj.__init_subclass__)
             return_obj = obj
             update_doc_of = obj
 


### PR DESCRIPTION
object.__init_subclass__ is only available in Python >= 3.6, so do not reference
it when not available