### PR TITLE
energy_model: fix single CPU cluster energy estimate

### DIFF
--- a/lisa/energy_model.py
+++ b/lisa/energy_model.py
@@ -626,12 +626,19 @@ class EnergyModel(Serializable, Loggable):
             _idle_power = max(node.idle_states[idle_states[c]] for c in cpus)
             idle_power = _idle_power * (1 - active_time)
 
+            if cpus not in ret:
+                if combine:
+                    ret[cpus] = 0
+                else:
+                    ret[cpus] = {}
+                    ret[cpus]["active"] = 0
+                    ret[cpus]["idle"] = 0
+
             if combine:
-                ret[cpus] = active_power + idle_power
+                ret[cpus] += active_power + idle_power
             else:
-                ret[cpus] = {}
-                ret[cpus]["active"] = active_power
-                ret[cpus]["idle"] = idle_power
+                ret[cpus]["active"] += active_power
+                ret[cpus]["idle"] += idle_power
 
         return ret
 


### PR DESCRIPTION
Some topologies like the Pixel4 have a single CPU on a cluster. In this
case, the CPU and the cluster are described similarly:

e.g. multiple CPUs cluster:

 Single CPU description: (4, )
 Cluster description: (4, 5, 6)

e.g. single CPU cluster:

 Single CPU description: (7, )
 Cluster description: (7, )

This is problematic in _estimate_from_active_time(), as the energy computed
would be overwritten. Ensure a single result table initialization when
several nodes have the same description. This avoid losing the energy
computed for the first nodes of an identical description.

Signed-off-by: Vincent Donnefort <vincent.donnefort@arm.com>