### PR TITLE
logging: Log full strings rather than relying on logging.XXX() interp…

### DIFF
--- a/lisa/analysis/frequency.py
+++ b/lisa/analysis/frequency.py
@@ -368,9 +368,9 @@ class FrequencyAnalysis(TraceAnalysisBase):
         if "freqs" in self.trace.plat_info:
             frequencies = self.trace.plat_info['freqs'][cpu]
         else:
-            logger.info("Estimating CPU%s frequencies from trace", cpu)
+            logger.info("Estimating CPU{} frequencies from trace".format(cpu))
             frequencies = sorted(list(df.frequency.unique()))
-            logger.debug("Estimated frequencies: %s", frequencies)
+            logger.debug("Estimated frequencies: {}".format(frequencies))
 
         avg = self.get_average_cpu_frequency(cpu)
         logger.info(

--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -401,7 +401,7 @@ class EnergyModel(Serializable, Loggable):
         max_cap = max(n.max_capacity for n in self.cpu_nodes)
         if max_cap != self.capacity_scale:
             logger.debug(
-                'Unusual max capacity (%s), overriding capacity_scale', max_cap)
+                'Unusual max capacity ({}), overriding capacity_scale'.format(max_cap))
             self.capacity_scale = max_cap
 
     def _cpus_with_capacity(self, cap):
@@ -725,8 +725,9 @@ class EnergyModel(Serializable, Loggable):
 
         logger = self.get_logger()
         logger.debug(
-            '%14s - Searching %d configurations for optimal task placement...',
-            'EnergyModel', num_candidates)
+            'Searching {} configurations for optimal task placement...'.format(
+            num_candidates
+        ))
 
         candidates = {}
         excluded = []
@@ -762,7 +763,7 @@ class EnergyModel(Serializable, Loggable):
         min_power = min(p for p in iter(candidates.values()))
         ret = [u for u, p in candidates.items() if p == min_power]
 
-        logger.debug('%14s - Done', 'EnergyModel')
+        logger.debug('done')
         return ret
 
     @classmethod

--- a/lisa/platforms/platinfo.py
+++ b/lisa/platforms/platinfo.py
@@ -131,7 +131,7 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
         try:
             return EnergyModel.from_target(target)
         except (TargetStableError, RuntimeError, ValueError) as err:
-            logger.error("Couldn't read target energy model: %s", err)
+            logger.error("Couldn't read target energy model: {}".format(err))
             return None
 
     @classmethod

--- a/lisa/target.py
+++ b/lisa/target.py
@@ -255,7 +255,7 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
             # Make a copy of the PlatformInfo so we don't modify the original
             # one we were passed when adding the target source to it
             plat_info = copy.copy(plat_info)
-            logger.info('User-defined platform information:\n%s', plat_info)
+            logger.info('User-defined platform information:\n{}'.format(plat_info))
 
         self.plat_info = plat_info
 
@@ -285,7 +285,7 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
 
         # Initialize binary tools to deploy
         if tools:
-            logger.info('Tools to install: %s', tools)
+            logger.info('Tools to install: {}'.format(tools))
             self.install_tools(tools)
 
         # Autodetect information from the target, after the Target is
@@ -603,9 +603,9 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
         else:
             raise ValueError('Unsupported platform type {}'.format(kind))
 
-        logger.info('%s %s target connection settings:', kind, name)
+        logger.info('{} {} target connection settings:'.format(kind, name))
         for key, val in conn_settings.items():
-            logger.info('    %s: %s', key, val)
+            logger.info('    {}: {}'.format(key, val))
 
         ########################################################################
         # Devlib Platform configuration
@@ -643,10 +643,10 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
 
         logger.debug('Checking target connection...')
         logger.debug('Target info:')
-        logger.debug('      ABI: %s', target.abi)
-        logger.debug('     CPUs: %s', target.cpuinfo)
-        logger.debug(' clusters: %s', target.core_clusters)
-        logger.debug('  workdir: %s', target.working_directory)
+        logger.debug('      ABI: {}'.format(target.abi))
+        logger.debug('     CPUs: {}'.format(target.cpuinfo))
+        logger.debug(' clusters: {}'.format(target.core_clusters))
+        logger.debug('  workdir: {}'.format(target.working_directory))
 
         target.setup()
 
