### PR TITLE
install_base.sh: Add missing dependencies for arm64

### DIFF
--- a/install_base.sh
+++ b/install_base.sh
@@ -176,14 +176,15 @@ pacman_packages=(
 # ABI-specific packages
 case $(uname -m) in
     aarch64)
-        # Since scipy does not ship a prebuilt wheel on PyPI for arm64, it needs
-        # to be built from source. That requires BLAS to be available.
-        apt_packages+=(libblas-dev liblapack-dev)
-        # This will not be enough as of August 2019, since these packages do not
-        # include the dev headers, although they should according to the general
-        # Archlinux policy.
-        pacman_packages+=(lapack blas)
-        ;;
+	# Since scipy does not ship a prebuilt wheel on PyPI for arm64, it needs
+	# to be built from source. That requires BLAS to be available, as well
+	# as a fortran compiler.
+	apt_packages+=(libblas-dev liblapack-dev gfortran libfreetype6)
+	# This will not be enough as of August 2019, since these packages do not
+	# include the dev headers, although they should according to the general
+	# Archlinux policy.
+	pacman_packages+=(lapack blas gcc-fortran freetype2)
+	;;
 esac
 
 # Array of functions to call in order


### PR DESCRIPTION
I've only tested the apt side of things; with these two extra packages I
can run the install (and even run the tests!) on an Ampere eMAG running
Ubuntu 19.04.