### PR TITLE
Change PlatformInfo "cpu-capacities" key

### DIFF
--- a/doc/traces/plat_info.yml
+++ b/doc/traces/plat_info.yml
@@ -2,12 +2,13 @@ platform-info:
     conf:
         abi: arm64
         cpu-capacities:
-            0: 446
-            1: 1024
-            2: 1024
-            3: 446
-            4: 446
-            5: 446
+            orig:
+                0: 446
+                1: 1024
+                2: 1024
+                3: 446
+                4: 446
+                5: 446
         cpus-count: 6
         freq-domains:
         -   - 0

--- a/lisa/analysis/cpus.py
+++ b/lisa/analysis/cpus.py
@@ -78,8 +78,12 @@ class CpusAnalysis(TraceAnalysisBase):
         :param cpu: The CPU
         :type cpu: int
         """
-        if "cpu-capacities" in self.trace.plat_info:
-            axis.axhline(self.trace.plat_info["cpu-capacities"][cpu],
+        try:
+            orig_capacities = self.trace.plat_info['cpu-capacities']['orig']
+        except KeyError:
+            pass
+        else:
+            axis.axhline(orig_capacities[cpu],
                          color=self.get_next_color(axis),
                          linestyle='--', label="orig_capacity")
 

--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -189,7 +189,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
         elif signal == 'required_capacity':
             # Add a column which represents the max capacity of the smallest
             # CPU which can accomodate the task utilization
-            capacities = sorted(self.trace.plat_info["cpu-capacities"].values())
+            capacities = sorted(self.trace.plat_info["cpu-capacities"]['orig'].values())
 
             def fits_capacity(util):
                 for capacity in capacities:
@@ -240,7 +240,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
         """
         df = self._df_either_event(self._SCHED_PELT_SE_NAMES)
 
-        if "cpu-capacities" in self.trace.plat_info:
+        if "orig" in self.trace.plat_info['cpu-capacities']:
             df['required_capacity'] = self.df_tasks_signal('required_capacity')['required_capacity']
         return df
 
@@ -409,7 +409,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
 
         # Get all utilization update events
         df = self.df_task_signal(task_id, 'required_capacity').copy()
-        cpu_capacities = self.trace.plat_info["cpu-capacities"]
+        cpu_capacities = self.trace.plat_info["cpu-capacities"]['orig']
 
         def evaluate_placement(cpu, required_capacity):
             capacity = cpu_capacities[cpu]

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1332,7 +1332,7 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         else:
             capacity_scale = 1024
 
-        return int((plat_info["cpu-capacities"][cpu] / capacity_scale) * utilization_pct)
+        return int((plat_info["cpu-capacities"]['rtapp'][cpu] / capacity_scale) * utilization_pct)
 
     @classmethod
     @abc.abstractmethod

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -42,7 +42,7 @@ class MisfitMigrationBase(RTATestBundle):
         """
         :returns: Whether the target has asymmetric CPU capacities
         """
-        return len(set(target.plat_info["cpu-capacities"].values())) > 1
+        return len(set(target.plat_info["cpu-capacities"]['orig'].values())) > 1
 
     @classmethod
     def _get_max_lb_interval(cls, plat_info):

--- a/lisa/tests/staging/sched_android.py
+++ b/lisa/tests/staging/sched_android.py
@@ -262,7 +262,7 @@ class SchedTunePlacementItem(SchedTuneItemBase):
 
         # Find CPUs without enough capacity to meet the boost
         boost = self.boost
-        cpu_caps = self.plat_info['cpu-capacities']
+        cpu_caps = self.plat_info['cpu-capacities']['rtapp']
         ko_cpus = list(filter(lambda x: (cpu_caps[x] / 10.24) < boost, cpu_caps))
 
         # Count how much time was spend on wrong CPUs

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -32,7 +32,7 @@ from operator import itemgetter
 from devlib import TargetStableError
 
 from lisa.wlgen.workload import Workload
-from lisa.utils import Loggable, ArtifactPath, TASK_COMM_MAX_LEN, groupby, nullcontext
+from lisa.utils import Loggable, ArtifactPath, TASK_COMM_MAX_LEN, group_by_value, nullcontext
 from lisa.pelt import PELT_SCALE
 
 
@@ -475,8 +475,8 @@ class RTA(Workload):
             return pload
 
         capa_ploads = {
-            capacity: {cpu: pload[cpu] for cpu, capa in cpu_caps}
-            for capacity, cpu_caps in groupby(orig_capacities.items(), itemgetter(1))
+            capacity: {cpu: pload[cpu] for cpu in cpus}
+            for capacity, cpus in group_by_value(orig_capacities).items()
         }
 
         # Find the min pload per capacity level, i.e. the fastest detected CPU.
@@ -590,9 +590,7 @@ class RTA(Workload):
         # value for the whole class anyway
         new_capacities = {}
         # Group the CPUs by original capacity