@@ -703,7 +703,7 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
             res_dir = ArtifactPath(root, os.path.join(relative, name))
 
             # Compute base installation path
-            logger.info('Creating result directory: %s', str(res_dir))
+            logger.info('Creating result directory: {}'.format(res_dir))
 
             # It will fail if the folder already exists. In that case,
             # append_time should be used to ensure we get a unique name.
@@ -785,7 +785,7 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
 
                 @contextlib.contextmanager
                 def cm():
-                    logger.info('Freezing all tasks except: %s', ','.join(exclude))
+                    logger.info('Freezing all tasks except: {}'.format(','.join(exclude)))
                     try:
                         yield self.target.cgroups.freeze(exclude)
                     finally:

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -343,7 +343,7 @@ class Trace(Loggable, TraceBase):
             max_cpu = max(int(self.df_events(e)['__cpu'].max())
                           for e in self.available_events)
             count = max_cpu + 1
-            self.get_logger().info("Estimated CPU count from trace: %s", count)
+            self.get_logger().info("Estimated CPU count from trace: {}".format(count))
             return count
 
     @deprecate('Direct access to underlying ftrace object is discouraged as this is now an implementation detail of that class which could change in the future',
@@ -475,8 +475,7 @@ class Trace(Loggable, TraceBase):
         :type trace_format: str
         """
         logger = self.get_logger()
-        logger.debug('Loading [sched] events from trace in [%s]...', path)
-        logger.debug('Parsing events: %s', self.events)
+        logger.debug('Parsing events {} from trace: {}'.format(self.events, path))
         if trace_format.upper() == 'SYSTRACE' or path.endswith('html'):
             logger.debug('Parsing SysTrace format...')
             trace_class = trappy.SysTrace
@@ -529,8 +528,6 @@ class Trace(Loggable, TraceBase):
             if not obj.data_frame.empty:
                 available_events.append(val)
         logger.debug('Events found on trace: {}'.format(', '.join(available_events)))
-        for evt in available_events:
-            logger.debug(' - %s', evt)
         return available_events
 
     @memoized
@@ -647,8 +644,8 @@ class Trace(Loggable, TraceBase):
         self.end = self.start + duration
         self.time_range = self.end - self.start
 
-        self.get_logger().debug('Trace contains events from %s to %s',
-                                self.start, self.end)
+        self.get_logger().debug('Trace contains events from {} to {}'.format(
+            self.start, self.end))
 
     def get_task_name_pids(self, name, ignore_fork=True):
         """
@@ -1088,12 +1085,12 @@ class Trace(Loggable, TraceBase):
                 for cpus in domains:
                     dl_freqs = dl_df[dl_df.cpu.isin(cpus)]
                     os_freqs = os_df[os_df.cpu.isin(cpus)]
-                    logger.debug("First freqs for %s:\n%s", cpus, dl_freqs)
+                    logger.debug("First freqs for {}:\n{}".format(cpus, dl_freqs))
                     # All devlib events "before" os-generated events
-                    logger.debug("Min os freq @: %s", os_freqs.index.min())
+                    logger.debug("Min os freq @: {}".format(os_freqs.index.min()))
                     if os_freqs.empty or \
                        os_freqs.index.min() > dl_freqs.index.max():
-                        logger.debug("Insert devlib freqs for %s", cpus)
+                        logger.debug("Insert devlib freqs for {}".format(cpus))
                         df = pd.concat([dl_freqs, df])
 
                 # Inject "final" devlib frequencies
@@ -1102,12 +1099,12 @@ class Trace(Loggable, TraceBase):
                 for cpus in domains:
                     dl_freqs = dl_df[dl_df.cpu.isin(cpus)]
                     os_freqs = os_df[os_df.cpu.isin(cpus)]
-                    logger.debug("Last freqs for %s:\n%s", cpus, dl_freqs)
+                    logger.debug("Last freqs for {}:\n{}".format(cpus, dl_freqs))
                     # All devlib events "after" os-generated events
-                    logger.debug("Max os freq @: %s", os_freqs.index.max())
+                    logger.debug("Max os freq @: {}".format(os_freqs.index.max()))
                     if os_freqs.empty or \
                        os_freqs.index.max() < dl_freqs.index.min():
-                        logger.debug("Append devlib freqs for %s", cpus)
+                        logger.debug("Append devlib freqs for {}".format(cpus))
                         df = pd.concat([df, dl_freqs])
 
                 df.sort_index(inplace=True)

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -183,7 +183,7 @@ class RTA(Workload):
 
         if not self.log_stats:
             return
-        logger.debug('Pulling logfiles to [%s]...', self.res_dir)
+        logger.debug('Pulling logfiles to: {}'.format(self.res_dir))
         for task in self.tasks:
             # RT-app appends some number to the logs, so we can't predict the
             # exact filename
@@ -298,7 +298,7 @@ class RTA(Workload):
         }
 
         if max_duration_s:
