### PR TITLE
lisa: use str.casefold() to canonicalize strings

### DIFF
--- a/lisa/analysis/functions.py
+++ b/lisa/analysis/functions.py
@@ -111,7 +111,7 @@ class FunctionsAnalysis(AnalysisHelpers):
             if metric.upper() == 'TIME':
                 title = 'Total Execution Time per CPUs'
                 ylabel = 'Execution Time [us]'
-            data = df[metric.lower()].unstack()
+            data = df[metric.casefold()].unstack()
             data.plot(kind='bar',
                      ax=axis, figsize=(16, 8), legend=True,
                      title=title, table=True)

--- a/lisa/doc/helpers.py
+++ b/lisa/doc/helpers.py
@@ -174,7 +174,7 @@ def is_test(method):
         return False
     else:
         return any(
-            'result' in cls.__qualname__.lower()
+            'result' in cls.__qualname__.casefold()
             for cls in base_cls_list
         )
 

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1470,7 +1470,7 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
                 for name, task in profile.items()
             }
 
-        wload = RTA.by_profile(target, "rta_{}".format(cls.__name__.lower()),
+        wload = RTA.by_profile(target, "rta_{}".format(cls.__name__.casefold()),
                                profile, res_dir=res_dir,
                                trace_events=trace_events)
         cgroup = cls._target_configure_cgroup(target, cg_cfg)

--- a/lisa/typeclass.py
+++ b/lisa/typeclass.py
@@ -730,7 +730,7 @@ class BoolFromStringInstance(FromString, types=bool):
             * ``0``, ``n``, ``false``
             * ``1``, ``y``, ``true``
         """
-        string = string.lower().strip()
+        string = string.casefold().strip()
         if string in ('0', 'n', 'false'):
             return False
         elif string in ('1', 'y', 'true'):


### PR DESCRIPTION
Rather than str.lower(), str.casefold() is designed to make comparison
against a reference work better with unicode.