### PR TITLE
load_tracking: Fix wrong parameters passed to is_almost_equal()

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -921,8 +921,8 @@ class CPUMigrationBase(LoadTrackingBase):
                 expected_util = expected_cpu_util[cpu][i]
                 trace_util = trace_cpu_util[cpu][i]
                 if not self.is_almost_equal(
-                        trace_util,
                         expected_util,
+                        trace_util,
                         allowed_error_pct):
                     passed = False
 


### PR DESCRIPTION
The parameters passed to is_almost_equal() functions were swapped. The
target utilization is the *expeted* value not the value from the trace.

Fix that.

Signed-off-by: Qais Yousef <qais.yousef@arm.com>