### PR TITLE
setup.py: Remove version constraint for Tornado

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,6 @@ setup(
         "ruamel.yaml >= 0.15.81",
         "docutils", # For the HTML output of analysis plots
 
-        # Jupyter doesn't like >= 6.0
-        "tornado < 6.0",
-
         # Depdendencies that are shipped as part of the LISA repo as
         # subtree/submodule
         "devlib",


### PR DESCRIPTION
Since jupyter has been updated to work with Tornado 6, that constraint is not
needed anymore.