### PR TITLE
Improve MultiSrcConf

### DIFF
--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -454,7 +454,7 @@ class LevelKeyDesc(KeyDescBase, Mapping):
         except KeyError:
             try:
                 closest_match = difflib.get_close_matches(
-                    word=key,
+                    word=str(key),
                     possibilities=self._key_map.keys(),
                     n=1,
                 )[0]

--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -1400,7 +1400,6 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
         :type eval_deferred: bool
         """
         out = []
-        idt_style = ' '
 
         # We add the derived keys when pretty-printing, for the sake of
         # completeness. This will not honor eval_deferred for base keys.

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -20,7 +20,7 @@ import os
 import copy
 from unittest import TestCase
 
-from lisa.conf import MultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc, TypedList, DerivedKeyDesc
+from lisa.conf import MultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc, TypedList, DerivedKeyDesc, DeferredValue
 from .utils import StorageTestCase, HOST_PLAT_INFO, HOST_TARGET_CONF
 
 """ A test suite for the MultiSrcConf subclasses."""
@@ -149,6 +149,22 @@ class TestTestConf(StorageTestCase, TestMultiSrcConf):
                 'subkey': 42
             }
         })
+        self.assertEqual(conf['derived'], 46)
+
+    def test_derived_with_deferred_base(self):
+        conf = copy.deepcopy(self.conf)
+        conf.add_src('mysrc', {
+            'foo': DeferredValue(lambda: 1),
+            'bar': [1, 2],
+            'sublevel': {
+                'subkey': 42
+            }
+        })
+        # Check that the value we get is transitively a DeferredValue
+        val = conf.get_key('derived', eval_deferred=False)
+        self.assertIsInstance(val, DeferredValue)
+
+        # Regular access will evaluate all the bases
         self.assertEqual(conf['derived'], 46)
 
     def test_force_src_nested(self):


### PR DESCRIPTION
Improve DerivedKey support:
* Allow base keys outside the current subtree with the "magic" `..` key that goes one level up
* Honor eval_deferred for base keys when computing the value/displaying it