### PR TITLE
doc: Add module declaration for LISA

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,6 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. module:: lisa
+
 LISA Documentation
 ==================
 


### PR DESCRIPTION
Declare the "lisa" package to Sphinx, so that foreign projects can
reference to it using autodoc with :mod:`lisa`.