### PR TITLE
Allow interactive df display linked to a plot widget

### DIFF
--- a/doc/misc_utilities.rst
+++ b/doc/misc_utilities.rst
@@ -31,6 +31,12 @@ Dataframe and Series handling utilities
 .. automodule:: lisa.datautils
    :members:
 
+Interactive notebooks utilities
+===============================
+
+.. automodule:: lisa.notebook
+   :members:
+
 PELT signals simulations
 ========================
 

--- a/lisa/analysis/base.py
+++ b/lisa/analysis/base.py
@@ -27,6 +27,7 @@ import contextlib
 import warnings
 import itertools
 from operator import itemgetter
+from collections.abc import Sequence
 
 import numpy
 import matplotlib
@@ -37,6 +38,7 @@ from cycler import cycler as make_cycler
 
 from lisa.utils import Loggable, get_subclasses, get_doc_url, get_short_doc, split_paragraphs, update_wrapper_doc, guess_format, is_running_ipython, nullcontext
 from lisa.trace import MissingTraceEventError
+from lisa.notebook import axis_link_dataframes
 
 # Colorblind-friendly cycle, see https://gist.github.com/thriveth/8560036
 COLOR_CYCLES = [
@@ -66,7 +68,7 @@ class AnalysisHelpers(Loggable, abc.ABC):
         pass
 
     @classmethod
-    def setup_plot(cls, width=16, height=4, ncols=1, nrows=1, interactive=None, **kwargs):
+    def setup_plot(cls, width=16, height=4, ncols=1, nrows=1, interactive=None, link_dataframes=None, **kwargs):
         """
         Common helper for setting up a matplotlib plot
 
@@ -111,6 +113,18 @@ class AnalysisHelpers(Loggable, abc.ABC):
         else:
             figure = Figure(figsize=(width, height * nrows))
             axes = figure.subplots(ncols=ncols, nrows=nrows, **kwargs)
+
+        if link_dataframes:
+            if not interactive:
+                cls.get_logger().error('Dataframes can only be linked to axes in interactive widget plots')
+            else:
+                if isinstance(axes, Sequence):
+                    ax_list = axes
+                else:
+                    ax_list = [axes]
+
+                for axis in ax_list:
+                    axis_link_dataframes(axis, link_dataframes)
 
         # Needed for multirow plots to not overlap with each other
         figure.set_tight_layout(dict(h_pad=3.5))

--- a/lisa/notebook.py
+++ b/lisa/notebook.py
@@ -22,6 +22,20 @@ import functools
 from ipywidgets import widgets, Output, HBox, Layout, interact
 from IPython.display import display
 
+class WrappingHBox(widgets.HBox):
+    """
+    HBox that will overflow on multiple lines if the content is too large to
+    fit on one line.
+    """
+    def __init__(self, *args, **kwargs):
+        layout = Layout(
+            # Overflow items to the next line rather than hiding them
+            flex_flow='row wrap',
+            # Evenly spread on one line of items
+            justify_content='space-around',
+        )
+        super().__init__(*args, layout=layout, **kwargs)
+
 def axis_link_dataframes(axis, df_list, before=1, after=5, cursor_color='red', follow_cursor=False):
     """
     Link some dataframes to an axis displayed in the interactive matplotlib widget.

--- a/lisa/notebook.py
+++ b/lisa/notebook.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2019, Arm Limited and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Various utilities for interactive notebooks.
+"""
+
+from ipywidgets import widgets, Output, HBox, Layout
+from IPython.display import display
+
+def axis_link_dataframes(axis, df_list, before=1, after=5, cursor_color='red', follow_cursor=False):
+    """
+    Link some dataframes to an axis displayed in the interactive matplotlib widget.
+
+
+    :param axis: Axis to link to.
+    :type axis: matplotlib.axes.Axes
+
+    :param df_list: List of pandas dataframe to link.
+    :type df_list: list(pandas.DataFrame)
+
+    :param before: Number of dataframe rows to display before the selected
+        location.
+    :type before: int
+
+    :param after: Number of dataframe rows to display after the selected
+        location.
+    :type after: int
+
+    :param cursor_color: Color of the vertical line added at the clicked
+        location.
+    :type cursor_color: str
+
+    :param follow_cursor: If ``True``, the cursor will be followed without the
+        need to click.
+    :type follow_cursor: bool
+
+    When the user clicks on the graph, a vertical marker will appear and the
+    dataframe slice will update to show the relevant row.
+
+    .. note:: This requires the matplotlib widget enabled using ``%matplotlib
+        widget`` magic.
+    """
+    output_list = [widgets.Output() for df in df_list]
+    layout = Layout(
+        # Overflow items to the next line rather than hiding them
+        flex_flow='row wrap',
+        # Evenly spread on one line of item when there is more than one item,
+        # align left otherwise
+        justify_content='space-around' if len(df_list) > 1 else 'flex-start',
+    )
+    hbox = widgets.HBox(output_list, layout=layout)
+    cursor_vline = axis.axvline(color=cursor_color)
+
+    def show_loc(loc):
+        cursor_vline.set_xdata(loc)
+
+        for df, output in zip(df_list, output_list):
+            if loc < df.index[0]:
+                iloc = 0
+            elif loc > df.index[-1]:
+                iloc = -1
+            else:
+                iloc = df.index.get_loc(loc, method='ffill')
+            index_loc = df.index[iloc]
+
+            begin = max(iloc - before, 0)
+            end = min(iloc + after, len(df))
+            sliced_df = df.iloc[begin:end]
+
+            def highlight_row(row):
+                if row.name == index_loc:
+                    return ['background: lightblue'] * len(row)
+                else:
+                    return [''] * len(row)
+
+            styler = sliced_df.style.apply(highlight_row, axis=1)
+            styler = styler.set_properties(**{
+                'text-align': 'left',
+                # perserve multiple consecutive spaces
+                'white-space': 'pre',
+                # Make sure all chars have the same width to preserve column
+                # alignments in preformatted strings
+                'font-family': 'monospace',
+            })
+
+
+            # wait=True avoids flicker by waiting for new content to be ready
+            # to display before clearing the previous one
+            output.clear_output(wait=True)
+            with output:
+                display(styler)
+
+    init_loc = min(df.index[0] for df in df_list)
+    show_loc(init_loc)
+
+    def handler(event):
+        loc = event.xdata
+        return show_loc(loc)
+
+    event = 'motion_notify_event' if follow_cursor else 'button_press_event'
+    axis.get_figure().canvas.mpl_connect('button_press_event', handler)
+    display(hbox)
+
+
+# vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/notebook.py
+++ b/lisa/notebook.py
@@ -112,7 +112,6 @@ def axis_link_dataframes(axis, df_list, before=1, after=5, cursor_color='red', f
                 'font-family': 'monospace',
             })
 
-
             # wait=True avoids flicker by waiting for new content to be ready
             # to display before clearing the previous one
             output.clear_output(wait=True)


### PR DESCRIPTION
That should solve the long standing annoyance of going back and forth between kernelshark and the notebook when one needs to look at the exact events in a dataframe at a given time:

![image](https://user-images.githubusercontent.com/23336875/69834145-80642b80-1230-11ea-83f9-e8e42ccbcb92.png)


For good measure, also add an easy way to select the task to look at using a dropdown:
![image](https://user-images.githubusercontent.com/23336875/69835028-66c5e280-1236-11ea-9203-ea798dcd162b.png)

And to finish the basic UI, add an "open in kernelshark" button next to every figure that analysis plot methods touch:
![image](https://user-images.githubusercontent.com/23336875/69835902-cd4dff00-123c-11ea-9bbb-cc4ae580f759.png)

Kernelshark can unfortunately not zoom in the trace from the command line, it needs a session file that needs to contain lots of other info, and is a bit picky about what makes it happy and what makes it segfault.