-            logger.warning('Limiting workload duration to %d [s]', max_duration_s)
+            logger.warning('Limiting workload duration to {} [s]'.format(max_duration_s))
 
         if default_policy:
             if default_policy in self.sched_policies:
@@ -306,8 +306,8 @@ class RTA(Workload):
             else:
                 raise ValueError('scheduling class {} not supported'.format(default_policy))
 
-        logger.info('Calibration value: %s', global_conf['calibration'])
-        logger.info('Default policy: %s', global_conf['default_policy'])
+        logger.info('Calibration value: {}'.format(global_conf['calibration']))
+        logger.info('Default policy: {}'.format(global_conf['default_policy']))
 
         rta_profile['global'] = global_conf
 
@@ -325,13 +325,13 @@ class RTA(Workload):
                 sched_descr = 'sched: {}'.format(task.sched_policy)
 
             logger.info('------------------------')
-            logger.info('task [%s], %s', tid, sched_descr)
+            logger.info('task [{}], {}'.format(tid, sched_descr))
 
             task_conf['delay'] = int(task.delay_s * 1e6)
-            logger.info(' | start delay: %.6f [s]', task.delay_s)
+            logger.info(' | start delay: {:.6f} [s]'.format(task.delay_s))
 
             task_conf['loop'] = task.loops
-            logger.info(' | loops count: %d', task.loops)
+            logger.info(' | loops count: {}'.format(task.loops))
 
             task_conf['phases'] = OrderedDict()
             rta_profile['tasks'][tid] = task_conf
@@ -441,7 +441,7 @@ class RTA(Workload):
         # Create calibration task
         if target.is_rooted:
             max_rtprio = int(target.execute('ulimit -Hr').split('\r')[0])
-            logger.debug('Max RT prio: %d', max_rtprio)
+            logger.debug('Max RT prio: {}'.format(max_rtprio))
 
             priority = max_rtprio if max_rtprio <= 10 else 10
             sched_policy = 'FIFO'
@@ -451,7 +451,7 @@ class RTA(Workload):
             sched_policy = None
 
         for cpu in target.list_online_cpus():
-            logger.info('CPU%d calibration...', cpu)
+            logger.info('CPU{} calibration...'.format(cpu))
 
             # RT-app will run a calibration for us, so we just need to
             # run a dummy task and read the output
@@ -477,9 +477,9 @@ class RTA(Workload):
                 if pload_match is None:
                     continue
                 pload[cpu] = int(pload_match.group(1))
-                logger.debug('>>> cpu%d: %d', cpu, pload[cpu])
+                logger.debug('>>> CPU{}: {}'.format(cpu, pload[cpu]))
 
-        logger.info('Target RT-App calibration: %s', pload)
+        logger.info('Target RT-App calibration: {}'.format(pload))
 
         plat_info = target.plat_info
 
@@ -676,7 +676,7 @@ class Phase(Loggable):
     :param period_ms: the phase period in [ms].
     :type period_ms: int
 
