### PR TITLE
lisa.tests.base: Consider the sum of noisy task run time rather than …

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1259,7 +1259,7 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         if df_noise.empty:
             return ResultBundle.from_bool(True)
 
-        res = ResultBundle.from_bool(df_noise['runtime'].max() < threshold_s)
+        res = ResultBundle.from_bool(df_noise['runtime'].sum() < threshold_s)
 
         pid = df_noise.index[0]
         comm = df_noise['comm'].iloc[0]


### PR DESCRIPTION
…the max

Sum all the noise contribution together, since the influence on runqueue util
signals will be impacted by the sum of the util of each attached task, and not
just the largest util among the attached tasks.