### PR TITLE
lisa.stats: Do not use unit column for aggregation

### DIFF
--- a/lisa/stats.py
+++ b/lisa/stats.py
@@ -344,7 +344,9 @@ class Stats(Loggable):
         else:
             raise ValueError('No aggregation column can be inferred. Either pass a ref_group or agg_cols')
 
-        agg_cols = sorted(set(agg_cols) - {value_col})
+        agg_cols = sorted(set(agg_cols) - {value_col, unit_col})
+        if not agg_cols:
+            raise ValueError('No aggregation columns have been selected, ensure that each special column has only one use')
 
         # Ultimately, the tags we want to have in the stat dataframe will not
         # include the one we aggregated over

--- a/lisa/stats.py
+++ b/lisa/stats.py
@@ -823,8 +823,8 @@ class Stats(Loggable):
         Returns a :class:`matplotlib.figure.Figure` containing the statistics
         for the class input :class:`pandas.DataFrame`.
 
-        :param filename: Path to HTML plot file to create
-        :type filename: str
+        :param filename: Path to the image file to write to.
+        :type filename: str or None
         """
         df = self.get_df(
             remove_ref=remove_ref,
@@ -981,7 +981,7 @@ class Stats(Loggable):
         :param nbins: Number of bins for the distribution.
         :type nbins: int or None
 
-        :param filename: Create a HTML file containing the plot.
+        :param filename: Path to the image file to write to.
         :type filename: str or None
         """
         def plot_func(df, group, ax, x_col, y_col):
@@ -1006,7 +1006,8 @@ class Stats(Loggable):
         Returns a :class:`matplotlib.figure.Figure` with the values in the input
         :class:`pandas.DataFrame`.
 
-        :param filename: Create a HTML file containing the plot.
+        :param filename: Path to the image file to write to.
+        :type filename: str or None
         """
 
         def plot_func(df, group, ax, x_col, y_col):


### PR DESCRIPTION
The columns to aggregate can be auto-detected. Make sure the unit column
is not taken as part of it, as it will confuse some methods that expect
the unit to not be part of the aggregation column.