### PR TITLE
shell: Log the Python modules version with lisa-install

### DIFF
--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -267,6 +267,14 @@ function lisa-install {
 
     # Install additiona Jupyter Notebook extensions
     _lisa-install-nbextensions
+
+    local lisa_install_versions="$LISA_HOME/.lisa-install-versions"
+
+    # Log the version of all Python modules, so we know what is the faulty
+    # version when something goes wrong
+    LC_ALL=C date >> "$lisa_install_versions"
+    lisa-version >> "$lisa_install_versions"
+    _lisa-python -m pip freeze >> "$lisa_install_versions"
 }
 
 ################################################################################


### PR DESCRIPTION
To simplify debugging issues related to module versions, dump the list
of modules that were used and which version was used whenever
lisa-install is used.