### PR TITLE
lisa.wlgen.rta: Add RTA.resolve_trace_task_names()

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1101,27 +1101,8 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         If the task forked, the list will contain more than one item.
         """
         trace = self.get_trace(events=['sched_switch'])
-
-        prefix_regexps = {
-            prefix: re.compile(r"^{}(-[0-9]+)*$".format(re.escape(prefix)))
-            for prefix in self.rtapp_profile.keys()
-        }
-
-        comms = set(itertools.chain.from_iterable(trace.get_tasks().values()))
-        task_map = {
-            prefix: sorted(
-                comm
-                for comm in comms
-                if re.match(regexp, comm)
-            )
-            for prefix, regexp in prefix_regexps.items()
-        }
-
-        missing = sorted(prefix for prefix, comms in task_map.items() if not comms)
-        if missing:
-            raise RuntimeError("Missing tasks matching the following rt-app profile names: {}"
-                                .format(', '.join(missing)))
-        return task_map
+        names = sorted(self.rtapp_profile.keys())
+        return RTA.resolve_trace_task_names(trace, names)
 
     @property
     def cgroup_configuration(self):

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -806,6 +806,20 @@ class Trace(Loggable, TraceBase):
         """
         return self._task_pid_map
 
+    @property
+    @memoized
+    def task_ids(self):
+        """
+        List of all the :class:`TaskID` in the trace, sorted by PID.
+        """
+        key = lambda k_v: k_v[0]
+
+        return [
+            TaskID(pid=pid, comm=comm)
+            for pid, comms in sorted(self._task_pid_map.items(), key=key)
+            for comm in comms
+        ]
+
     def show(self):
         """
         Open the parsed trace using the most appropriate native viewer.


### PR DESCRIPTION
Allow resolving RTA profile names to task names as found in a trace. To avoid
filtering the trace again and again, cache the result in RTA.