### PR TITLE
lisa.tests.base: Return float in RTATestBundle.unscaled_utilization()

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1334,7 +1334,7 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         else:
             capacity_scale = 1024
 
-        return int((plat_info["cpu-capacities"]['rtapp'][cpu] / capacity_scale) * utilization_pct)
+        return (plat_info["cpu-capacities"]['rtapp'][cpu] / capacity_scale) * utilization_pct
 
     @classmethod
     @abc.abstractmethod

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -74,12 +74,12 @@ class EASBehaviour(RTATestBundle):
         """
         if utilization_pct is None:
             cpus = plat_info["capacity-classes"][-1]
+            utilization_pct = 100
         else:
             try:
                 cpus = plat_info["capacity-classes"][-2]
             except IndexError:
                 cpus = plat_info["capacity-classes"][0]
-            utilization_pct = 100
 
         return cls.unscaled_utilization(plat_info, cpus[0], utilization_pct)
 


### PR DESCRIPTION
Instead of rounding down the percentage, return a float. lisa.wlgen.rta will
round the values at the step to avoid precision loss as much as possible.