### PR TITLE
setup.py: Force jupyterlab <= 1.2.6 until extensions are fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,9 @@ setup(
 
     extras_require={
         "notebook": [
-            "jupyterlab",
+            # Force to 1.2.6 until matplotlib widget works again:
+            # https://github.com/matplotlib/jupyter-matplotlib/issues/193
+            "jupyterlab<=1.2.6",
             "ipympl", # For %matplotlib widget under jupyter lab
             "sphobjinv", # To open intersphinx inventories
         ],


### PR DESCRIPTION
The issue encountered for matplotlib widget (at least):
https://github.com/matplotlib/jupyter-matplotlib/issues/193