### PR TITLE
lisa.analysis.tasks: Fix TaksState.__module__

### DIFF
--- a/lisa/analysis/tasks.py
+++ b/lisa/analysis/tasks.py
@@ -51,6 +51,11 @@ class StateInt(int):
             int(self) | int(other),
             char=(self.char + other.char))
 
+    # This is needed for some obscure reason (maybe a bug in std library ?)
+    # In any case, if we don't provide that, Enum's metaclass will "sabbotage"
+    # pickling, and by doing so, will set cls.__module__ = '<unknown>'
+    __reduce__ = int.__reduce__
+
 
 class TaskState(StateInt, Enum):
     """

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -790,7 +790,11 @@ class TestBundle(Serializable, ExekallTaggable, abc.ABC, metaclass=TestBundleMet
         return bundle
 
     @classmethod
-    def _filepath(cls, res_dir):
+    def _get_filepath(cls, res_dir):
+        """
+        Returns the path of the file containing the serialized object in
+        ``res_dir`` folder.
+        """
         return ArtifactPath.join(res_dir, "{}.yaml".format(cls.__qualname__))
 
     @classmethod
@@ -798,12 +802,15 @@ class TestBundle(Serializable, ExekallTaggable, abc.ABC, metaclass=TestBundleMet
         """
         Wrapper around :meth:`lisa.utils.Serializable.from_path`.
 
-        It uses :meth:`_filepath` to get the name of the serialized file to
+        It uses :meth:`_get_filepath` to get the name of the serialized file to
         reload.
+
+
+         .. automethod:: _get_filepath
         """
         res_dir = ArtifactPath(root=res_dir, relative='')
 
-        bundle = super().from_path(cls._filepath(res_dir))
+        bundle = super().from_path(cls._get_filepath(res_dir))
         # We need to update the res_dir to the one we were given
         if update_res_dir:
             bundle.res_dir = res_dir
@@ -814,7 +821,7 @@ class TestBundle(Serializable, ExekallTaggable, abc.ABC, metaclass=TestBundleMet
         """
         See :meth:`lisa.utils.Serializable.to_path`
         """
-        super().to_path(self._filepath(res_dir))
+        super().to_path(self._get_filepath(res_dir))
 
 
 class FtraceTestBundleMeta(TestBundleMeta):

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -85,7 +85,9 @@ class LoadTrackingHelpers:
     @classmethod
     def filter_capacity_classes(cls, plat_info):
         """
-        Filter out capacity-classes key of ``plat_info`` to remove blacklisted CPUs.
+        Filter out capacity-classes key of ``plat_info`` to remove blacklisted
+        CPUs.
+
         .. seealso:: :meth:`_get_blacklisted_cpus`
         """
         blacklisted_cpus = set(cls._get_blacklisted_cpus(plat_info))

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -86,9 +86,9 @@ class LoadTrackingHelpers:
     def filter_capacity_classes(cls, plat_info):
         """
         Filter out capacity-classes key of ``plat_info`` to remove blacklisted
-        CPUs.
+        CPUs provided by:
 
-        .. seealso:: :meth:`_get_blacklisted_cpus`
+        .. automethod:: _get_blacklisted_cpus
         """
         blacklisted_cpus = set(cls._get_blacklisted_cpus(plat_info))
         return [

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -577,6 +577,7 @@ class TxtTraceParserBase(TraceParserBase):
         be inferred from the fields parsed in the trace, which is costly and
         can lead to using larger dtypes than necessary (e.g. ``int64`` rather
         than ``uint16``).
+
         .. seealso:: :class:`TxtEventParser`
     :type event_parsers: list(EventParserBase)
 
@@ -1141,6 +1142,7 @@ class TxtTraceParser(TxtTraceParserBase):
         be inferred from the fields parsed in the trace, which is costly and can
         lead to using larger dtypes than necessary (e.g. ``int64`` rather than
         ``uint16``).
+
         .. seealso:: :class:`TxtEventParser`
     :type event_parsers: list(EventParserBase)
 
@@ -3015,6 +3017,7 @@ class Trace(Loggable, TraceBase):
 
     :param events: events to be parsed. Since events can be loaded on-demand,
         that is optional but still recommended to improve trace parsing speed.
+
         .. seealso:: :meth:`df_event` for event formats accepted.
     :type events: list(str) or None
 


### PR DESCRIPTION
Prevent Enum's metaclass to set TaskState.__module__ = '<unknown>' by
providing StateInt.__reduce__