### PR TITLE
Revert "setup.py: Force jupyterlab <= 1.2.6 until extensions are fixed"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,9 +82,7 @@ setup(
 
     extras_require={
         "notebook": [
-            # Force to 1.2.6 until matplotlib widget works again:
-            # https://github.com/matplotlib/jupyter-matplotlib/issues/193
-            "jupyterlab<=1.2.6",
+            "jupyterlab",
             "ipympl", # For %matplotlib widget under jupyter lab
             "sphobjinv", # To open intersphinx inventories
         ],


### PR DESCRIPTION
This reverts commit cb9dd2f4048cb1369657436be819144705d1fdba.