### PR TITLE
lisa.utils: Fix deprecate(msg=...) for multilines msg

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -1235,7 +1235,7 @@ def deprecate(msg=None, replaced_by=None, deprecated_in=None, removed_in=None, p
         removed_in = parse_version(removed_in)
     current_version = lisa.version.version_tuple
 
-    def make_msg(deprecated_obj, parameter=None, style=None, show_doc_url=True):
+    def make_msg(deprecated_obj, parameter=None, style=None, show_doc_url=True, indent=None):
         if replaced_by is not None:
             doc_url = ''
             if show_doc_url:
@@ -1261,11 +1261,18 @@ def deprecate(msg=None, replaced_by=None, deprecated_in=None, removed_in=None, p
                 parameter = '``{}``'.format(parameter)
             name = '{} parameter of {}'.format(parameter, name)
 
+        if msg is None:
+            _msg = ''
+        else:
+            _msg = textwrap.dedent(msg).strip()
+            if indent:
+                _msg = _msg.replace('\n', '\n' + indent)
+
         return '{name} is deprecated{remove}{replace}{msg}'.format(
             name=name,
             replace=replacement_msg,
             remove=removal_msg,
-            msg=': ' + msg if msg else '',
+            msg=': ' +  _msg if _msg else '',
         )
 
     def decorator(obj):
@@ -1356,7 +1363,7 @@ def deprecate(msg=None, replaced_by=None, deprecated_in=None, removed_in=None, p
                 deprecated_in=deprecated_in if deprecated_in else '<unknown>',
                 # The documentation already creates references to the replacement,
                 # so we can avoid downloading the inventory for nothing.
-                msg=make_msg(obj, parameter, style='rst', show_doc_url=False),
+                msg=make_msg(obj, parameter, style='rst', show_doc_url=False, indent=' ' * 12),
             )).strip()
         doc = inspect.getdoc(update_doc_of) or ''
 


### PR DESCRIPTION
Correctly indent the message when it spans multiple lines.