### PR TITLE
lisa.tests.base: Add a buffer phase to all workloads of RTATestBundle

### DIFF
--- a/lisa/analysis/rta.py
+++ b/lisa/analysis/rta.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 import pandas as pd
 
 from lisa.analysis.base import AnalysisHelpers, TraceAnalysisBase
-from lisa.datautils import df_filter_task_ids, df_window
+from lisa.datautils import df_filter_task_ids, df_window, df_split_signals
 from lisa.trace import TaskID, requires_events, requires_one_event_of, may_use_events, MissingTraceEventError
 from lisa.utils import memoized, deprecate
 from lisa.analysis.tasks import TasksAnalysis
@@ -487,40 +487,23 @@ class RTAEventsAnalysis(TraceAnalysisBase):
         :returns: A :class:`pandas.DataFrame` with index representing the
             start time of a phase and these column:
 
+                * ``phase``: the phase number.
                 * ``duration``: the measured phase duration.
         """
-        # Mark for removal all the events that are not the first 'start'
-        def keep_first_start(raw):
-            if raw.phase_loop:
-                return -1
-            if raw.event == 'end':
-                return -1
-            return 0
+        def get_duration(phase, df):
+            start = df.index[0]
+            end = df.index[-1]
+            duration = end - start
+            return (start, {'phase': phase, 'duration': duration})
 
         loops_df = self.df_rtapp_loop(task)
+        durations = sorted(
+            get_duration(cols['phase'], df)
+            for cols, df in df_split_signals(loops_df, ['phase'])
+        )
 
-        # Keep only the first 'start' and the last 'end' event
-        # Do that by first setting -1 the 'phase_loop' of all entries which are
-        # not the first 'start' event. Then drop the 'event' column so that we
-        # can drop all duplicates thus keeping only the last 'end' even for
-        # each phase.
-        phases_df = loops_df[['event', 'phase', 'phase_loop']].copy()
-        phases_df['phase_loop'] = phases_df.apply(keep_first_start, axis=1)
-        phases_df = phases_df[['phase', 'phase_loop']]
-        phases_df.drop_duplicates(keep='last', inplace=True)
-
-        # Compute deltas and keep only [start..end] intervals, by dropping
-        # instead the [end..start] internals
-        durations = phases_df.index[1:] - phases_df.index[:-1]
-        durations = durations[::2]
-
-        # Drop all 'end' events thus keeping only the first 'start' event
-        phases_df = phases_df[::2][['phase']]
-
-        # Append the duration column
-        phases_df['duration'] = durations
-
-        return phases_df[['duration']]
+        index, columns = zip(*durations)
+        return pd.DataFrame(columns, index=index)
 
     @df_phases.used_events
     def task_phase_windows(self, task):

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -177,9 +177,13 @@ class StaggeredFinishes(MisfitMigrationBase):
         for cpu in cpus:
             profile["{}{}".format(cls.task_prefix, cpu)] = (
                 Periodic(
+                    duty_cycle_pct=0,
+                    duration_s=cls.IDLING_DELAY_S,
+                    period_ms=cls.TASK_PERIOD_MS,
+                    cpus=[cpu]
+                ) + Periodic(
                     duty_cycle_pct=100,
                     duration_s=cls.PIN_DELAY_S,
-                    delay_s=cls.IDLING_DELAY_S,
                     period_ms=cls.TASK_PERIOD_MS,
                     cpus=[cpu]
                 ) + Periodic(

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -921,7 +921,7 @@ class Pulse(RTATask):
     initial and final load.
 
     The main difference with the 'step' class is that a pulse workload is
-    by definition a 'step down', i.e. the workload switch from an finial
+    by definition a 'step down', i.e. the workload switch from an initial
     load to a final one which is always lower than the initial one.
     Moreover, a pulse load does not generate a sleep phase in case of 0[%]
     load, i.e. the task ends as soon as the non null initial load has
@@ -929,7 +929,7 @@ class Pulse(RTATask):
 
     :param start_pct: the initial load percentage.
     :param end_pct: the final load percentage. Must be lower than ``start_pct``
-                    value. If end_pct is 0, the task end after the ``start_pct``
+                    value. If end_pct is 0, the task ends after the ``start_pct``
                     period has completed.
     :param time_s: the duration in seconds of each load step.
     :param period_ms: the period used to define the load in [ms].
@@ -951,24 +951,21 @@ class Pulse(RTATask):
                  uclamp_min=None, uclamp_max=None):
         super().__init__(delay_s, loops, sched_policy, priority)
 
-        if end_pct >= start_pct:
+        if end_pct > start_pct:
             raise ValueError('end_pct must be lower than start_pct')
 
         if not (0 <= start_pct <= 100 and 0 <= end_pct <= 100):
             raise ValueError('end_pct and start_pct must be in [0..100] range')
 
-        if end_pct >= start_pct:
-            raise ValueError('end_pct must be lower than start_pct')
+        loads = [start_pct]
+        if end_pct:
+            loads += [end_pct]
 
-        phases = []
-        for load in [start_pct, end_pct]:
-            if load == 0:
-                continue
-            phase = Phase(time_s, period_ms, load, cpus, uclamp_min=uclamp_min,
+        self.phases = [
+            Phase(time_s, period_ms, load, cpus, uclamp_min=uclamp_min,
                           uclamp_max=uclamp_max)
-            phases.append(phase)
-
-        self.phases = phases
+            for load in loads
+        ]
 
 
 class Periodic(Pulse):


### PR DESCRIPTION
Add a buffer phase to let PELT signals converge before the tests' wlgen tasks
actually start executing. This phase is then cropped away by
RTATestBundle.trace_window() so it's completely transparent to the tests.