### PR TITLE
lisa.tests.staging.util_tracking: Rename UtilConvergence.test_areas()…

### DIFF
--- a/lisa/tests/staging/util_tracking.py
+++ b/lisa/tests/staging/util_tracking.py
@@ -231,12 +231,12 @@ class UtilConvergence(UtilTrackingBase):
                     failures.append(phase.start)
 
                 # DOWN: ewma ramping down
-                elif phase.id <= 5 and mean_ewma < mean_enqueued:
+                elif phase.id <= 4 and mean_ewma < mean_enqueued:
                     failure_reasons[phase_name] = 'FAST_RAMP(DOWN): EWMA smaller then Enqueued'
                     failures.append(phase.start)
 
                 # UP: ewma ramping up
-                elif phase.id >= 4 and mean_ewma > mean_enqueued:
+                elif phase.id >= 5 and mean_ewma > mean_enqueued:
                     failure_reasons[phase_name] = 'FAST_RAMP(UP): EWMA bigger then Enqueued'
                     failures.append(phase.start)
 
@@ -331,7 +331,7 @@ class UtilConvergence(UtilTrackingBase):
                     failures.append(activation)
 
                 # DOWN: ewma ramping down
-                elif phase.id <= 5 and enq > ewma:
+                elif phase.id <= 4 and enq > ewma:
                     failure_reasons[idx] = 'enqueued({}) bigger than ewma({}) @ {}'\
                         .format(enq, ewma, activation)
                     failures.append(activation)


### PR DESCRIPTION
… into test_means()

Compute the mean of signals for each phases, which is equivalent to checking
their integral but has the advantage of giving normalized output in a
human-friendly unit.