### PR TITLE
lisa.tests.base: Cache trace property for at most 10 TestBundle at a …

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -44,7 +44,7 @@ from lisa.wlgen.rta import RTA
 from lisa.target import Target
 
 from lisa.utils import (
-    Serializable, memoized, ArtifactPath, non_recursive_property,
+    Serializable, memoized, lru_memoized, ArtifactPath, non_recursive_property,
     update_wrapper_doc, ExekallTaggable, annotations_from_signature,
     nullcontext,
 )
@@ -1140,7 +1140,8 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         return self.get_cgroup_configuration(self.plat_info)
 
     @non_recursive_property
-    @memoized
+    # Only cache the trace of N bundles at a time, to avoid running out of memory
+    @lru_memoized(first_param_maxsize=10)
     def trace(self):
         """
         :returns: a :class:`lisa.trace.TraceView` cropped to fit the ``rt-app``


### PR DESCRIPTION
…time

The `trace` property of TestBundle will only be cached for a small number of
TestBundle. This avoids running out of memory when manipulating a large amount
of TestBundle. This can happen in long-running exekall processes that keep
references to TestBundle alive for results display and serialization.