### PR TITLE
WIP lisa.analysis: Add interactive html output format.

### DIFF
--- a/lisa/analysis/base.py
+++ b/lisa/analysis/base.py
@@ -39,6 +39,7 @@ from matplotlib.figure import Figure
 from cycler import cycler as make_cycler
 
 import mplcursors
+import mpld3
 
 from ipywidgets import widgets
 from IPython.display import display
@@ -539,6 +540,7 @@ class AnalysisHelpers(Loggable, abc.ABC):
                     format_map = {
                         'rst': cls._get_rst_content,
                         'html': cls._get_html,
+                        'interactive_html': cls._get_interactive_html,
                     }
                     try:
                         return format_map[fmt]
@@ -563,7 +565,7 @@ class AnalysisHelpers(Loggable, abc.ABC):
                     out = resolve_formatter(output)(f, args, f_kwargs, axis)
 
                 if filepath:
-                    if img_format in ('html', 'rst'):
+                    if img_format in ('html', 'interactive_html', 'rst'):
                         content = resolve_formatter(img_format)(f, args, f_kwargs, axis)
 
                         with open(filepath, 'wt', encoding='utf-8') as fd:
@@ -663,6 +665,12 @@ class AnalysisHelpers(Loggable, abc.ABC):
         rst = cls._get_rst(*args, **kwargs)
         parts = cls._docutils_render(writer='html', rst=rst, doctitle_xform=True)
         return parts['whole']
+
+    @classmethod
+    def _get_interactive_html(cls, f, args, kwargs, axis):
+        fig = axis.get_figure()
+        html = mpld3.fig_to_html(fig, template_type='general')
+        return html
 
 
 class TraceAnalysisBase(AnalysisHelpers):

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         "ipython",
         "ipywidgets",
         "mplcursors",
+        "mpld3",
 
         # Depdendencies that are shipped as part of the LISA repo as
         # subtree/submodule

--- a/tools/lisa-plot
+++ b/tools/lisa-plot
@@ -239,6 +239,10 @@ Available plots:
         help='Platform information, necessary for some plots',
     )
 
+    parser.add_argument('--interactive-html', action='store_true',
+        help='Use mpld3 to generate an interactive HTML file when html format is in use',
+    )
+
     parser.add_argument('--xkcd', action='store_true',
         help='Graphs will look like XKCD plots',
     )
@@ -331,6 +335,9 @@ Available plots:
             os.makedirs(dirname, exist_ok=True)
 
         kwargs = make_plot_kwargs(f, file_path, extra_options=args.option)
+
+        if args.interactive_html:
+            kwargs['img_format'] = 'interactive_html'
 
         with handle_plot_excep(exit_on_error=not args.best_effort):
             with xkcd_cm:


### PR DESCRIPTION
Can be enabled using output='interactive_html' in plot methods, or with:
lisa-plot --interactive-html