### PR TITLE
lisa: Remove unnecessary uses of Series.values

### DIFF
--- a/lisa/analysis/rta.py
+++ b/lisa/analysis/rta.py
@@ -147,8 +147,8 @@ class RTAEventsAnalysis(TraceAnalysisBase):
         """
         df = self.df_rtapp_main()
         return (
-            df[df.event == 'start'].index.values[0],
-            df[df.event == 'end'].index.values[0])
+            df[df.event == 'start'].index[0],
+            df[df.event == 'end'].index[0])
 
     @property
     @memoized
@@ -166,7 +166,7 @@ class RTAEventsAnalysis(TraceAnalysisBase):
         """
         df = self.df_rtapp_main()
         df = df[df['event'] == 'clock_ref']
-        return RefTime(df.index.values[0], df.data.values[0])
+        return RefTime(df.index[0], df.data.iloc[0])
 
     ###########################################################################
     # rtapp_task events related methods
@@ -375,7 +375,8 @@ class RTAEventsAnalysis(TraceAnalysisBase):
         if phase and phase < 0:
             phase += len(df)
         phase += 1  # because of the followig "head().tail()" filter
-        return df.loc[task.comm].head(phase).tail(1).Time.values[0]
+        breakpoint()
+        return df.loc[task.comm].head(phase).tail(1).Time.iloc[0]
 
     @_get_task_phase.used_events
     def df_rtapp_phase_start(self, task, phase=0):

--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -267,7 +267,7 @@ def df_squash(df, start, end, column='delta'):
     if df.empty:
         return df
 
-    end = min(end, df.index[-1] + df[column].values[-1])
+    end = min(end, df.index[-1] + df[column].iloc[-1])
     res_df = pd.DataFrame(data=[], columns=df.columns)
 
     if start > end:
@@ -316,7 +316,7 @@ def df_squash(df, start, end, column='delta'):
             res_df = res_df.drop([end])
         else:
             # Fix the delta for the last row
-            delta = min(end - res_df.index[-1], res_df[column].values[-1])
+            delta = min(end - res_df.index[-1], res_df[column].iloc[-1])
             res_df.at[res_df.index[-1], column] = delta
 
     return res_df

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1263,8 +1263,8 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
             return ResultBundle.from_bool(True)
 
         pid = df_noise.index[0]
-        comm = df_noise.comm.values[0]
-        duration_s = df_noise.runtime.values[0]
+        comm = df_noise['comm'].iloc[0]
+        duration_s = df_noise['runtime'].iloc[0]
         duration_pct = duration_s * 100 / self.trace.time_range
 
         res = ResultBundle.from_bool(duration_s < threshold_s)

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -189,7 +189,7 @@ class StaggeredFinishes(MisfitMigrationBase):
             return state_df
 
         return df_squash(state_df, self.start_time,
-                         state_df.index[-1] + state_df.delta.values[-1], "delta")
+                         state_df.index[-1] + state_df['delta'].iloc[-1], "delta")
 
     @requires_events('sched_switch', TasksAnalysis.df_task_states.used_events)
     def test_preempt_time(self, allowed_preempt_pct=1) -> ResultBundle:


### PR DESCRIPTION
Using Series.values can lead to a copy, and is no necessary when all we want is
to index in it. `iloc[N]` is the way to go.