### PR TITLE
lisa.analysis.load_tracking: Fix bullet list in docstring

### DIFF
--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -137,6 +137,7 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
             ``cpu``.
 
         :param signal: Signal name to get. Can be any of:
+
             * ``util``
             * ``load``
             * ``enqueued`` (util est enqueued)


### PR DESCRIPTION
Add linebreak to fix the bullet list in a docstring.