### PR TITLE
exekall: pretty print test metrics

### DIFF
--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -542,3 +542,13 @@ comparison. Can be repeated.""")
                 if val.result is Result.FAILED:
                     return 10
         return 0
+
+    def format_result(self, expr_val):
+        val = expr_val.value
+        if val is NoValue or val is None:
+            return super().format_result(expr_val)
+        else:
+            if isinstance(val, ResultBundleBase):
+                return val.pretty_format()
+            else:
+                return str(val)

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -72,9 +72,11 @@ class TaskID(namedtuple('TaskID', ('pid', 'comm'))):
 
     def __str__(self):
         if self.pid is not None and self.comm is not None:
-            return '{}:{}'.format(self.pid, self.comm)
+            out = '{}:{}'.format(self.pid, self.comm)
         else:
-            return str(self.comm if self.comm is not None else self.pid)
+            out = str(self.comm if self.comm is not None else self.pid)
+
+        return '[{}]'.format(out)
 
 
 class TraceBase(abc.ABC):

--- a/tools/exekall/exekall/customization.py
+++ b/tools/exekall/exekall/customization.py
@@ -251,8 +251,9 @@ class AdaptorBase:
             for result in result_list:
                 msg = self.format_result(result)
                 msg = msg + '\n' if '\n' in msg else msg
-                summary.append('{id:<{max_id_len}} {result}'.format(
+                summary.append('{id:<{max_id_len}} UUID={uuid} {result}'.format(
                     id=result_id_map[result],
+                    uuid=result.uuid,
                     result=msg,
                     max_id_len=max_id_len,
                 ))
@@ -290,4 +291,3 @@ class AdaptorBase:
             if subcls.name == name:
                 return subcls
         return None
-


### PR DESCRIPTION
Finally get some decent output, such as this exekall summary:
```
################################################################################
[EXEKALL][2019-10-21 18:32:55,548] INFO  Artifacts dir: /home/dourai01/Data/Git/lisa/results/pwrsft-juno-r0-1/20191021_18:32:52_2474a9215fc54e2ca141b6147bfd3da4
[EXEKALL][2019-10-21 18:32:55,548] INFO  Result summary:
OneSmallTask[board=pwrsft-juno-r0-1]:test_dmesg          UUID=968577749bcb4aea817a593d6a3f4ad7 PASSED: dmesg output:
OneSmallTask[board=pwrsft-juno-r0-1]:test_slack          UUID=c92c7d5ae0564db1bab80d12e25f362c PASSED: small-0 delayed activations: 0.0 %
OneSmallTask[board=pwrsft-juno-r0-1]:test_task_placement UUID=1bc2c5fc904f43e58f7f2bfb5754a271 PASSED
    energy threshold: 40.16330044843049 bogo-joules
    estimated energy: 37.66641002577397 bogo-joules
    noisiest task: 
        comm: rcu_preempt
        duration (abs): 0.00030419999984587776 s
        duration (rel): 0.030686161314524632 %
        pid: 10
```

note: When not nested, a single line is used. When more items are available, the multiline output is used automatically.
note2: The ResultBundle's UUID is now displayed, so its artifacts can be easily looked up in `<artifact dir>/BY_UUID/<UUID>`