### PR TITLE
exekall: Handle x.__module__ == None and x.__globals__ == None

### DIFF
--- a/tools/exekall/exekall/_utils.py
+++ b/tools/exekall/exekall/_utils.py
@@ -156,7 +156,7 @@ def get_name(obj, full_qual=True, qual=True, pretty=False):
         else:
             module_name = (
                 module_name + '.'
-                if module_name != '__main__' and module_name != 'builtins'
+                if module_name not in ('__main__', 'builtins', None)
                 else ''
             )
     else:

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -2360,7 +2360,7 @@ class Operator:
         """
         Returns a dictionnary of global variables as seen by the callable.
         """
-        globals_ = self.resolved_callable.__globals__
+        globals_ = self.resolved_callable.__globals__ or {}
         # Make sure the class name can be resolved
         if isinstance(self.callable_, UnboundMethod):
             globals_ = copy.copy(globals_)


### PR DESCRIPTION
pypy interpreter seems to sometimes set `__module__` and `__globals__` to
None. Handle gracefully both cases.