### PR TITLE
shell: Don't override ANDROID_HOME

### DIFF
--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -24,7 +24,7 @@
 ################################################################################
 
 export _DOC_ANDROID_HOME="Base folder of Android SDK installation"
-export ANDROID_HOME="$LISA_HOME/tools/android-sdk-linux"
+export ANDROID_HOME=${ANDROID_HOME:-"$LISA_HOME/tools/android-sdk-linux"}
 
 export _DOC_LISA_HOME="Base directory of LISA environment"
 


### PR DESCRIPTION
If the user already has a valid Android SDK specified in $ANDROID_HOME,
there is no need to override it.

Make the lisa default path conditional on $ANDROID_HOME not being set.

Signed-off-by: Quentin Perret <qperret@google.com>