### PR TITLE
lisa.tests: Remove interactive=False for debug plots

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -334,13 +334,11 @@ class InvarianceItem(LoadTrackingBase, ExekallTaggable):
     def _plot_pelt(self, task, signal_name, simulated, test_name):
         trace = self.trace
 
-        kwargs = dict(interactive=False)
-
-        axis = trace.analysis.load_tracking.plot_task_signals(task, signals=[signal_name], **kwargs)
+        axis = trace.analysis.load_tracking.plot_task_signals(task, signals=[signal_name])
         simulated.plot(ax=axis, drawstyle='steps-post', label='simulated {}'.format(signal_name))
 
         activation_axis = axis.twinx()
-        trace.analysis.tasks.plot_task_activation(task, alpha=0.2, axis=activation_axis, duration=True, **kwargs)
+        trace.analysis.tasks.plot_task_activation(task, alpha=0.2, axis=activation_axis, duration=True)
 
         axis.legend()
 

--- a/lisa/tests/scheduler/util_tracking.py
+++ b/lisa/tests/scheduler/util_tracking.py
@@ -132,8 +132,8 @@ class UtilConvergence(UtilTrackingBase):
 
     def _plot_signals(self, task, test, failures):
         signals = ['util', 'util_est_enqueued', 'util_est_ewma']
-        ax = self.trace.analysis.load_tracking.plot_task_signals(task, signals=signals, interactive=False)
-        ax = self.trace.analysis.rta.plot_phases(task, axis=ax, interactive=False)
+        ax = self.trace.analysis.load_tracking.plot_task_signals(task, signals=signals)
+        ax = self.trace.analysis.rta.plot_phases(task, axis=ax)
         for start in failures:
             ax.axvline(start, alpha=0.5, color='r')
         filepath = os.path.join(self.res_dir, 'util_est_{}.png'.format(test))

--- a/lisa/tests/staging/schedutil.py
+++ b/lisa/tests/staging/schedutil.py
@@ -159,7 +159,7 @@ class RampBoostTestBase(RTATestBundle):
     def _plot_test_boost(self, df):
         task = self.rtapp_tasks[0]
         analysis = self.trace.analysis.frequency
-        fig, axis = analysis.setup_plot(interactive=False)
+        fig, axis = analysis.setup_plot()
         df['cost_margin'].plot(ax=axis, drawstyle='steps-post', color='r')
         df['boost_points'].astype('int', copy=False).plot(ax=axis, drawstyle='steps-post', color='black')
         df['expected_cost_margin'].plot(ax=axis, drawstyle='steps-post', color='blue')

--- a/lisa/tests/staging/schedutil.py
+++ b/lisa/tests/staging/schedutil.py
@@ -263,7 +263,7 @@ class LargeStepUp(RampBoostTestBase):
         # boards. This helps having predictable execution.
         with target.disable_idle_states():
             with target.cpufreq.use_governor("schedutil"):
-                cls._run_rtapp(target, res_dir, rtapp_profile, ftrace_coll=ftrace_coll)
+                cls.run_rtapp(target, res_dir, rtapp_profile, ftrace_coll=ftrace_coll)
 
         return cls(res_dir, plat_info, cpu, nr_steps)
 


### PR DESCRIPTION
interactive value is now already False in non-interactive context, and True
inside a Jupyter notebook. Having an interactive debug plot in notebooks is
actually useful as it can be considered as part of the output of the test
methods.