### PR TITLE
install_base.sh: Install sshpass

### DIFF
--- a/install_base.sh
+++ b/install_base.sh
@@ -142,6 +142,7 @@ apt_packages=(
     build-essential
     git
     openssh-client
+    sshpass
     wget
     unzip
     kernelshark
@@ -160,6 +161,7 @@ pacman_packages=(
     coreutils
     git
     openssh
+    sshpass
     base-devel
     wget
     unzip


### PR DESCRIPTION
Since it's required by devlib to connect to ssh targets with password
auth.