### PR TITLE
lisa.utils: Add formatter when setup_logging(level=...) is used

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -582,21 +582,24 @@ def setup_logging(filepath='logging.conf', level=None):
 
     :param level: Override the conf file and force logging level. Defaults to
         ``logging.INFO``.
-    :type level: int
+    :type level: int or str
     """
     resolved_level = logging.INFO if level is None else level
-
-    # Load the specified logfile using an absolute path
-    if not os.path.isabs(filepath):
-        filepath = os.path.join(LISA_HOME, filepath)
 
     # Capture the warnings as log entries
     logging.captureWarnings(True)
 
-    # Set the level first, so the config file can override with more details
-    logging.getLogger().setLevel(resolved_level)
+    if level is not None:
+        log_format = '%(asctime)s %(levelname)-8s: %(name)-12s : %(message)s'
+        logging.basicConfig(level=resolved_level, format=log_format)
+    else:
+        # Load the specified logfile using an absolute path
+        if not os.path.isabs(filepath):
+            filepath = os.path.join(LISA_HOME, filepath)
 
-    if not level:
+        # Set the level first, so the config file can override with more details
+        logging.getLogger().setLevel(resolved_level)
+
         if os.path.exists(filepath):
             logging.config.fileConfig(filepath)
             logging.info('Using LISA logging configuration: {}'.format(filepath))

--- a/logging.conf
+++ b/logging.conf
@@ -5,7 +5,7 @@
 
 [logger_root]
 level=INFO
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler,DEBUGfileHandler,INFOfileHandler
 propagate=0
 
 ################################################################################
@@ -16,27 +16,29 @@ propagate=0
 #
 # For example, to enable debugging just for the module, you need to
 # uncomment the logger_TestEnv section and set:
+
 [loggers]
-keys=root,Target,WaResultsCollector
+keys=root
+#keys=root,Target,WaResultsCollector
 
-[logger_Target]
-qualname=lisa.target.Target
-level=INFO
-handlers=consoleHandler,fileHandler
-propagate=0
+# [logger_Target]
+# qualname=lisa.target.Target
+# level=INFO
+# handlers=consoleHandler,DEBUGfileHandler,INFOfileHandler
+# propagate=0
 
-[logger_WaResultsCollector]
-qualname=WaResultsCollector
-level=INFO
-handlers=consoleHandler,fileHandler
-propagate=0
+# [logger_WaResultsCollector]
+# qualname=WaResultsCollector
+# level=INFO
+# handlers=consoleHandler,DEBUGfileHandler,INFOfileHandler
+# propagate=0
 
 ################################################################################
 ### Handlers
 ################################################################################
 
 [handlers]
-keys=consoleHandler,fileHandler
+keys=consoleHandler,DEBUGfileHandler,INFOfileHandler
 
 [handler_consoleHandler]
 class=StreamHandler
@@ -44,9 +46,15 @@ level=DEBUG
 formatter=simpleFormatter
 args=(sys.stderr,)
 
-[handler_fileHandler]
+[handler_DEBUGfileHandler]
 class=FileHandler
 level=DEBUG
+formatter=simpleFormatter
+args=("lisa_debug.log",)
+
+[handler_INFOfileHandler]
+class=FileHandler
+level=INFO
 formatter=simpleFormatter
 args=("lisa.log",)
 


### PR DESCRIPTION
A formatter is needed when logging.conf is not used.