### PR TITLE
exekall: --replay now implies --pdb

### DIFF
--- a/doc/man1/exekall.1
+++ b/doc/man1/exekall.1
@@ -111,7 +111,7 @@ optional arguments:
                         Load the (indirect) instances of the given class from the database
                         instead of the root objects.
   \-\-replay REPLAY       Replay the execution of the given UUID, loading as much prerequisite
-                        from the DB as possible.
+                        from the DB as possible. This implies \-\-pdb for convenience.
   \-\-load\-uuid LOAD_UUID
                         Load the given UUID from the database.
   \-\-artifact\-dir ARTIFACT_DIR

--- a/tools/exekall/exekall/main.py
+++ b/tools/exekall/exekall/main.py
@@ -263,7 +263,7 @@ please run ``exekall run YOUR_SOURCES_OR_MODULES --help``.
 
     run_uuid_group = run_parser.add_mutually_exclusive_group()
     add_argument(run_uuid_group, '--replay',
-        help="""Replay the execution of the given UUID, loading as much prerequisite from the DB as possible.""")
+        help="""Replay the execution of the given UUID, loading as much prerequisite from the DB as possible. This implies --pdb for convenience.""")
 
     add_argument(run_uuid_group, '--load-uuid', action='append',
         default=[],
@@ -683,7 +683,7 @@ def do_run(args, parser, run_parser, argv):
     module_set.add(inspect.getmodule(adaptor_cls))
 
     verbose = args.verbose
-    use_pdb = args.pdb
+    use_pdb = args.pdb or args.replay
     save_db = args.save_value_db
 
     iteration_nr = args.n


### PR DESCRIPTION
Since --replay is used for debugging, make it imply --pdb so that all
users will benefit from that.