### PR TITLE
lisa.tets.scheduler.load_tracking: Improve CPUMigrationBase.get_trace…

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -898,6 +898,10 @@ class CPUMigrationBase(LoadTrackingBase):
             duration = row.duration
             start = row.Index
             end = start + duration
+            # Ignore the first quarter of the util signal of each phase, since
+            # it's impacted by the phase change, and util can be affected
+            # (rtapp does some bookkeeping at the beginning of phases)
+            start += duration / 4
             phase_df = df_window(df, (start, end), method='pre', clip_window=True)
 
             for cpu in self.cpus:


### PR DESCRIPTION
…_cpu_util()

Ignore the util of the first quarter of the phase, since it can be impacted by
phase change bookkeeping of rtapp.