### PR TITLE
self tests: Replace nose by pytest

### DIFF
--- a/doc/contributors_guide.rst
+++ b/doc/contributors_guide.rst
@@ -17,9 +17,7 @@ Updating the subtrees
 
 If you got a Pull Request merged in e.g. :mod:`devlib` and want to use some of
 the features you introduced in LISA, you'll need to update the subtrees. There is
-a handy LISA shell command available for that:
-
-  >>> lisa-update-subtrees
+a handy LISA shell command available for that: ``lisa-update-subtrees``.
 
 This will update every subtree in the repository with the right incantation, and
 the result can be pushed straight away to LISA as a Pull Request (or included in
@@ -56,11 +54,15 @@ self-tests, which is a mix of unit and behavioural tests.
 
 From the root of LISA, you can run those tests like so:
 
->>> python3 -m nose
->>> # You can also target specific test modules
->>> python3 -m nose tests/test_test_bundle.py
->>> # Or even specific test classes
->>> python3 -m nose tests/test_test_bundle.py:BundleCheck
+    .. code-block:: shell
+
+        python3 -m pytest
+        # You can also target specific test modules
+        python3 -m pytest tests/test_test_bundle.py
+        # Or even specific test classes
+        python3 -m pytest tests/test_test_bundle.py::BundleCheck
+        # Or even specific test method
+        python3 -m pytest tests/test_test_bundle.py::BundleCheck::test_init
 
 Writing self-tests
 ++++++++++++++++++

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths=tests
+# Ignore DeprecationWarning on "from imp import reload" in the past module
+# (from python-future)
+filterwarnings =
+    error
+    ignore::DeprecationWarning:past.builtins.misc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[nosetests]
-# The default regex can match things like create_local_testenv
-# We don't want that
-match=^[Tt]est_
-
 [flake8]
 ignore = E501,E128,E124,E402,E721,E712
 filename = lisa/*.py,tests/*.py,tools/bisector/*.py,tools/exekall/*.py,doc/*.py

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         ],
 
         "test": [
-            "nose",
+            "pytest",
         ],
     },
 

--- a/tests/test_datautils.py
+++ b/tests/test_datautils.py
@@ -33,6 +33,6 @@ class DfCheck(TestCase):
 
         for ident, subdf in du.df_split_signals(df, ["bar"]):
             if ident["bar"] == 0:
-                self.assertEqual(len(subdf), 3)
+                assert len(subdf) == 3
             else:
-                self.assertEqual(len(subdf), 2)
+                assert len(subdf) == 2

--- a/tests/test_events_checkers.py
+++ b/tests/test_events_checkers.py
@@ -16,6 +16,7 @@
 #
 
 from unittest import TestCase
+import pytest
 
 from lisa.utils import nullcontext
 from lisa.trace import TraceEventChecker, AndTraceEventChecker, OrTraceEventChecker, MissingTraceEventError
@@ -23,10 +24,12 @@ from lisa.trace import TraceEventChecker, AndTraceEventChecker, OrTraceEventChec
 """ A test suite for event checking infrastructure."""
 
 
-class TestEventCheckerBase:
+class TestEventCheckerBase(TestCase):
     """
     A test class that verifies checkers work as expected
     """
+    __test__ = False
+
     EVENTS_SET = {'foo', 'bar', 'baz'}
     expected_success = True
 
@@ -34,59 +37,79 @@ class TestEventCheckerBase:
         if self.expected_success:
             cm = nullcontext()
         else:
-            cm = self.assertRaises(MissingTraceEventError)
+            cm = pytest.raises(MissingTraceEventError)
 
         with cm:
             print('Checking: {}'.format(self.checker))
             self.checker.check_events(self.EVENTS_SET)
 
 
-class TestEventChecker_and1(TestEventCheckerBase, TestCase):
+class TestEventChecker_and1(TestEventCheckerBase):
+    __test__ = True
+
     checker = AndTraceEventChecker.from_events(['foo', 'bar'])
 
 
-class TestEventChecker_and2(TestEventCheckerBase, TestCase):
+class TestEventChecker_and2(TestEventCheckerBase):
+    __test__ = True
+
     checker = AndTraceEventChecker.from_events(['foo', 'lancelot'])
     expected_success = False
 
 
-class TestEventChecker_or1(TestEventCheckerBase, TestCase):
+class TestEventChecker_or1(TestEventCheckerBase):
+    __test__ = True
+
     checker = OrTraceEventChecker.from_events(['foo', 'bar'])
 
 
-class TestEventChecker_or2(TestEventCheckerBase, TestCase):
+class TestEventChecker_or2(TestEventCheckerBase):
+    __test__ = True
+
     checker = OrTraceEventChecker.from_events(['foo', 'lancelot'])
 
 
-class TestEventChecker_or3(TestEventCheckerBase, TestCase):
+class TestEventChecker_or3(TestEventCheckerBase):
+    __test__ = True
+
     checker = OrTraceEventChecker.from_events(['arthur', 'lancelot'])
     expected_success = False
 
 
-class TestEventChecker_single1(TestEventCheckerBase, TestCase):
+class TestEventChecker_single1(TestEventCheckerBase):
+    __test__ = True
+
     checker = TraceEventChecker('bar')
 
 
-class TestEventChecker_single2(TestEventCheckerBase, TestCase):
+class TestEventChecker_single2(TestEventCheckerBase):
+    __test__ = True
+
     checker = TraceEventChecker('non-existing-event')
     expected_success = False
 
 
-class TestEventChecker_and3(TestEventCheckerBase, TestCase):
+class TestEventChecker_and3(TestEventCheckerBase):
+    __test__ = True
+
     checker = AndTraceEventChecker.from_events([
         TestEventChecker_and1.checker,
         TestEventChecker_or1.checker,
     ])
 
 
-class TestEventChecker_and4(TestEventCheckerBase, TestCase):
+class TestEventChecker_and4(TestEventCheckerBase):
+    __test__ = True
+
     checker = AndTraceEventChecker.from_events([
         TestEventChecker_and1.checker,
         TestEventChecker_or2.checker,
     ])
 
 
-class TestEventChecker_and5(TestEventCheckerBase, TestCase):
+class TestEventChecker_and5(TestEventCheckerBase):
+    __test__ = True
+
     checker = AndTraceEventChecker.from_events([
         TestEventChecker_and1.checker,
         TestEventChecker_and2.checker,

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -30,4 +30,4 @@ class TargetEnvCheck(TestCase):
         args = "--kind host --password 'foobar'"
         target = Target.from_cli(shlex.split(args))
 
-        self.assertNotEqual(target.os, None)
+        assert target.os is not None

--- a/tests/test_test_bundle.py
+++ b/tests/test_test_bundle.py
@@ -20,11 +20,18 @@ from lisa.platforms.platinfo import PlatformInfo
 from lisa.tests.base import TestBundle, ResultBundle
 from .utils import create_local_target, StorageTestCase
 
+class TestBundle(TestBundle):
+    """
+    Dummy proxy class so that pytest does not try to build it, since it
+    contains "Test" in the name.
+    """
+    __test__ = False
 
 class DummyTestBundle(TestBundle):
     """
     A dummy bundle that only does some simple target interaction
     """
+    __test__ = False
 
     def __init__(self, res_dir, shell_output):
         plat_info = PlatformInfo()
@@ -52,8 +59,8 @@ class BundleCheck(StorageTestCase):
     base behaviours.
     """
 
-    def setUp(self):
-        super().setUp()
+    def setup_method(self, method):
+        super().setup_method(method)
         self.target = create_local_target()
 
     def test_init(self):
@@ -78,4 +85,4 @@ class BundleCheck(StorageTestCase):
         bundle.to_dir(self.res_dir)
         bundle = DummyTestBundle.from_dir(self.res_dir)
 
-        self.assertEqual(output, bundle.shell_output)
+        assert output == bundle.shell_output

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,8 +55,8 @@ class StorageTestCase(TestCase):
     A base class for tests that also provides a directory
     """
 
-    def setUp(self):
+    def setup_method(self, method):
         self.res_dir = tempfile.mkdtemp()
 
-    def tearDown(self):
+    def teardown_method(self, method):
         shutil.rmtree(self.res_dir)

--- a/tests/wlgen.py
+++ b/tests/wlgen.py
@@ -58,7 +58,7 @@ class TestTarget(LocalLinuxTarget):
         self.execute_calls = []
 
 
-class WlgenSelfBase(TestCase):
+class WlgenBase(TestCase):
     """
     Base class for wlgen self-tests
 
@@ -85,7 +85,7 @@ class WlgenSelfBase(TestCase):
             os.getenv('LISA_HOME'), 'results',
             'lisa_selftest_out_{}'.format(self.__class__.__name__))
 
-    def setUp(self):
+    def setup_method(self, method):
         self.target = TestTarget()
 
         tools_path = os.path.join(os.getenv('LISA_HOME'),

--- a/tools/travis_tests.sh
+++ b/tools/travis_tests.sh
@@ -36,8 +36,8 @@ source init_env || exit 1
 # Failing commands will make the script return with an error code
 set -e
 
-echo "Starting nosetests ..."
-python3 -m nose -vv
+echo "Starting self tests ..."
+python3 -m pytest -vv
 
 echo "Starting exekall self tests"
 exekall run "$LISA_HOME/tools/exekall/exekall/tests"


### PR DESCRIPTION
nose is not maintained anymore and has a number of annoying behaviours,
so replace it with the more widely-used pytest.

PENDING ON:
https://github.com/ARM-software/devlib/pull/514
Otherwise, the tests fail at import time since the SyntaxWarning is turned into an error