### PR TITLE
lisa.wlgen.rta: Strengthen sanity check on calibration values

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -778,7 +778,11 @@ class PELTTask(LoadTrackingBase):
 
         df = df[settling_time:]
 
-        settled_signal_mean = series_mean(df[signal_name])
+        signal_min = df[signal_name].min()
+        # Instead of taking the mean, take the average between the min and max
+        # values of the settled signal. This avoids the bias introduced by the
+        # fact that the util signal stays high while the task sleeps
+        settled_signal_mean = abs(df[signal_name].max() - signal_min) / 2 + signal_min
         expected_signal_mean = expected_final_util
         expected_signal_mean = self.correct_expected_pelt(self.plat_info, cpu, expected_signal_mean)
 

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -27,7 +27,7 @@ from lisa.tests.base import (
 from lisa.target import Target
 from lisa.utils import ArtifactPath, groupby, ExekallTaggable
 from lisa.datautils import series_mean, df_window, df_filter_task_ids
-from lisa.wlgen.rta import Periodic, RTATask
+from lisa.wlgen.rta import RTA, Periodic, RTATask
 from lisa.trace import FtraceCollector, requires_events
 from lisa.analysis.load_tracking import LoadTrackingAnalysis
 from lisa.pelt import PELT_SCALE, simulate_pelt, pelt_settling_time
@@ -137,6 +137,28 @@ class LoadTrackingHelpers:
             end_df = end_df[(end_df["__cpu"] == cpu)]
 
         return (start_df.index[0], end_df.index[-1])
+
+    @classmethod
+    def correct_expected_pelt(cls, plat_info, cpu, signal_value):
+        """
+        Correct an expected PELT signal from ``rt-app`` based on the calibration
+        values.
+
+        Since the instruction mix of ``rt-app`` might not be the same as the
+        benchmark that was used to establish CPU capacities, the duty cycle of
+        ``rt-app`` will only be accurate on big CPUs. When we know on which CPU
+        the task actually executed, we can correct the expected value based on
+        the ratio of calibration values and CPU capacities.
+        """
+
+        calib = plat_info['rtapp']['calib']
+        cpu_capacities = plat_info['cpu-capacities']
+
+        # Correct the signal mean to what it should have been if rt-app
+        # workload was exactly the same as the one used to establish CPU
+        # capacities
+        true_capacities = RTA.get_cpu_capacities_from_calibrations(calib)
+        return signal_value * cpu_capacities[cpu] / true_capacities[cpu]
 
 
 class LoadTrackingBase(RTATestBundle, LoadTrackingHelpers):
@@ -745,6 +767,10 @@ class PELTTask(LoadTrackingBase):
         phase = self.wlgen_task.phases[0]
         df = self.get_simulated_pelt(task, signal_name)
 
+        cpus = phase.cpus
+        assert len(cpus) == 1
+        cpu = cpus[0]
+
         expected_duty_cycle_pct = phase.duty_cycle_pct
         expected_final_util = expected_duty_cycle_pct / 100 * UTIL_SCALE
         settling_time = pelt_settling_time(1, init=0, final=expected_final_util)
@@ -754,6 +780,7 @@ class PELTTask(LoadTrackingBase):
 
         settled_signal_mean = series_mean(df[signal_name])
         expected_signal_mean = expected_final_util
+        expected_signal_mean = self.correct_expected_pelt(self.plat_info, cpu, expected_signal_mean)
 
         signal_mean_error_pct = abs(expected_signal_mean - settled_signal_mean) / UTIL_SCALE * 100
         res = ResultBundle.from_bool(signal_mean_error_pct < error_margin_pct)

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -30,20 +30,11 @@ from lisa.datautils import series_mean, df_window, df_filter_task_ids
 from lisa.wlgen.rta import Periodic, RTATask
 from lisa.trace import FtraceCollector, requires_events
 from lisa.analysis.load_tracking import LoadTrackingAnalysis
-from lisa.pelt import simulate_pelt, pelt_settling_time
+from lisa.pelt import PELT_SCALE, simulate_pelt, pelt_settling_time
 
+UTIL_SCALE = PELT_SCALE
 
-UTIL_SCALE = 1024
-"""
-PELT utilization values scale
-"""
-
-HALF_LIFE_MS = 32
-"""
-PELT half-life value in ms
-"""
-
-UTIL_AVG_CONVERGENCE_TIME_S = 0.3
+UTIL_AVG_CONVERGENCE_TIME_S = pelt_settling_time(1, init=0, final=1024)
 """
 Time in seconds for util_avg to converge (i.e. ignored time)
 """

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -23,9 +23,11 @@ import sys
 from collections import OrderedDict
 from shlex import quote
 import copy
+import itertools
 
 from lisa.wlgen.workload import Workload
 from lisa.utils import Loggable, ArtifactPath, TASK_COMM_MAX_LEN, groupby, nullcontext
+from lisa.pelt import PELT_SCALE
 
 class RTA(Workload):
     """
@@ -408,16 +410,26 @@ class RTA(Workload):
 
         logger.info('Target RT-App calibration: %s', pload)
 
-        if 'sched' not in target.modules:
+        plat_info = target.plat_info
+
+        # Sanity check calibration values for asymmetric systems if we have
+        # access to capacities
+        try:
+            cpu_capacities = plat_info['cpu-capacities']
+        except KeyError:
             return pload
 
-        # Sanity check calibration values for asymmetric systems
-        cpu_capacities = target.sched.get_capacities()
-
-        # Find the max pload per capacity level
-        capa_pload = {
-            capacity: max(pload[cpu] for cpu, capa in cpu_caps)
+        capa_ploads = {
+            capacity: {cpu: pload[cpu] for cpu, capa in cpu_caps}
             for capacity, cpu_caps in groupby(cpu_capacities.items(), lambda k_v: k_v[1])
+        }
+
+        # Find the min pload per capacity level, i.e. the fastest detected CPU.
+        # It is more likely to represent the right pload, as it has suffered
+        # from less IRQ slowdown or similar disturbances that might be random.
+        capa_pload = {
+            capacity: min(ploads.values())
+            for capacity, ploads in capa_ploads.items()
         }
 
         # Sort by capacity
@@ -430,7 +442,70 @@ class RTA(Workload):
         if list(pload_list) != sorted(pload_list, reverse=True):
             raise RuntimeError('Calibration values reports big cores less capable than LITTLE cores')
 
+        # Check that the CPU capacities seen by rt-app are similar to the one
+        # the kernel uses
+        true_capacities = cls.get_cpu_capacities_from_calibrations(pload)
+        capa_factors_pct = {
+            cpu: true_capacities[cpu] / cpu_capacities[cpu] * 100
+            for cpu in cpu_capacities.keys()
+        }
+        dispersion_pct = max(abs(100 - factor) for factor in capa_factors_pct.values())
+
+        if dispersion_pct > 2:
+            logger.warning('The calibration values are not inversely proportional to the CPU capacities, the duty cycles will be up to {:.2f}% off on some CPUs: {}'.format(dispersion_pct, capa_factors_pct))
+
+        if dispersion_pct > 20:
+            raise RuntimeError('The calibration values are not inversely proportional to the CPU capacities. Either rt-app calibration failed, or the rt-app busy loops has a very different instruction mix compared to the workload used to establish the CPU capacities: {}'.format(capa_factors_pct))
+
+        # Map of CPUs X to list of CPUs Ys that are faster than it although CPUs
+        # of Ys have a smaller capacity than X
+        faster_than_map = {
+            cpu1: sorted(
+                cpu2
+                for cpu2, pload2 in ploads2.items()
+                # CPU2 faster than CPU1
+                if pload2 < pload1
+            )
+            for (capa1, ploads1), (capa2, ploads2) in itertools.permutations(capa_ploads.items())
+            for cpu1, pload1 in ploads1.items()
+            # Only look at permutations in which CPUs of ploads1 are supposed
+            # to be faster than the one in ploads2
+            if capa1 > capa2
+        }
+
+        # Remove empty lists
+        faster_than_map = {
+            cpu: faster_cpus
+            for cpu, faster_cpus in faster_than_map.items()
+            if faster_cpus
+        }
+
+        if faster_than_map:
+            logger.warning('Some CPUs of higher capacities are slower than other CPUs of smaller capacities: {}'.format(faster_than_map))
+
         return pload
+
+    @classmethod
+    def get_cpu_capacities_from_calibrations(cls, calibrations):
+        """
+        Compute the CPU capacities out of the rt-app calibration values.
+
+        :returns: A mapping of CPU to capacity.
+
+        :param calibrations: Mapping of CPU to pload value.
+        :type calibrations: dict
+        """
+
+        # calibration values are inversely proportional to the CPU capacities
+        inverse_calib = {cpu: 1/calib for cpu, calib in calibrations.items()}
+
+        def compute_capa(cpu):
+            # True CPU capacity for the rt-app workload, rather than for the
+            # whatever workload was used to compute the CPU capacities exposed by
+            # the kernel
+            return inverse_calib[cpu] / max(inverse_calib.values()) * PELT_SCALE
+
+        return {cpu: compute_capa(cpu) for cpu in calibrations.keys()}
 
     @classmethod
     def get_cpu_calibrations(cls, target, res_dir=None):

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -92,9 +92,6 @@ class RTA(Workload):
         :parameters: Attributes that have been pre-computed and ended up
           in the json file. Passing them can prevent a needless file read.
         """
-        if not os.path.exists(self.local_json):
-            raise RuntimeError("Could not find {}".format(self.local_json))
-
         if calibration or not tasks_names:
             with open(self.local_json, "r") as fh:
                 desc = json.load(fh)


### PR DESCRIPTION
* Check against the fastest CPU in each capacity class. This CPU is the
  one that has been the less impacted by external disturbances, that are
  usually random.

* Check that the rt-app calibration values are inversely proportional to
  the CPU capacities. When the scaling factor diverges too much for some
  CPUs, raise an exception. This indicates that rt-app will be unable to
  provide predictable utilizations across different CPUs, which is the
  underlying assumption of all wlgen-based code in LISA.

* Use the CPU capacities from plat_info rather than trying to fetch them
  directly using devlib. This follows the practice in LISA, allowing the
  user to provide the values in a configuration file in order to run as
  non-root (it's also faster and uses values printed in the log, for a
  consistent debugging experience).