### PR TITLE
tools: Add lisa-execute-notebook

### DIFF
--- a/doc/lisa_shell/man/man.rst
+++ b/doc/lisa_shell/man/man.rst
@@ -73,6 +73,8 @@ Notebooks commands
       * - `PORT`
         - the tcp port for the server (default: 8888)
 
+* ``lisa-execute-notebook`` - Execute the given notebook as a script.
+
 Test commands
 -------------
 

--- a/doc/man1/lisa.1
+++ b/doc/man1/lisa.1
@@ -127,6 +127,8 @@ _
 .TE
 .UNINDENT
 .UNINDENT
+.IP \(bu 2
+\fBlisa\-execute\-notebook\fP \- Execute the given notebook as a script.
 .UNINDENT
 .SS Test commands
 .INDENT 0.0

--- a/tools/lisa-execute-notebook
+++ b/tools/lisa-execute-notebook
@@ -1,0 +1,11 @@
+# !/bin/bash
+
+ipynb=$1
+
+# piping straight to IPython seems to not work, so use a temporary file instead
+script=$(mktemp)
+cleanup() { rm "$script"; }
+trap cleanup EXIT
+
+jupyter nbconvert --to python --stdout "$ipynb"  > "$script" &&
+ipython3 "$script"


### PR DESCRIPTION
Execute a given notebook like a regular script using jupyter nbconvert and
ipython. Separate use of IPython is necessary since jupyter nbconvert --execute
is not able to print the output on its stdout like a regular script would.