### PR TITLE
lisa.tests.scheduler.load_tracking: Unify PELTTask and Invariance

### DIFF
--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -610,5 +610,41 @@ def df_filter_task_ids(df, task_ids, pid_col='pid', comm_col='comm', invert=Fals
 
     return df[tasks_filter]
 
+def series_local_extremum(series, kind):
+    """
+    Returns a series of local extremum.
+
+    :param series: Series to look at.
+    :type series: pandas.Series
+
+    :param kind: Kind of extremum: ``min`` or ``max``.
+    :type kind: str
+    """
+    if kind == 'min':
+        comparator = np.less_equal
+    elif kind == 'max':
+        comparator = np.greater_equal
+    else:
+        raise ValueError('Unsupported kind: {}'.format(kind))
+
+    ilocs = scipy.signal.argrelextrema(series.values, comparator=comparator)
+    return series.iloc[ilocs]
+
+def series_tunnel_mean(series):
+    """
+    Compute the average between the mean of local maximums and local minimums
+    of the series.
+
+    Assuming that the values are ranging inside a tunnel, this will give the
+    average center of that tunnel.
+    """
+    maxs = series_local_extremum(series, kind='max')
+    mins = series_local_extremum(series, kind='min')
+
+    maxs_mean = series_mean(maxs)
+    mins_mean = series_mean(mins)
+
+    return (maxs_mean - mins_mean) / 2 + mins_mean
+
 
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -871,21 +871,19 @@ class CPUMigrationBase(LoadTrackingBase):
             for i, phase in enumerate(self.reference_task.phases):
                 expected_util = expected_cpu_util[cpu][i]
                 expected_util = self.correct_expected_pelt(self.plat_info, cpu, expected_util)
+                trace_util = trace_cpu_util[cpu][i]
                 if not self.is_almost_equal(
-                        trace_cpu_util[cpu][i],
+                        trace_util,
                         expected_util,
                         allowed_error_pct):
                     passed = False
 
                 # Just some verbose metric collection...
                 phase_str = "phase{}".format(i)
+                delta = 100 * (trace_util - expected_util) / expected_util
 
-                expected = expected_cpu_util[cpu][i]
-                trace = trace_cpu_util[cpu][i]
-                delta = 100 * (trace - expected) / expected
-
-                expected_metrics[cpu_str].data[phase_str] = TestMetric(expected)
-                trace_metrics[cpu_str].data[phase_str] = TestMetric(trace)
+                expected_metrics[cpu_str].data[phase_str] = TestMetric(expected_util)
+                trace_metrics[cpu_str].data[phase_str] = TestMetric(trace_util)
                 deltas[cpu_str].data[phase_str] = TestMetric(delta, "%")
 
         res = ResultBundle.from_bool(passed)

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -869,9 +869,11 @@ class CPUMigrationBase(LoadTrackingBase):
             deltas[cpu_str] = TestMetric({})
 
             for i, phase in enumerate(self.reference_task.phases):
+                expected_util = expected_cpu_util[cpu][i]
+                expected_util = self.correct_expected_pelt(self.plat_info, cpu, expected_util)
                 if not self.is_almost_equal(
                         trace_cpu_util[cpu][i],
-                        expected_cpu_util[cpu][i],
+                        expected_util,
                         allowed_error_pct):
                     passed = False
 

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -470,8 +470,8 @@ class Invariance(TestBundle, LoadTrackingHelpers):
     """
     Basic check for frequency invariant load and utilization tracking
 
-    This test runs the same workload on the most capable CPU on the system at a
-    cross section of available frequencies.
+    This test runs the same workload on one CPU of each capacity available in
+    the system at a cross section of available frequencies.
 
     This class is mostly a wrapper around :class:`InvarianceItem`,
     providing a way to build a list of those for a few frequencies, and

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -34,7 +34,7 @@ from lisa.pelt import PELT_SCALE, simulate_pelt, pelt_settling_time
 
 UTIL_SCALE = PELT_SCALE
 
-UTIL_CONVERGENCE_TIME_S = pelt_settling_time(1, init=0, final=1024)
+UTIL_CONVERGENCE_TIME_S = pelt_settling_time(0.1, init=0, final=1024)
 """
 Time in seconds for util_avg to converge (i.e. ignored time)
 """

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -395,7 +395,7 @@ class InvarianceItem(LoadTrackingBase, ExekallTaggable):
         return res
 
     @_test_correctness.used_events
-    def test_util_correctness(self, mean_error_margin_pct=2, max_error_margin_pct=2) -> ResultBundle:
+    def test_util_correctness(self, mean_error_margin_pct=2, max_error_margin_pct=5) -> ResultBundle:
         """
         Check that the utilization signal is as expected.
 
@@ -416,7 +416,7 @@ class InvarianceItem(LoadTrackingBase, ExekallTaggable):
         )
 
     @_test_correctness.used_events
-    def test_load_correctness(self, mean_error_margin_pct=2, max_error_margin_pct=2) -> ResultBundle:
+    def test_load_correctness(self, mean_error_margin_pct=2, max_error_margin_pct=5) -> ResultBundle:
         """
         Same as :meth:`test_util_correctness` but checking the load.
         """
@@ -558,7 +558,7 @@ class Invariance(TestBundle, LoadTrackingHelpers):
     # InvarianceItem with the result merged.
 
     @InvarianceItem.test_util_correctness.used_events
-    def test_util_correctness(self, mean_error_margin_pct=2, max_error_margin_pct=2) -> AggregatedResultBundle:
+    def test_util_correctness(self, mean_error_margin_pct=2, max_error_margin_pct=5) -> AggregatedResultBundle:
         """
         Aggregated version of :meth:`InvarianceItem.test_util_correctness`
         """
@@ -570,7 +570,7 @@ class Invariance(TestBundle, LoadTrackingHelpers):
         return self._test_all_freq(item_test)
 
     @InvarianceItem.test_load_correctness.used_events
-    def test_load_correctness(self, mean_error_margin_pct=2, max_error_margin_pct=2) -> AggregatedResultBundle:
+    def test_load_correctness(self, mean_error_margin_pct=2, max_error_margin_pct=5) -> AggregatedResultBundle:
         """
         Aggregated version of :meth:`InvarianceItem.test_load_correctness`
         """


### PR DESCRIPTION
Unify Invariance and PELTTask tests, so that:
* duplicated behaviour check is removed (and a fair amount of helpers that come with that)
* PELT tests are carried on all types of CPUs, at multiple frequencies, giving much more coverage to the correctness test.


Note that this *requires* to have access to the PELT clock in the sched_load_se
event, otherwise the simulated signal is completely wrong. The test is able to
catch that though.

Note: Computations in PELT use an inaccurate delta of its clock, leading to some unwanted artifacts that happen to be reduced by other rounding errors. Since the simulator does not suffer from rounding errors, the artifacts become much more visible, which leads to a noticeable between the simulated signal and the one computed by the kernel.
