### PR TITLE
lisa.tests.scheduler.load_tracking: Fix init value of simulated PELT

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -712,6 +712,10 @@ class PELTTask(LoadTrackingBase):
         # Ignore the first activation, as its signals are incorrect
         df_activation = df_activation.iloc[2:]
 
+        # Make sure the activation df does not start before the dataframe of
+        # signal values, otherwise we cannot provide a sensible init value
+        df_activation = df_activation[df.index[0]:]
+
         # Get the initial signal value matching the first activation we will care about
         init_iloc = df.index.get_loc(df_activation.index[0], method='ffill')
         init = df[signal_name].iloc[init_iloc]


### PR DESCRIPTION
Cope with activation dataframe before after the signal dataframe by
restricting the activations we look at.