### PR TITLE
tests: load_tracking: CPUMigrationBase: Use rtapp phase event

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -856,22 +856,21 @@ class CPUMigrationBase(LoadTrackingBase):
         :returns: A dict of the shape {cpu : {phase_id : trace_util}}
         """
         df = self.trace.analysis.load_tracking.df_cpus_signal('util')
-        phase_start = self.trace.start
-        cpu_util = {}
+        tasks = self.rtapp_task_ids_map.keys()
+        task = sorted(task for task in tasks if task.startswith('migr'))[0]
+        task = self.rtapp_task_ids_map[task][0]
 
-        for i, phase in enumerate(self.reference_task.phases):
-            # Start looking at signals once they should've converged
-            start = phase_start + UTIL_CONVERGENCE_TIME_S
-            # Trim the end a bit, otherwise we could have one or two events
-            # from the next phase
-            end = phase_start + phase.duration_s * .9
-            phase_df = df[start:end]
+        cpu_util = {}
+        for row in self.trace.analysis.rta.df_phases(task).itertuples():
+            phase = row.phase
+            duration = row.duration
+            start = row.Index
+            end = start + duration
+            phase_df = df_window(df, (start, end), method='pre', clip_window=True)
 
             for cpu in self.cpus:
-                util = phase_df[phase_df.cpu == cpu].util
-                cpu_util.setdefault(cpu, {})[i] = series_tunnel_mean(util)
-
-            phase_start += phase.duration_s
+                util = phase_df[phase_df['cpu'] == cpu]['util']
+                cpu_util.setdefault(cpu, {})[phase] = series_tunnel_mean(util)
 
         return cpu_util
 

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -914,7 +914,7 @@ class CPUMigrationBase(LoadTrackingBase):
     @get_trace_cpu_util.used_events
     @_plot_util.used_events
     @RTATestBundle.check_noisy_tasks(noise_threshold_pct=1)
-    def test_util_task_migration(self, allowed_error_pct=5) -> ResultBundle:
+    def test_util_task_migration(self, allowed_error_pct=3) -> ResultBundle:
         """
         Test that a migrated task properly propagates its utilization at the CPU level
 


### PR DESCRIPTION
Accurately find the start and end of each rtapp phase using the events
from rtapp, rather than blindly relying on the rtapp profile.

Depends on https://github.com/ARM-software/lisa/pull/1266 since signal convergence is fully delegated to the buffer phase, which means it has to run on the right CPUs to allow run-queue signals to converge.