### PR TITLE
lisa.tests.base: TestBundle: set res_dir in from_dir()

### DIFF
--- a/tests/test_test_bundle.py
+++ b/tests/test_test_bundle.py
@@ -60,7 +60,7 @@ class BundleCheck(StorageTestCase):
         """
         Test that creating a dummy bundle works
         """
-        bundle = DummyTestBundle(None, "42")
+        bundle = DummyTestBundle("/foo", "42")
 
     def test_target_init(self):
         """
@@ -72,7 +72,7 @@ class BundleCheck(StorageTestCase):
         """
         Test that bundle serialization works correctly
         """
-        bundle = DummyTestBundle(None, "42")
+        bundle = DummyTestBundle("/foo", "42")
         output = bundle.shell_output
 
         bundle.to_dir(self.res_dir)


### PR DESCRIPTION
When creating a TestBundle instance from a dir, res_dir is
never set. However the variable is required in case of
a new serialization, or to set the res_dir variable of
the TestBundle instances referenced in __children_test_bundles.