### PR TITLE
Fix traces name/PID mapping

### DIFF
--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -138,8 +138,9 @@ class TestTrace(TraceTestCase):
         trace = self.make_trace(in_data)
 
         self.assertEqual(trace.get_task_pid_names(1234), ['father'])
-        self.assertEqual(trace.get_task_pid_names(5678), ['child'])
+        self.assertEqual(trace.get_task_pid_names(5678), ['father', 'child'])
         self.assertEqual(trace.get_task_name_pids('father'), [1234])
+        self.assertEqual(trace.get_task_name_pids('father', ignore_fork=False), [1234, 5678])
 
     def test_time_range(self):
         """


### PR DESCRIPTION
* Correctly handle task renames which was broken by recent use of extra sched_switch fields
* Correctly merge information from multiple events: always preserve trace appearance order across events.