### PR TITLE
lisa.utils: Make get_doc_url() robust against names of other domains

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -1355,7 +1355,7 @@ def _get_doc_url(obj_name):
     inv = sphobjinv.Inventory(url=inv_url)
 
     for inv_obj in inv.objects:
-        if inv_obj.name == obj_name:
+        if inv_obj.name == obj_name and inv_obj.domain == "py":
             doc_page = inv_obj.uri.replace('$', inv_obj.name)
             doc_url = urllib.parse.urljoin(doc_base_url, doc_page)
             return doc_url


### PR DESCRIPTION
Inventory names might not be unique across domains so check for the py domain as
well:
https://github.com/ARM-software/lisa/issues/1308

#fixes #1308 