### PR TITLE
lisa.trace: Forward devlib.DmesgCollector.LOG_LEVELS

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -1776,6 +1776,7 @@ class DmesgCollector(CollectorBase):
     """
 
     TOOLS = ['dmesg']
+    LOG_LEVELS = devlib.DmesgCollector.LOG_LEVELS
 
     def __init__(self, target, **kwargs):
         collector = devlib.DmesgCollector(target, **kwargs)


### PR DESCRIPTION
Since we don't forward class attribute lookup automatically, do it
manually for LOG_LEVELS.