### PR TITLE
lisa.analysis.rta: Remove unwanted TraceAnalysis.cache

### DIFF
--- a/lisa/analysis/rta.py
+++ b/lisa/analysis/rta.py
@@ -365,7 +365,6 @@ class RTAEventsAnalysis(TraceAnalysisBase):
         """
         return self._get_rtapp_phases('end', task)
 
-    @TraceAnalysisBase.cache
     @df_rtapp_phases_start.used_events
     def _get_task_phase(self, event, task, phase):
         task = self.trace.get_task_id(task)


### PR DESCRIPTION
This decorator can only be used on functions returning a dataframe with string
column names. numpy.float64 or pandas.Series cannot be cached.