### PR TITLE
lisa: Add __repr_pretty__() implementations to MultiSrcConf and Resul…

### DIFF
--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -1572,6 +1572,9 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
         derived_keys = set(self._get_derived_key_names())
         return sorted(regular_keys | derived_keys)
 
+    def _repr_pretty_(self, p, cycle):
+        "Pretty print instances in Jupyter notebooks"
+        p.text(self.pretty_format())
 
 class SimpleMultiSrcConf(MultiSrcConf):
     """

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -197,6 +197,10 @@ class ResultBundleBase:
 
         return self.result.name + metrics_str
 
+    def _repr_pretty_(self, p, cycle):
+        "Pretty print instances in Jupyter notebooks"
+        p.text(self.pretty_format())
+
     def add_metric(self, name, data, units=None):
         """
         Lets you append several test :class:`TestMetric` to the bundle.


### PR DESCRIPTION
…tBundle

This allows pretty printing by default in Jupyter notebooks.