### PR TITLE
ipynb: Fix RTA.by_profile() calls parameter order

### DIFF
--- a/ipynb/examples/typical_experiment.ipynb
+++ b/ipynb/examples/typical_experiment.ipynb
@@ -488,7 +488,7 @@
     }
    ],
    "source": [
-    "wload = RTA.by_profile(target, \"experiment_wload\", rtapp_profile)"
+    "wload = RTA.by_profile(target, rtapp_profile, name='experiment_workload')"
    ]
   },
   {

--- a/ipynb/profiling/kernel_functions_profiling.ipynb
+++ b/ipynb/profiling/kernel_functions_profiling.ipynb
@@ -347,7 +347,7 @@
     }
    ],
    "source": [
-    "wload = RTA.by_profile(target, \"profiling_wload\", rtapp_profile)"
+    "wload = RTA.by_profile(target, rtapp_profile, name='profiling_wload')"
    ]
   },
   {


### PR DESCRIPTION
Since "name" has been made optional, it is now after "profile"