### PR TITLE
lisa.tests.scheduler.eas_behaviour: Remove ResultBundle plat_info mon…

### DIFF
--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -330,8 +330,6 @@ class EASBehaviour(RTATestBundle):
         res.add_metric("estimated energy", est_energy, 'bogo-joules')
         res.add_metric("energy threshold", threshold, 'bogo-joules')
 
-        res.plat_info = self.plat_info
-
         return res
 
     @RTAEventsAnalysis.df_rtapp_stats.used_events


### PR DESCRIPTION
…key patching

A monkey patching debugging attribute assignment slipped in a previous commit.
Since plat_info can get pretty big (kernel config), remove it.