-        for capa, items in groupby(orig_capacities.items(), key=itemgetter(1)):
-            capa_class, _ = zip(*items)
-
+        for capa, capa_class in group_by_value(orig_capacities).items():
             avg_capa = mean(
                 capa
                 for cpu, capa in rtapp_capacities.items()

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -526,13 +526,34 @@ class RTA(Workload):
         # Check that the CPU capacities seen by rt-app are similar to the one
         # the kernel uses
         true_capacities = cls.get_cpu_capacities_from_calibrations(pload)
+        cls.warn_capacities_mismatch(cpu_capacities, true_capacities)
+
+        return pload
+
+    @classmethod
+    def warn_capacities_mismatch(cls, orig_capacities, new_capacities):
+        """
+        Compare ``orig_capacities`` and ``new_capacities`` and log warnings if
+        they are not consistent.
+
+        :param orig_capacities: Original CPU capacities, as a map of CPU to capacity.
+        :type orig_capacities: dict(int, int)
+
+        :param new_capacities: New CPU capacities, as a map of CPU to capacity.
+        :type new_capacities: dict(int, int)
+        """
+        logger = cls.get_logger()
+        capacities = {
+            cpu: (orig_capacities[cpu], new_capacities[cpu])
+            for cpu in orig_capacities.keys() & new_capacities.keys()
+        }
+        logger.info('CPU capacities according to rt-app workload: {}'.format(new_capacities))
+
         capa_factors_pct = {
-            cpu: true_capacities[cpu] / cpu_capacities[cpu] * 100
-            for cpu in cpu_capacities.keys()
+            cpu: new / orig * 100
+            for cpu, (orig, new) in capacities.keys()
         }
         dispersion_pct = max(abs(100 - factor) for factor in capa_factors_pct.values())
-
-        logger.info('CPU capacities according to rt-app workload: {}'.format(true_capacities))
 
         if dispersion_pct > 2:
             logger.warning('The calibration values are not inversely proportional to the CPU capacities, the duty cycles will be up to {:.2f}% off on some CPUs: {}'.format(dispersion_pct, capa_factors_pct))
@@ -541,20 +562,15 @@ class RTA(Workload):
             logger.warning('The calibration values are not inversely proportional to the CPU capacities. Either rt-app calibration failed, or the rt-app busy loops has a very different instruction mix compared to the workload used to establish the CPU capacities: {}'.format(capa_factors_pct))
 
         # Map of CPUs X to list of CPUs Ys that are faster than it although CPUs
-        # of Ys have a smaller capacity than X
-        if len(capa_ploads) > 1:
+        # of Ys have a smaller orig capacity than X
+        if len(capacities) > 1:
             faster_than_map = {
                 cpu1: sorted(
                     cpu2
-                    for cpu2, pload2 in ploads2.items()
-                    # CPU2 faster than CPU1
-                    if pload2 < pload1
+                    for cpu2, (orig2, new2) in capacities.items()
+                    if new2 > new1 and orig2 < orig1
                 )
-                for (capa1, ploads1), (capa2, ploads2) in itertools.permutations(capa_ploads.items())
-                for cpu1, pload1 in ploads1.items()
-                # Only look at permutations in which CPUs of ploads1 are supposed
-                # to be faster than the one in ploads2
-                if capa1 > capa2
+                for cpu1, (orig1, new1) in capacities.items()
             }
         else:
             faster_than_map = {}
@@ -568,8 +584,6 @@ class RTA(Workload):
 
         if faster_than_map:
             raise CalibrationError('Some CPUs of higher capacities are slower than other CPUs of smaller capacities: {}'.format(faster_than_map))
-
-        return pload
 
     @classmethod
     def get_cpu_capacities_from_calibrations(cls, calibrations):

--- a/tests/assets/plat_info.yml
+++ b/tests/assets/plat_info.yml
@@ -2,12 +2,13 @@ platform-info:
     conf:
         abi: arm64
         cpu-capacities:
-            0: 446
-            1: 1024
-            2: 1024
-            3: 446
-            4: 446
-            5: 446
+            orig:
+                0: 446
+                1: 1024
+                2: 1024
+                3: 446
+                4: 446
+                5: 446
         cpus-count: 6
         freq-domains:
         -   - 0

--- a/tests/assets/sched_load/plat_info.yml
+++ b/tests/assets/sched_load/plat_info.yml
@@ -2,12 +2,13 @@ platform-info:
     conf:
         abi: arm64
         cpu-capacities:
-            0: 446
-            1: 1024
-            2: 1024
-            3: 446
-            4: 446
-            5: 446
+            orig:
+                0: 446
+                1: 1024
+                2: 1024
+                3: 446
+                4: 446
+                5: 446
         cpus-count: 6
         freq-domains:
         -   - 0


### PR DESCRIPTION
BREAKING CHANGE

The old "cpu-capacities" content can now be found under "cpu-capacities/orig".
