### PR TITLE
[RFC] Use DataFrame.query() in df_filter_tasks()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,11 @@ setup(
         "ruamel.yaml >= 0.15.81",
         "docutils", # For the HTML output of analysis plots
 
+        # Recommended dependencies to speedup pandas
+        # https://pandas.pydata.org/pandas-docs/stable/install.html#install-recommended-dependencies
+        "numexpr >= 2.6.2",
+        "bottleneck >= 1.2.1",
+
         # Depdendencies that are shipped as part of the LISA repo as
         # subtree/submodule
         "devlib",


### PR DESCRIPTION
Allow using the query language of pandas for filtering dataframes. Since it can be slower for small input and lead to MemoryError or ValueError for very large queries, abstract over it to allow both regular indexing and query building.

TODO: If that is deemed to be an interesting feature, the query building blocks might be turned into classes with overloaded operators, so that it's possible to write code once and then choose the method of evaluation separately.