### PR TITLE
lisa.energy_model: Warn when a CPU has no idle states

### DIFF
--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -812,7 +812,19 @@ class EnergyModel(Serializable, Loggable):
 
         subcls = cls._find_subcls(target)
         logger.info('Attempting to load EM using {}'.format(subcls.__name__))
-        return subcls.from_target(target)
+        em = subcls.from_target(target)
+
+        cpu_missing_idle_states = sorted(
+            node.cpu
+            for node in em.root.iter_leaves()
+            if not node.idle_states
+        )
+        if cpu_missing_idle_states:
+            logger.warning('CPUs missing idle states in cpuidle framework: {}'.format(
+                cpu_missing_idle_states,
+            ))
+
+        return em
 
     @deprecate(replaced_by='lisa.energy_model.LinuxEnergyModel.from_target', deprecated_in='2.0', removed_in='2.1')
     @staticmethod

--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -1325,7 +1325,7 @@ class LegacyEnergyModel(EnergyModel):
 
         # Sort core groups so that the lowest-numbered cores are first
         # Again, not strictly necessary, just more pleasant.
-        return sorted(ret, key=lambda x: x[0])
+        return sorted(ret, key=operator.itemgetter(0))
 
 
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -110,7 +110,11 @@ class _CpuTree(Loggable):
         else:
             if len(children) == 0:
                 raise ValueError('children cannot be empty')
-            self.cpus = tuple(sorted(set().union(*[n.cpus for n in children])))
+            self.cpus = tuple(sorted(set(
+                cpu
+                for node in children
+                for cpu in node.cpus
+            )))
             self.children = children
             for child in children:
                 child.parent = self
@@ -361,12 +365,14 @@ class EnergyModel(Serializable, Loggable):
         if self.cpus != tuple(range(len(self.cpus))):
             raise ValueError('CPU IDs [{}] are sparse'.format(self.cpus))
 
+        domains_as_set = [set(dom) for dom in freq_domains]
+
         # Check that freq_domains is a partition of the CPUs
-        fd_intersection = set().intersection(*freq_domains)
+        fd_intersection = set.intersection(*domains_as_set)
         if fd_intersection:
             raise ValueError('CPUs {} exist in multiple freq domains'.format(
                 fd_intersection))
-        fd_difference = set(self.cpus) - set().union(*freq_domains)
+        fd_difference = set(self.cpus) - set.union(*domains_as_set)
         if fd_difference:
             raise ValueError('CPUs {} not in any frequency domain'.format(
                 fd_difference))


### PR DESCRIPTION
Warn about missing idle states in EnergyModel.from_target() so that we
report missing idle states in the context of a specific target.

This is to be preferred to a warning in __init__ that would trigger on
any object built, even in cases where it could be legitimate, since that
is just a plain mutable data structure.