-    :param duty_cycle_pct: the generated load in [%].
+    :param duty_cycle_pct: the generated load in percents.
     :type duty_cycle_pct: numbers.Number
 
     :param cpus: the CPUs on which task execution is restricted during this phase.
@@ -718,14 +718,14 @@ class Phase(Loggable):
 
         # A duty-cycle of 0[%] translates to a 'sleep' phase
         if self.duty_cycle_pct == 0:
-            logger.info(' | sleep %.6f [s]', duration / 1e6)
+            logger.info(' | sleep {:.6f} [s]'.format(duration / 1e6))
 
             phase['loop'] = 1
             phase['sleep'] = duration
 
         # A duty-cycle of 100[%] translates to a 'run-only' phase
         elif self.duty_cycle_pct == 100:
-            logger.info(' | batch %.6f [s]', duration / 1e6)
+            logger.info(' | batch {:.6f} [s]'.format(duration / 1e6))
 
             phase['loop'] = 1
             phase['run'] = duration
@@ -746,12 +746,12 @@ class Phase(Loggable):
             # https://github.com/scheduler-tools/rt-app/issues/82
             running_time = int(period - sleep_time)
 
-            logger.info(' | duration %.6f [s] (%d loops)',
-                        duration / 1e6, cloops)
-            logger.info(' |  period   %6d [us], duty_cycle %3d %%',
-                        period, self.duty_cycle_pct)
-            logger.info(' |  run_time %6d [us], sleep_time %6d [us]',
-                        running_time, sleep_time)
+            logger.info(' | duration {:.6f} [s] ({} loops)'.format(
+                        duration / 1e6, cloops))
+            logger.info(' |  period   {:>3} [us], duty_cycle {:>3,.2f} %'.format(
+                        int(period), self.duty_cycle_pct))
+            logger.info(' |  run_time {:>6} [us], sleep_time {:>6} [us]'.format(
+                        int(running_time), int(sleep_time)))
 
             phase['loop'] = cloops
             phase['run'] = running_time
@@ -762,11 +762,11 @@ class Phase(Loggable):
 
         if self.uclamp_min is not None:
             phase['util_min'] = self.uclamp_min
-            logger.info(' | util_min %7d', self.uclamp_min)
+            logger.info(' | util_min {:>7}'.format(self.uclamp_min))
 
         if self.uclamp_max is not None:
             phase['util_max'] = self.uclamp_max
-            logger.info(' | util_max %7d', self.uclamp_max)
+            logger.info(' | util_max {:>7}'.format(self.uclamp_max))
 
         return phase
 

--- a/lisa/wlgen/workload.py
+++ b/lisa/wlgen/workload.py
@@ -95,7 +95,7 @@ class Workload(Loggable):
                                       quote(wlgen_dir), quote(temp_fmt))).strip()
 
         logger = self.get_logger()
-        logger.info("Creating target's run directory: %s", self.run_dir)
+        logger.info("Creating target's run directory: {}".format(self.run_dir))
 
         res_dir = res_dir if res_dir else target.get_res_dir(
             name='{}-{}'.format(self.__class__.__qualname__, name)
@@ -169,7 +169,7 @@ class Workload(Loggable):
 
         _command = 'cd {} && {}'.format(quote(self.run_dir), _command)
 
-        logger.info("Execution start: %s", _command)
+        logger.info("Execution start: {}".format(_command))
 
         if background:
             target.background(_command, as_root=as_root)
@@ -178,7 +178,7 @@ class Workload(Loggable):
             logger.info("Execution complete")
 
             logfile = ArtifactPath.join(self.res_dir, 'output.log')
-            logger.debug('Saving stdout to %s...', logfile)
+            logger.debug('Saving stdout to {}...'.format(logfile))
 
             with open(logfile, 'w') as ofile:
                 ofile.write(self.output)


### PR DESCRIPTION
…olation

This allows easier replacement of the logger objects with some custom subclass
adding extra behaviors. When LISA starts requiring Python >= 3.6, we will be
able to get rid of all the annoying explicit calls to str.format() and use
f-string instead.