### PR TITLE
tools: batch-rebase: Add empty commit sha1

### DIFF
--- a/tools/batch-rebase
+++ b/tools/batch-rebase
@@ -342,7 +342,8 @@ def rerere_autocommit(repo):
         else:
             if empty_staging_area(repo):
                 # If the commit would be empty, just skip it
-                warn('Empty commit, skipping it')
+                curr_sha1 = git(['rev-list', '-n1', 'CHERRY_PICK_HEAD'], capture=True).decode()
+                warn('Empty commit, skipping it: {}'.format(curr_sha1))
                 git(['reset'])
             else:
                 info('Git rerere supplied solution, carrying on')


### PR DESCRIPTION
When cherry-picking a commit already merged in the base branch, the
cherry-picked commit will be empty. Since it should be removed from the topic
branch (as it is merged already), report its sha1 for easier identification.