### PR TITLE
tests.test_conf: Use more realistic example for test_disallowed_val()

### DIFF
--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -111,7 +111,7 @@ class TestMultiSrcConf(TestMultiSrcConfBase):
 
     def test_disallowed_val(self):
         with self.assertRaises(TypeError):
-            self.conf.add_src('bar', ['a', 'b'])
+            self.conf.add_src('bar', {'foo': ['a', 'b']})
 
     def test_multitypes(self):
         conf = copy.deepcopy(self.conf)


### PR DESCRIPTION
User-provided top-level input can be expected to be mappings. What validation is
really about is checking types of values for each key.