### PR TITLE
lisa.trace: Read parquet files with mmap

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -1089,7 +1089,7 @@ class TraceCache:
                 # Try to load the dataframe from that path
                 try:
                     if self.DATAFRAME_SWAP_FORMAT == 'parquet':
-                        data = pd.read_parquet(path)
+                        data = pd.read_parquet(path, memory_map=True)
                     else:
                         raise ValueError('Dataframe swap format "{}" not handled'.format(self.DATAFRAME_SWAP_FORMAT))
                 except (OSError, pyarrow.lib.ArrowIOError):


### PR DESCRIPTION
Use mmap as it does not seem to harm performance. It might help avoiding
some copies for large dataframes.