### PR TITLE
lisa.tests.base: TestBundle._fixup_res_dir handle reference cycle

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -833,10 +833,13 @@ class TestBundle(Serializable, ExekallTaggable, abc.ABC, metaclass=TestBundleMet
         This is used for some post-deserialization fixup that need to walk the
         whole graph of :class:`TestBundle`.
         """
-        return set(self._get_referred_objs(
+        objs = set(self._get_referred_objs(
             self,
             lambda x: isinstance(x, TestBundle)
         ))
+
+        objs.discard(self)
+        return objs
 
     def _fixup_res_dir(self, new):
         orig_root = self.res_dir

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -846,9 +846,7 @@ class TestBundle(Serializable, ExekallTaggable, abc.ABC, metaclass=TestBundleMet
             absolute = os.path.abspath(os.path.join(new, rel))
             obj.res_dir = absolute
 
-        fixup(self)
-
-        for child in self._children_test_bundles:
+        for child in self._children_test_bundles | {self}:
             fixup(child)
 
     @classmethod


### PR DESCRIPTION
Ensure we don't fixup twice the res_dir of the toplevel object.