### PR TITLE
lisa.analysis.tasks: Make df_task_activation() duty_cycle aware of pr…

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -286,7 +286,12 @@ class InvarianceItem(LoadTrackingBase, ExekallTaggable):
         task = trace.get_task_id(task)
         cpus = trace.analysis.tasks.cpus_of_tasks([task])
 
-        df_activation = trace.analysis.tasks.df_task_activation(task)
+        df_activation = trace.analysis.tasks.df_task_activation(
+            task,
+            # Util only takes into account times where the task is actually
+            # executing
+            preempted_value=0,
+        )
         df = trace.analysis.load_tracking.df_tasks_signal(signal_name)
         df = df_filter_task_ids(df, [task])
 


### PR DESCRIPTION
…eemption

BREAKING CHANGE

Make sure the duty cycle is not affected by preemption by default.

The former behaviour where preempted == sleeping can be restored with
preempted_is_sleeping=True.