### PR TITLE
bisector: Use gzip compression for LISA-test artifacts

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -1913,7 +1913,7 @@ class LISATestStep(ShellStep):
                 info('Compressing exekall artifact directory {} ...'.format(artifact_path))
                 archive_name = shutil.make_archive(
                     base_name=artifact_path,
-                    format='xztar',
+                    format='gztar',
                     root_dir=os.path.join(artifact_path, '..'),
                     base_dir=os.path.split(artifact_path)[-1],
                 )


### PR DESCRIPTION
Speed up compression by using gzip archive instead of xz.