### PR TITLE
setup.py: Add ipython to doc dependencies

### DIFF
--- a/lisa/doc/helpers.py
+++ b/lisa/doc/helpers.py
@@ -138,6 +138,7 @@ class RunCommandDirective(RecursiveDirective):
         check = False if 'ignore-error' in options else True
 
         cmd = '\n'.join(self.content)
+
         out = subprocess.run(
             cmd, shell=True, check=check,
             stdout=subprocess.PIPE, stderr=stderr,

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,8 @@ setup(
             "sphinx_rtd_theme",
             "sphinxcontrib-plantuml",
             "nbsphinx",
+            # necessary to import some modules
+            "ipython",
         ],
 
         "test": [


### PR DESCRIPTION
Since it's necessary to import some modules, make sure to have it installed to
build the doc.