### PR TITLE
lisa.pelt: Change pelt_settling_time(margin=...) parameter

### DIFF
--- a/lisa/pelt.py
+++ b/lisa/pelt.py
@@ -154,12 +154,11 @@ def simulate_pelt(activations, init=0, index=None, clock=None, window=PELT_WINDO
     return df['pelt']
 
 
-def pelt_settling_time(margin_pct=1, init=0, final=1024, window=PELT_WINDOW, half_life=PELT_HALF_LIFE):
+def pelt_settling_time(margin=1, init=0, final=PELT_SCALE, window=PELT_WINDOW, half_life=PELT_HALF_LIFE, scale=PELT_SCALE):
     """
     Compute an approximation of the PELT settling time.
 
-    :param margin_pct: How close to the final value we want to get, as a
-        percentage of ``final``.
+    :param margin: How close to the final value we want to get, in PELT units.
     :type margin_pct: float
 
     :param init: Initial PELT value.
@@ -204,12 +203,11 @@ def pelt_settling_time(margin_pct=1, init=0, final=1024, window=PELT_WINDOW, hal
 
     # Since the equation we have is for a step response, i.e. from 0 to a final
     # value
-    if init > final:
-        init, final = final, init
-    final -= init
-
-    margin = margin_pct / 100
-    A = 1 - margin
+    delta = abs(final - init)
+    # Since margin and delta are in the same unit, we don't have to normalize
+    # them to `scale` first.
+    relative_margin = (margin / delta)
+    A = 1 - relative_margin
 
     settling_time = - tau * math.log(1 - A)
     return settling_time

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -34,7 +34,7 @@ from lisa.pelt import PELT_SCALE, simulate_pelt, pelt_settling_time
 
 UTIL_SCALE = PELT_SCALE
 
-UTIL_CONVERGENCE_TIME_S = pelt_settling_time(0.1, init=0, final=1024)
+UTIL_CONVERGENCE_TIME_S = pelt_settling_time(1, init=0, final=1024)
 """
 Time in seconds for util_avg to converge (i.e. ignored time)
 """
@@ -357,7 +357,7 @@ class InvarianceItem(LoadTrackingBase, ExekallTaggable):
 
         expected_duty_cycle_pct = phase.duty_cycle_pct
         expected_final_util = expected_duty_cycle_pct / 100 * UTIL_SCALE
-        settling_time = pelt_settling_time(1, init=0, final=expected_final_util)
+        settling_time = pelt_settling_time(10, init=0, final=expected_final_util)
         settling_time += df.index[0]
 
         df = df[settling_time:]


### PR DESCRIPTION
Remove margin_pct and introduce margin, expressed in PELT units. This restores
the dependency of the result on the init and final values.