### PR TITLE
Don't force running rta as root for calibration

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -403,7 +403,7 @@ class RTA(Workload):
                                  res_dir=res_dir)
 
             with rta, target.disable_idle_states(), target.freeze_userspace():
-                rta.run(as_root=True)
+                rta.run(as_root=target.is_rooted)
 
             for line in rta.output.split('\n'):
                 pload_match = re.search(pload_regexp, line)


### PR DESCRIPTION
target.freeze_tasks() needs to check if the device is rooted before
looking for the cgroup devlib module. This module is never present in
unrooted devices.

Only run rta as root if the device is rooted.

Fixes: 48db507ca67b4e959f1c835f49f102e58da5a051