### PR TITLE
lisa.energy_model: Fix EnergyModel building with all CPUs in one freq…

### DIFF
--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -365,7 +365,7 @@ class EnergyModel(Serializable, Loggable):
 
         # Check that freq_domains is a partition of the CPUs
         fd_intersection = set.intersection(*domains_as_set)
-        if fd_intersection:
+        if len(domains_as_set) > 1 and fd_intersection:
             raise ValueError('CPUs {} exist in multiple freq domains'.format(
                 fd_intersection))
         fd_difference = set(self.cpus) - set.union(*domains_as_set)


### PR DESCRIPTION
… domain

Rather than raising an exception, taking the intersection of a set
with no other set gives back the initial set:

  set.intersection(x) == x

This made EnergyModel choke on calls with all CPUs in the same frequency
domain.

Fix that by checking the number of domains first.