### PR TITLE
lisa.wlgen.rta: Fix rt-app ftrace events JSON building

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -220,7 +220,7 @@ class RTA(Workload):
             # the JSON
             'lock_pages': False,
             'logstats' : log_stats,
-            'ftrace': ','.join(trace_events),
+            'ftrace': ','.join(self.trace_events),
         }
 
         if max_duration_s:


### PR DESCRIPTION
Use the attribute, which is guaranteed to be a list rather than the parameter
which could be None.