### PR TITLE
Update CPU capacities while running rt-app

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1361,7 +1361,7 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         return '/' + cg.name
 
     @classmethod
-    def run_rtapp(cls, target, res_dir, profile=None, ftrace_coll=None, cg_cfg=None, wipe_run_dir=True):
+    def run_rtapp(cls, target, res_dir, profile=None, ftrace_coll=None, cg_cfg=None, wipe_run_dir=True, update_cpu_capacities=None):
         """
         Run the given RTA profile on the target, and collect an ftrace trace.
 
@@ -1390,6 +1390,11 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         :param wipe_run_dir: Remove the run directory on the target after
             execution of the workload.
         :type wipe_run_dir: bool
+
+        :param update_cpu_capacities: Attempt to update the CPU capacities
+            based on the calibration values of rtapp to get the most accurate
+            reproduction of duty cycles.
+        :type update_cpu_capacities: bool
         """
 
         trace_path = ArtifactPath.join(res_dir, cls.TRACE_PATH)
@@ -1418,7 +1423,7 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         target.plat_info['rtapp']['calib']
 
         with wload_cm, dmesg_coll, ftrace_coll, target.freeze_userspace():
-            wload.run(cgroup=cgroup, as_root=as_root)
+            wload.run(cgroup=cgroup, as_root=as_root, update_cpu_capacities=update_cpu_capacities)
 
         ftrace_coll.get_trace(trace_path)
         dmesg_coll.get_trace(dmesg_path)

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -367,7 +367,6 @@ class InvarianceItem(LoadTrackingBase, ExekallTaggable):
         # fact that the util signal stays high while the task sleeps
         settled_signal_mean = series_tunnel_mean(df[signal_name])
         expected_signal_mean = expected_final_util
-        expected_signal_mean = self.correct_expected_pelt(self.plat_info, cpu, expected_signal_mean)
 
         signal_mean_error_pct = abs(expected_signal_mean - settled_signal_mean) / UTIL_SCALE * 100
         res = ResultBundle.from_bool(signal_mean_error_pct < error_margin_pct)
@@ -889,7 +888,6 @@ class CPUMigrationBase(LoadTrackingBase):
 
             for i, phase in enumerate(self.reference_task.phases):
                 expected_util = expected_cpu_util[cpu][i]
-                expected_util = self.correct_expected_pelt(self.plat_info, cpu, expected_util)
                 trace_util = trace_cpu_util[cpu][i]
                 if not self.is_almost_equal(
                         trace_util,

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -528,7 +528,7 @@ class RTA(Workload):
             logger.warning('The calibration values are not inversely proportional to the CPU capacities, the duty cycles will be up to {:.2f}% off on some CPUs: {}'.format(dispersion_pct, capa_factors_pct))
 
         if dispersion_pct > 20:
-            raise CalibrationError('The calibration values are not inversely proportional to the CPU capacities. Either rt-app calibration failed, or the rt-app busy loops has a very different instruction mix compared to the workload used to establish the CPU capacities: {}'.format(capa_factors_pct))
+            logger.warning('The calibration values are not inversely proportional to the CPU capacities. Either rt-app calibration failed, or the rt-app busy loops has a very different instruction mix compared to the workload used to establish the CPU capacities: {}'.format(capa_factors_pct))
 
         # Map of CPUs X to list of CPUs Ys that are faster than it although CPUs
         # of Ys have a smaller capacity than X


### PR DESCRIPTION
Allow rt-app to run with actual CPU invariant utilization.

TODO: check the CPUMigration test debug plot to make sure there is no change in util value when migrating the same task.