### PR TITLE
Streamline typed containers

### DIFF
--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -1770,35 +1770,4 @@ class TypedList(GenericContainerBase, list, metaclass=GenericSequenceMeta):
     pass
 
 
-class IntIntDict(TypedDict):
-    _type = (int, int)
-
-
-class IntList(TypedList):
-    _type = int
-
-
-class FloatList(TypedList):
-    _type = float
-
-
-class IntIntListDict(TypedDict):
-    _type = (int, IntList)
-
-
-class IntListList(TypedList):
-    _type = IntList
-
-
-class StrList(TypedList):
-    _type = str
-
-
-class StrIntListDict(TypedDict):
-    _type = (str, IntList)
-
-
-class IntStrDict(TypedDict):
-    _type = (int, str)
-
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -1762,10 +1762,29 @@ class GenericSequenceMeta(GenericContainerMetaBase, type(Sequence)):
                     type_=type_.__qualname__
                 ), i)
 
+class GenericSortedSequenceMeta(GenericSequenceMeta):
+    def instancecheck(cls, instance):
+        super().instancecheck(instance)
+        for i, (x, y) in enumerate(zip(instance, instance[1:])):
+            if x > y:
+                raise TypeError('Item #{i} "{x}" is higher than the next item "{y}", but the list must be sorted'.format(
+                    i=i,
+                    x=x,
+                    y=y
+                ))
+
 
 class TypedList(GenericContainerBase, list, metaclass=GenericSequenceMeta):
     """
     Subclass of list providing keys and values type check.
+    """
+    pass
+
+
+class SortedTypedList(GenericContainerBase, list, metaclass=GenericSortedSequenceMeta):
+    """
+    Subclass of list providing keys and values type check, and also check the
+    list is sorted in ascending order.
     """
     pass
 

--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -1669,6 +1669,11 @@ class Configurable(abc.ABC, metaclass=ConfigurableMeta):
 class GenericContainerMetaBase(type):
     """
     Base class for the metaclass of generic containers.
+
+    They are parameterized with the ``type_`` class attribute, and classes can
+    also be created by indexing on classes with :class:`GenericContainerBase`
+    metaclass. The ``type_`` class attribute will be set with what is passed as
+    the key.
     """
     def __instancecheck__(cls, instance):
         try:
@@ -1677,6 +1682,22 @@ class GenericContainerMetaBase(type):
             return False
         else:
             return True
+
+    def __getitem__(self, type_):
+        class NewClass(self):
+            _type = type_
+
+        types = type_ if isinstance(type_, Sequence) else [type_]
+
+        name = '{}[{}]'.format(
+            self.__name__,
+            ','.join(type_.__name__ for type_ in types)
+        )
+        NewClass.__name__ = name
+        NewClass.__qualname__ = name
+        NewClass.__module__ = self.__module__
+
+        return NewClass
 
 
 class GenericContainerBase:

--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -35,7 +35,7 @@ import lisa
 from lisa.utils import (
     Serializable, Loggable, get_nested_key, set_nested_key, get_call_site,
     is_running_sphinx, get_cls_name, HideExekallID, get_subclasses, groupby,
-    import_all_submodules,
+    import_all_submodules, memoized,
 )
 
 from ruamel.yaml.comments import CommentedMap
@@ -762,7 +762,7 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
 
     def __init__(self, conf=None, src='user', add_default_src=True):
         self._nested_init(
-            structure=self.STRUCTURE,
+            key_desc_path=[],
             src_prio=[]
         )
         if conf is not None:
@@ -776,11 +776,11 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
     def get_help(cls, *args, **kwargs):
         return cls.STRUCTURE.get_help(*args, **kwargs)
 
-    def _nested_init(self, structure, src_prio):
+    def _nested_init(self, key_desc_path, src_prio):
         """Called to initialize nested instances of the class for nested
         configuration levels."""
-        self._structure = structure
-        "Structure of that level of configuration"
+        self._key_desc_path = key_desc_path
+        "Path in the structure of that level of configuration"
         # Make a copy to avoid sharing it with the parent
         self._src_prio = copy.copy(src_prio)
         "List of sources in priority order (1st item is highest prio)"
