### PR TITLE
lisa.datautils: Add signal for userspace@cpu_frequency_devlib

### DIFF
--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -1791,6 +1791,7 @@ _SIGNALS = [
     SignalDesc('cpu_idle', ['cpu_id']),
     SignalDesc('cpu_capacity', ['cpu_id']),
     SignalDesc('cpu_frequency', ['cpu_id']),
+    SignalDesc('userspace@cpu_frequency_devlib', ['cpu_id']),
     SignalDesc('sched_compute_energy', ['comm', 'pid']),
 
     SignalDesc('sched_pelt_se', ['comm', 'pid']),


### PR DESCRIPTION
Add missing signal so that
FrequencyAnalysis.df_cpus_frequency(signals_init=True) can make use of
the userspace events outside of the window.