### PR TITLE
tests: staging: sched_android: Ensure frequencies are sorted

### DIFF
--- a/lisa/tests/staging/sched_android.py
+++ b/lisa/tests/staging/sched_android.py
@@ -190,7 +190,7 @@ class SchedTuneFreqItem(SchedTuneItemBase):
         # into a real OPP
         boost = self.boost
         target_freq = min(max_freq, max_freq * boost / 80)
-        target_freq = list(filter(lambda f: f >= target_freq, freqs))[0]
+        target_freq = sorted(list(filter(lambda f: f >= target_freq, freqs)))[0]
 
         # Get the real average frequency
         avg_freq = self.trace.analysis.frequency.get_average_cpu_frequency(cpu)


### PR DESCRIPTION
Cpufreq's scaling_available_frequencies sysfs file does not guarantee
any particular order for the frequencies. As such, on devices where
they're not sorted in increasing order, the schedtune frequency test
will fail to compute the right target frequency, leading to test
failures.

Fix this by sorting the frequencies when necessary in sched_android.py.

Signed-off-by: Quentin Perret <qperret@google.com>