### PR TITLE
lisa.trace: Fix typo in has_events() leading to returning True

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -2083,7 +2083,7 @@ class Trace(Loggable, TraceBase):
             # yet.
             return all(
                 event in self.available_events
-                for event in self.available_events
+                for event in events
             )
 
     def get_view(self, window, **kwargs):


### PR DESCRIPTION
When a list of events is checked, has_events() would always return True.
Fix the typo so it checks the events that were asked for.