### PR TITLE
setup.py: Bump required Python to >= 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     license='LICENSE.txt',
     description='A stick to probe the kernel with',
     long_description=long_description,
-    python_requires='>= 3.5',
+    python_requires='>= 3.6',
     install_requires=[
         "psutil >= 4.4.2",
         # Figure.savefig() (without pyplot) does not work in


### PR DESCRIPTION
Prepare comming changes that will require Python >= 3.6.
It's time to upgrade now before any such change is merged.