### PR TITLE
lisa: Add warning about YAML file loading

### DIFF
--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -716,6 +716,9 @@ class MultiSrcConfABC(Serializable, abc.ABC, metaclass=MultiSrcConfMeta):
         :param add_default_src: Add a default source if available for that
             class.
         :type add_default_src: bool
+
+        .. note:: Only load YAML files from trusted source as it can lead to
+            arbitrary code execution.
         """
 
         toplevel_key = cls.STRUCTURE.name
@@ -746,6 +749,9 @@ class MultiSrcConfABC(Serializable, abc.ABC, metaclass=MultiSrcConfMeta):
             path will win if it defines some keys that were also defined in another
             file. Each file will be mapped to a different sources, named after
             the basename of the file.
+
+        .. note:: Only load YAML files from trusted source as it can lead to
+            arbitrary code execution.
         """
         # Make sure that all modules from LISA are loaded, so that
         # get_subclasses will be accurate.

--- a/lisa/exekall_customize.py
+++ b/lisa/exekall_customize.py
@@ -181,7 +181,7 @@ class LISAAdaptor(AdaptorBase):
     def register_run_param(parser):
         add_argument(parser, '--conf', action='append',
             default=[],
-            help="LISA configuration file. If multiple configurations of a given type are found, they are merged (last one can override keys in previous ones)")
+            help="LISA configuration file. If multiple configurations of a given type are found, they are merged (last one can override keys in previous ones). Only load trusted files as it can lead to arbitrary code execution.")
 
         add_argument(parser, '--inject', action='append',
             metavar='SERIALIZED_OBJECT_PATH',

--- a/lisa/target.py
+++ b/lisa/target.py
@@ -109,6 +109,9 @@ class TargetConf(SimpleMultiSrcConf, HideExekallID):
             name: !env:str BOARD_NAME
             port: !env:int PORT
 
+    .. note:: Only load trusted YAML files as it can lead to abritrary code
+        execution.
+
     .. note:: That structure in a YAML file is allowed and will work:
 
         * file foo.yml::
@@ -414,6 +417,9 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
         """
         Create a :class:`Target` from the YAML configuration file pointed by
         ``LISA_CONF`` environment variable.
+
+        .. note:: Only load trusted YAML files as it can lead to abritrary code
+            execution.
         """
         path = os.environ['LISA_CONF']
         return cls.from_one_conf(path)
@@ -425,6 +431,9 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
 
         This file will be used to provide a :class:`TargetConf` and
         :class:`lisa.platforms.platinfo.PlatformInfo` instances.
+
+        .. note:: Only load trusted YAML files as it can lead to abritrary code
+            execution.
         """
         conf = TargetConf.from_yaml_map(path)
         try:
@@ -483,6 +492,8 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
 
                 In both cases, --conf can also contain a PlatformInfo YAML description.
 
+                Note: only load trusted YAML files as it can lead to abritrary
+                code execution.
                 """.format(
                     script=os.path.basename(sys.argv[0])
                 )))

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -564,6 +564,9 @@ class Serializable(Loggable):
 
         :raises AssertionError: if the deserialized object is not an instance
                                 of the class.
+
+        .. note:: Only deserialize files from trusted source, as both pickle
+            and YAML formats can lead to arbitrary code execution.
         """
         instance = cls._from_path(filepath, fmt)
         assert isinstance(instance, cls)


### PR DESCRIPTION
Since LISA configurations allows for arbitrary code execution, add notes
in various places to inform about that.