### PR TITLE
install_base.sh: Install node-gyp to allow installing npm

### DIFF
--- a/install_base.sh
+++ b/install_base.sh
@@ -266,7 +266,9 @@ for arg in "$@"; do
             apt_packages+=(snapd)
             install_functions+=(install_nodejs_snap)
         else
-            apt_packages+=(nodejs npm)
+            # node-gyp seems to be required other apt fails to install npm on
+            # some versions of ubuntu
+            apt_packages+=(nodejs node-gyp npm)
             pacman_packages+=(nodejs npm)
         fi
         handled=1;


### PR DESCRIPTION
On some versions of Ubuntu, installing node-gyp is required.