### PR TITLE
Plot task activations with one row per CPU (kernelshark style)

### DIFF
--- a/doc/plot_conf.yml
+++ b/doc/plot_conf.yml
@@ -34,6 +34,7 @@ doc-plot-conf:
             kwargs:
                 task: *task
                 duration: True
+                which_cpu: True
 
         LoadTrackingAnalysis.plot_task_signals:
             kwargs:

--- a/lisa/analysis/tasks.py
+++ b/lisa/analysis/tasks.py
@@ -851,13 +851,14 @@ class TasksAnalysis(TraceAnalysisBase):
             if duty_cycle:
                 df['duty_cycle'].plot(ax=axis, drawstyle='steps-post', label='Duty cycle of {}'.format(task))
 
-            for active, label in (
-                    (active_value, 'Activations'),
-                    (sleep_value, 'Sleep')
-                ):
-                duration = df[df['active'] == active]['duration']
-                # Add blanks in the plot when the state is not the one we care about
-                duration = duration.reindex_like(df)
-                duration.plot(ax=axis, drawstyle='steps-post', label='{} duration of {}'.format(label, task))
+            if duration:
+                for active, label in (
+                        (active_value, 'Activations'),
+                        (sleep_value, 'Sleep')
+                    ):
+                    duration_series = df[df['active'] == active]['duration']
+                    # Add blanks in the plot when the state is not the one we care about
+                    duration_series = duration_series.reindex_like(df)
+                    duration_series.plot(ax=axis, drawstyle='steps-post', label='{} duration of {}'.format(label, task))
 
 # vim :set tabstop=4 shiftwidth=4 expandtab textwidth=80


### PR DESCRIPTION
On a standalone plot:
![Figure_1](https://user-images.githubusercontent.com/23336875/69769194-bdbab180-117b-11ea-84b0-7595713cb91b.png)

As an overlay on top of util and load signals:
![Figure_2](https://user-images.githubusercontent.com/23336875/69769304-2e61ce00-117c-11ea-8c4a-c5a5a7cfa6c6.png)

