### PR TITLE
lisa.tests.__init__: Remove matplotlib.use() call

### DIFF
--- a/lisa/__init__.py
+++ b/lisa/__init__.py
@@ -1,6 +1,8 @@
+import matplotlib
+import warnings
+
 from lisa.version import __version__
 
-import warnings
 # Raise an exception when a deprecated API is used from within a lisa.*
 # submodule. This ensures that we don't use any deprecated APIs internally, so
 # they are only kept for external backward compatibility purposes.
@@ -17,5 +19,9 @@ warnings.filterwarnings(
     category=DeprecationWarning,
     module=r'__main__',
 )
+
+# Prevent matplotlib from trying to connect to X11 server, for headless testing.
+# Must be done before importing matplotlib.pyplot or pylab
+matplotlib.use('Agg')
 
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/__init__.py
+++ b/lisa/__init__.py
@@ -1,5 +1,6 @@
 import matplotlib
 import warnings
+import os
 
 from lisa.version import __version__
 
@@ -22,6 +23,7 @@ warnings.filterwarnings(
 
 # Prevent matplotlib from trying to connect to X11 server, for headless testing.
 # Must be done before importing matplotlib.pyplot or pylab
-matplotlib.use('Agg')
+if not os.getenv('DISPLAY'):
+    matplotlib.use('Agg')
 
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/tests/__init__.py
+++ b/lisa/tests/__init__.py
@@ -15,9 +15,4 @@
 # limitations under the License.
 #
 
-import matplotlib
-# Prevent matplotlib from trying to connect to X11 server, for headless testing.
-# Must be done before importing matplotlib.pyplot or pylab
-matplotlib.use('Agg')
-
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab


### PR DESCRIPTION
Avoid forcefully setting the backend of matplotlib, to ease debugging.