@@ -795,9 +795,16 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
         for key, key_desc in self._structure.items():
             if isinstance(key_desc, LevelKeyDesc):
                 self._sublevel_map[key] = self._nested_new(
-                    structure=key_desc,
+                    key_desc_path=key_desc.path,
                     src_prio=self._src_prio,
                 )
+
+    @property
+    def _structure(self):
+        # The first level in the path is the top-level key, which must be
+        # skipped
+        path = self._key_desc_path[1:]
+        return get_nested_key(self.STRUCTURE, path)
 
     @classmethod
     def _nested_new(cls, *args, **kwargs):
@@ -814,9 +821,6 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
 
         # make a shallow copy of the attributes
         attr_set = set(self.__dict__.keys())
-        # we do not duplicate the structure, since it is a readonly bit of
-        # configuration. That would break parent links in it
-        attr_set -= {'_structure'}
         for attr in attr_set:
             new.__dict__[attr] = copy.copy(self.__dict__[attr])
 

--- a/lisa/energy_meter.py
+++ b/lisa/energy_meter.py
@@ -39,8 +39,7 @@ import devlib
 from lisa.utils import Loggable, get_subclasses, ArtifactPath, HideExekallID
 from lisa.datautils import series_integrate
 from lisa.conf import (
-    SimpleMultiSrcConf, KeyDesc, TopLevelKeyDesc, Configurable,
-    StrList, FloatList
+    SimpleMultiSrcConf, KeyDesc, TopLevelKeyDesc, Configurable, TypedList,
 )
 from lisa.target import Target
 
