### PR TITLE
lisa.conf: Improve exception handling of deferred values

### DIFF
--- a/tools/lisa-platinfo-extract
+++ b/tools/lisa-platinfo-extract
@@ -33,7 +33,7 @@ def main():
 
     # Make sure we get all the information we can, even if it means running for
     # a bit longer. RTapp calibration will be computed as it is a DeferredValue
-    plat_info.eval_deferred()
+    plat_info.eval_deferred(error='log')
 
     print(plat_info)
 


### PR DESCRIPTION
Add MultiSrcConf.eval_deferred(error='raise') parameter to keep going when
exceptions are raised with error='log'. This allows the consumer to
gather as many values as possible, and handle the exception later when
iterating over the object.