### PR TITLE
lisa.tests.util_tracking: Fix debug plotting

### DIFF
--- a/lisa/tests/staging/util_tracking.py
+++ b/lisa/tests/staging/util_tracking.py
@@ -141,10 +141,10 @@ class UtilConvergence(UtilTrackingBase):
 
     def _plot_signals(self, task, test, failures):
         signals = ['util', 'util_est_enqueued', 'util_est_ewma']
-        ax = self.trace.analysis.load_tracking.plot_task_signals(task, signals=signals)
-        ax = self.trace.analysis.rta.plot_phases(task, axis=ax);
+        ax = self.trace.analysis.load_tracking.plot_task_signals(task, signals=signals, interactive=False)
+        ax = self.trace.analysis.rta.plot_phases(task, axis=ax, interactive=False);
         for start in failures:
-            ax.axvline(start, alpha=0.5, color='r', axis=ax)
+            ax.axvline(start, alpha=0.5, color='r')
         filepath = os.path.join(self.res_dir, 'util_est_{}.png'.format(test))
         self.trace.analysis.rta.save_plot(ax.figure, filepath=filepath)
 


### PR DESCRIPTION
* Avoid interactive plots as they leak memory
* Remove ax=axis from axvline() call since it's redundant with the method call
  on the axis itself.