### PR TITLE
Test util task migration v5

### DIFF
--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -1848,4 +1848,29 @@ SignalDesc._SIGNALS_MAP = {
     for event, signal_descs in groupby(_SIGNALS, key=attrgetter('event'))
 }
 
+def _data_extend_index(data, extension):
+    """
+    ``data`` can either be a :class:`pandas.DataFrame` or :class:`pandas.Series`
+    """
+    return data.join(extension, how='outer')
+
+@SeriesAccessor.register_accessor
+def series_extend_index(series, extension):
+    """
+    Extending the index of a :class:`pandas.Series
+
+    :param: series: series to extend
+    :type series: :class:`pandas.Series`
+
+    :param extension: series holding the extension
+    :type extension: class:`pandas.Series`
+    """
+    return _data_extend_index(series, extension)
+
+@DataFrameAccessor.register_accessor
+def df_extend_index(df, extension):
+    """
+    Same as :func:`series_extend_index` but acting on a :class:`pandas.DataFrame`
+    """
+    return _data_extend_index(df, extension)
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -994,7 +994,7 @@ class CPUMigrationBase(LoadTrackingBase):
             # Ignore the first quarter of the util signal of each phase, since
             # it's impacted by the phase change, and util can be affected
             # (rtapp does some bookkeeping at the beginning of phases)
-            start += duration / 4
+            # start += duration / 4
             phase_df = df_window(df, (start, end), method='pre', clip_window=True)
 
             for cpu in self.cpus:

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -957,11 +957,11 @@ class CPUMigrationBase(LoadTrackingBase):
         """
         df = self.trace.analysis.load_tracking.df_cpus_signal('util')
         tasks = self.rtapp_task_ids_map.keys()
-        task = sorted(task for task in tasks if task.startswith('migr'))[0]
-        task = self.rtapp_task_ids_map[task][0]
+        migr_task = sorted(task for task in tasks if task.startswith('migr'))[0]
+        migr_task = self.rtapp_task_ids_map[migr_task][0]
 
         cpu_util = {}
-        for row in self.trace.analysis.rta.df_phases(task).itertuples():
+        for row in self.trace.analysis.rta.df_phases(migr_task).itertuples():
             phase = row.phase
             duration = row.duration
             start = row.Index


### PR DESCRIPTION
Solution for https://jira.arm.com/browse/PWRSOFT-2145

Last CI Tests: https://jenkins.oss.arm.com/view/Power/job/power/job/synthetic-tests/job/power-start-matrix-lisa-synthetics/381

- juno-r0:  OneTaskCPUMigration[board=juno-r0/00:02:F7:00:58:F3]:test_util_task_migration:  FAILED 11/50 (22.0%)
- juno-r2:  OneTaskCPUMigration[board=juno-r2/00:02:f7:00:67:99]:test_util_task_migration:  FAILED 7/50  (14.0%)
- hikey960: OneTaskCPUMigration[board=hikey960/00:0e:c6:b9:54:d7]:test_util_task_migration: passed 50/50 (100.0%)
- TC2:      OneTaskCPUMigration[board=tc2/00:02:F7:00:48:A4]:test_util_task_migration:      passed 50/50 (100.0%)
- db845c:   OneTaskCPUMigration[board=db845c/00:e0:4c:75:10:0f]:test_util_task_migration:   passed 50/50 (100.0%)

Commit 8cf1198ad718 "lisa.tests.scheduler.load_tracking: Fix remaining issue for CPUMigrationBase::test_util_task_migration" brings the error rate for juno-r0 and juno-r2 furher down to:

- juno-r0:  OneTaskCPUMigration[board=juno-r0/00:02:F7:00:58:F3]:test_util_task_migration:  FAILED 3/50 (6.0%)
- juno-r2:  OneTaskCPUMigration[board=juno-r2/00:02:f7:00:67:99]:test_util_task_migration:  FAILED 2/50  (4.0%)
 