### PR TITLE
lisa.trace: use category for func col of print/bprint/bputs df

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -4232,6 +4232,16 @@ class Trace(Loggable, TraceBase):
         df['cpus'] = df['cpus'].apply(f)
         return df
 
+    @_sanitize_event('print')
+    @_sanitize_event('bprint')
+    @_sanitize_event('bputs')
+    def _sanitize_print(self, event, df, aspects):
+        df = df.copy(deep=False)
+        # Reduce memory usage and speedup selection based on function
+        with contextlib.suppress(KeyError):
+            df['func'] = df['func'].astype('category', copy=False)
+        return df
+
 
 class TraceEventCheckerBase(abc.ABC, Loggable):
     """


### PR DESCRIPTION
Save some memory and speed-up selection based on function for the
print/bprint/bputs dataframes.