### PR TITLE
Fix misfit test issues

### DIFF
--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -39,17 +39,9 @@ class MisfitMigrationBase(RTATestBundle):
     @classmethod
     def _has_asym_cpucapacity(cls, target):
         """
-        :returns: Whether the target has SD_ASYM_CPUCAPACITY set on any of its sd
+        :returns: Whether the target has asymmetric CPU capacities
         """
-        # Just try to find at least one instance of that flag
-        sd_info = target.sched.get_sd_info()
-
-        for cpu, domain_node in sd_info.cpus.items():
-            for domain in domain_node.domains.values():
-                if SchedDomainFlag.SD_ASYM_CPUCAPACITY in domain.flags:
-                    return True
-
-        return False
+        return len(set(target.plat_info["cpu-capacities"].values())) > 1
 
     @classmethod
     def _get_max_lb_interval(cls, plat_info):
@@ -161,7 +153,7 @@ class StaggeredFinishes(MisfitMigrationBase):
     def check_from_target(cls, target):
         if not cls._has_asym_cpucapacity(target):
             raise CannotCreateError(
-                "Target doesn't have SD_ASYM_CPUCAPACITY on any sched_domain")
+                "Target doesn't have asymmetric CPU capacities")
 
     @classmethod
     def get_rtapp_profile(cls, plat_info):

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -94,6 +94,9 @@ class StaggeredFinishes(MisfitMigrationBase):
     to be long (we just have to ensure they spawn there), so arbitrary value
     """
 
+    # Let us handle things ourselves
+    _BUFFER_PHASE_DURATION_S=0
+
     IDLING_DELAY_S = 1
     """
     A somewhat arbitray delay - long enough to ensure

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -303,7 +303,7 @@ class Trace(Loggable, TraceBase):
                  trace_path,
                  plat_info=None,
                  events=None,
-                 normalize_time=True,
+                 normalize_time=False,
                  trace_format='FTrace',
                  plots_dir=None,
                  plots_prefix=''):


### PR DESCRIPTION
I've been hitting some nasty issues with the misfit tests since the introduction of the rt-app buffer phase. Some (most?) of it is due to shady things I wrote in that test, so I only really have myself to blame...

I tested this by keeping tasks pinned in the last phase (IOW forcing a failure scenario), and the detected big CPU idle times were exactly what I expected, so AFAICT this works fine.