@@ -310,9 +309,9 @@ class AEPConf(SimpleMultiSrcConf, HideExekallID):
     """
     STRUCTURE = TopLevelKeyDesc('aep-conf', 'AEP Energy Meter configuration', (
         KeyDesc('channel-map', 'Channels to use', [Mapping]),
-        KeyDesc('resistor-values', 'Resistor values', [FloatList]),
-        KeyDesc('labels', 'List of labels', [StrList]),
-        KeyDesc('device-entry', 'TTY device', [StrList]),
+        KeyDesc('resistor-values', 'Resistor values', [TypedList[float]]),
+        KeyDesc('labels', 'List of labels', [TypedList[str]]),
+        KeyDesc('device-entry', 'TTY device', [TypedList[str]]),
     ))
 
 

--- a/lisa/platforms/platinfo.py
+++ b/lisa/platforms/platinfo.py
@@ -21,7 +21,7 @@ from collections.abc import Mapping
 
 from lisa.utils import HideExekallID, group_by_value
 from lisa.conf import (
-    DeferredValue, TypedDict, TypedList,
+    DeferredValue, TypedDict, TypedList, SortedTypedList,
     MultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc, DerivedKeyDesc
 )
 from lisa.energy_model import EnergyModel
@@ -49,6 +49,10 @@ class KernelConfigKeyDesc(KeyDesc):
 class KernelSymbolsAddress(KeyDesc):
     def pretty_format(self, v):
         return '<symbols address>'
+
+
+CPUIdList = SortedTypedList[int]
+FreqList = SortedTypedList[int]
 
 
 class PlatformInfo(MultiSrcConf, HideExekallID):
@@ -81,13 +85,12 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
 
         KeyDesc('freq-domains',
                 'Frequency domains modeled by a list of CPU IDs for each domain',
-                [TypedList[TypedList[int]]]),
-        KeyDesc('freqs', 'Dictionnary of CPU ID to list of frequencies', [TypedDict[int, TypedList[int]]]),
+                [TypedList[CPUIdList]]),
+        KeyDesc('freqs', 'Dictionnary of CPU ID to list of frequencies', [TypedDict[int, FreqList]]),
 
         DerivedKeyDesc('capacity-classes',
-                       'Capacity classes modeled by a list of CPU IDs for each '
-                       'capacity, sorted by capacity',
-                       [TypedList[TypedList[int]]],
+                       'Capacity classes modeled by a list of CPU IDs for each capacity, sorted by capacity',
+                       [TypedList[CPUIdList]],
                        [['cpu-capacities']], compute_capa_classes),
     ))
     """Some keys have a reserved meaning with an associated type."""

--- a/lisa/platforms/platinfo.py
+++ b/lisa/platforms/platinfo.py
@@ -21,7 +21,7 @@ from collections.abc import Mapping
 
 from lisa.utils import HideExekallID, group_by_value
 from lisa.conf import (
-    DeferredValue, IntIntDict, IntListList, IntIntListDict, IntStrDict,
+    DeferredValue, TypedDict, TypedList,
     MultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc, DerivedKeyDesc
 )
 from lisa.energy_model import EnergyModel
@@ -64,16 +64,16 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
     # we need.
     STRUCTURE = TopLevelKeyDesc('platform-info', 'Platform-specific information', (
         LevelKeyDesc('rtapp', 'RTapp configuration', (
-            KeyDesc('calib', 'RTapp calibration dictionary', [IntIntDict]),
+            KeyDesc('calib', 'RTapp calibration dictionary', [TypedDict[int,int]]),
         )),
 
         LevelKeyDesc('kernel', 'Kernel-related information', (
             KeyDesc('version', '', [KernelVersion]),
             KernelConfigKeyDesc('config', '', [TypedKernelConfig]),
-            KernelSymbolsAddress('symbols-address', 'Dictionary of addresses to symbol names extracted from /proc/kallsyms', [IntStrDict]),
+            KernelSymbolsAddress('symbols-address', 'Dictionary of addresses to symbol names extracted from /proc/kallsyms', [TypedDict[int,str]]),
         )),
         KeyDesc('nrg-model', 'Energy model object', [EnergyModel]),
-        KeyDesc('cpu-capacities', 'Dictionary of CPU ID to capacity value', [IntIntDict]),
+        KeyDesc('cpu-capacities', 'Dictionary of CPU ID to capacity value', [TypedDict[int,int]]),
         KeyDesc('abi', 'ABI, e.g. "arm64"', [str]),
         KeyDesc('os', 'OS being used, e.g. "linux"', [str]),
         KeyDesc('name', 'Free-form name of the board', [str]),
@@ -81,13 +81,13 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
 
         KeyDesc('freq-domains',
                 'Frequency domains modeled by a list of CPU IDs for each domain',
-                [IntListList]),
-        KeyDesc('freqs', 'Dictionnary of CPU ID to list of frequencies', [IntIntListDict]),
+                [TypedList[TypedList[int]]]),
+        KeyDesc('freqs', 'Dictionnary of CPU ID to list of frequencies', [TypedDict[int, TypedList[int]]]),
 
         DerivedKeyDesc('capacity-classes',
                        'Capacity classes modeled by a list of CPU IDs for each '
                        'capacity, sorted by capacity',
-                       [IntListList],
+                       [TypedList[TypedList[int]]],
                        [['cpu-capacities']], compute_capa_classes),
     ))
     """Some keys have a reserved meaning with an associated type."""

--- a/lisa/target.py
+++ b/lisa/target.py
@@ -39,7 +39,7 @@ from devlib.platform.gem5 import Gem5SimulationPlatform
 import lisa.assets
 from lisa.wlgen.rta import RTA
 from lisa.utils import Loggable, HideExekallID, resolve_dotted_name, get_subclasses, import_all_submodules, LISA_HOME, RESULT_DIR, LATEST_LINK, ASSETS_PATH, setup_logging, ArtifactPath, nullcontext, ExekallTaggable
-from lisa.conf import SimpleMultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc, StrList, Configurable
+from lisa.conf import SimpleMultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc, TypedList, Configurable
 
 from lisa.platforms.platinfo import PlatformInfo
 
@@ -138,7 +138,7 @@ class TargetConf(SimpleMultiSrcConf, HideExekallID):
         KeyDesc('device', 'ADB device. Takes precedence over "host"', [str, None]),
         KeyDesc('keyfile', 'SSH private key file', [str, None]),
         KeyDesc('workdir', 'Remote target workdir', [str]),
-        KeyDesc('tools', 'List of tools to install on the target', [StrList]),
+        KeyDesc('tools', 'List of tools to install on the target', [TypedList[str]]),
         LevelKeyDesc('wait-boot', 'Wait for the target to finish booting', (
             KeyDesc('enable', 'Enable the boot check', [bool]),
             KeyDesc('timeout', 'Timeout of the boot check', [int]),
@@ -151,7 +151,7 @@ class TargetConf(SimpleMultiSrcConf, HideExekallID):
                 KeyDesc('class', 'Name of the class to use', [str]),
                 KeyDesc('args', 'Keyword arguments to build the Platform object', [Mapping]),
             )),
-            KeyDesc('excluded-modules', 'List of devlib modules to *not* load', [StrList]),
+            KeyDesc('excluded-modules', 'List of devlib modules to *not* load', [TypedList[str]]),
         ))
     ))
 

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -51,8 +51,7 @@ from lisa.utils import (
 from lisa.datautils import df_filter_task_ids
 from lisa.trace import FtraceCollector, FtraceConf, DmesgCollector
 from lisa.conf import (
-    SimpleMultiSrcConf, KeyDesc, TopLevelKeyDesc,
-    StrList,
+    SimpleMultiSrcConf, KeyDesc, TopLevelKeyDesc, TypedList,
 )
 
 
@@ -938,7 +937,7 @@ class DmesgTestConf(SimpleMultiSrcConf):
     {generated_help}
     """
     STRUCTURE = TopLevelKeyDesc('dmesg-test-conf', 'Dmesg test configuration', (
-        KeyDesc('ignored-patterns', 'List of Python regex matching dmesg entries content to be whitelisted', [StrList]),
+        KeyDesc('ignored-patterns', 'List of Python regex matching dmesg entries content to be whitelisted', [TypedList[str]]),
     ))
 
 

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -46,7 +46,7 @@ from devlib.target import KernelVersion
 
 from lisa.utils import Loggable, HideExekallID, memoized, deduplicate, deprecate, nullcontext
 from lisa.platforms.platinfo import PlatformInfo
