### PR TITLE
tools: lisa-plot: Only use pyplot.show() for interactive

### DIFF
--- a/tools/lisa-plot
+++ b/tools/lisa-plot
@@ -358,7 +358,6 @@ Available plots:
         if interactive:
             plt.show()
 
-    plt.show()
 if __name__ == '__main__':
     ret = main(sys.argv[1:])
     sys.exit(ret)


### PR DESCRIPTION
Remove extra pyplot.show() call that is likely a left over from a
refactoring.