### PR TITLE
misfit: avoid doing some work in __init__

### DIFF
--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -139,7 +139,6 @@ class StaggeredFinishes(MisfitMigrationBase):
         because we still need the first wakeups to be visible.
         """
         sdf = self.trace.df_events('sched_switch')
-        sdf = sdf[self.trace.start + self.IDLING_DELAY_S * 0.9:]
 
         # Find out when all tasks started executing on their designated CPU
         def get_start_time(sdf, task, profile):


### PR DESCRIPTION
work in __init__ can fail, which means that there will be no serialized object to reproduce the issue easily. This also means that the computation leading to the object state cannot be easily replaced/fixed on a deserialized instance, making it more difficult to debug.