-from lisa.conf import SimpleMultiSrcConf, KeyDesc, TopLevelKeyDesc, StrList, Configurable
+from lisa.conf import SimpleMultiSrcConf, KeyDesc, TopLevelKeyDesc, TypedList, Configurable
 
 
 class TaskID(namedtuple('TaskID', ('pid', 'comm'))):
@@ -1539,8 +1539,8 @@ class FtraceConf(SimpleMultiSrcConf, HideExekallID):
     {generated_help}
     """
     STRUCTURE = TopLevelKeyDesc('ftrace-conf', 'FTrace configuration', (
-        KeyDesc('events', 'FTrace events to trace', [StrList]),
-        KeyDesc('functions', 'FTrace functions to trace', [StrList]),
+        KeyDesc('events', 'FTrace events to trace', [TypedList[str]]),
+        KeyDesc('functions', 'FTrace functions to trace', [TypedList[str]]),
         KeyDesc('buffer-size', 'FTrace buffer size', [int]),
         KeyDesc('trace-clock', 'Clock used while tracing (see "trace_clock" in ftrace.txt kernel doc)', [str, None]),
         KeyDesc('saved-cmdlines-nr', 'Number of saved cmdlines with associated PID while tracing', [int]),

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -798,11 +798,10 @@ def get_nested_key(mapping, key_path, getitem=operator.getitem):
         :func:`operator.getitem`.
     :type getitem: collections.abc.Callable
     """
-    if not key_path:
-        return mapping
-    for key in key_path[:-1]:
+    for key in key_path:
         mapping = getitem(mapping, key)
-    return getitem(mapping, key_path[-1])
+
+    return mapping
 
 
 def set_nested_key(mapping, key_path, val, level=None):


### PR DESCRIPTION
Allow creating typed containers more easily, e.g.: `TypedDict[int, str]` is a typed dictionary with int keys and str values.