### PR TITLE
lisa.git: Cleanup find_shortes_symref

### DIFF
--- a/lisa/wa_results_collector.py
+++ b/lisa/wa_results_collector.py
@@ -164,7 +164,11 @@ class WaResultsCollector(Loggable):
         kernel_refs = {}
         for sha1 in df['kernel_sha1'].unique():
             if kernel_repo_path:
-                kernel_refs[sha1] = find_shortest_symref(kernel_repo_path, sha1) or sha1
+                try:
+                    symref = find_shortest_symref(kernel_repo_path, sha1)
+                except ValueError:
+                    symref = sha1
+                kernel_refs[sha1] = symref
             else:
                 kernel_refs[sha1] = sha1
 


### PR DESCRIPTION
* Drop compat for git older than 2.7 as we don't support anything before Ubuntu
  Xenial 16.04.

* Raise an exception when no symbolic reference can be found.