### PR TITLE
lisa.tests.base: Fix RTATestBundle.rtapp_tasks property

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1102,7 +1102,10 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         """
         trace = self.get_trace(events=['sched_switch'])
         names = sorted(self.rtapp_profile.keys())
-        return RTA.resolve_trace_task_names(trace, names)
+        return {
+            name: [task_id.comm for task_id in task_ids]
+            for name, task_ids in RTA.resolve_trace_task_names(trace, names).items()
+        }
 
     @property
     def cgroup_configuration(self):


### PR DESCRIPTION
Return a dict(str, list(str)) rather than a dict(str, list(TaskID))