### PR TITLE
lisa.conf: Add default conf example to conf class docstrings

### DIFF
--- a/lisa/doc/helpers.py
+++ b/lisa/doc/helpers.py
@@ -225,6 +225,7 @@ class DocPlotConf(SimpleMultiSrcConf):
     Analysis plot method arguments configuration for the documentation.
 
     {generated_help}
+    {yaml_example}
     """
     STRUCTURE = TopLevelKeyDesc('doc-plot-conf', 'Plot methods configuration', (
         # Avoid deepcopy of the value, since it contains a Trace object that we

--- a/lisa/energy_meter.py
+++ b/lisa/energy_meter.py
@@ -127,6 +127,7 @@ class HWMonConf(SimpleMultiSrcConf, HideExekallID):
     Configuration class for :class:`HWMon`.
 
     {generated_help}
+    {yaml_example}
     """
     STRUCTURE = TopLevelKeyDesc('hwmon-conf', 'HWMon Energy Meter configuration', (
         # TODO: find a better help and maybe a better type
@@ -307,6 +308,7 @@ class AEPConf(SimpleMultiSrcConf, HideExekallID):
     Configuration class for :class:`AEP`.
 
     {generated_help}
+    {yaml_example}
     """
     STRUCTURE = TopLevelKeyDesc('aep-conf', 'AEP Energy Meter configuration', (
         KeyDesc('channel-map', 'Channels to use', [Mapping]),
@@ -353,6 +355,7 @@ class MonsoonConf(SimpleMultiSrcConf, HideExekallID):
     Configuration class for :class:`Monsoon`.
 
     {generated_help}
+    {yaml_example}
     """
     STRUCTURE = TopLevelKeyDesc('monsoon-conf', 'Monsoon Energy Meter configuration', (
         KeyDesc('channel-map', 'Channels to use', [Mapping]),
@@ -395,6 +398,7 @@ class ACMEConf(SimpleMultiSrcConf, HideExekallID):
     Configuration class for :class:`ACME`.
 
     {generated_help}
+    {yaml_example}
     """
     STRUCTURE = TopLevelKeyDesc('acme-conf', 'ACME Energy Meter configuration', (
         KeyDesc('channel-map', 'Channels to use', [Mapping]),
@@ -605,6 +609,7 @@ class Gem5EnergyMeterConf(SimpleMultiSrcConf, HideExekallID):
     Configuration class for :class:`Gem5EnergyMeter`.
 
     {generated_help}
+    {yaml_example}
     """
     STRUCTURE = TopLevelKeyDesc('gem5-energy-meter-conf', 'Gem5 Energy Meter configuration', (
         KeyDesc('channel-map', 'Channels to use', [Mapping]),

--- a/lisa/platforms/platinfo.py
+++ b/lisa/platforms/platinfo.py
@@ -80,6 +80,7 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
     Platform-specific information made available to tests.
 
     {generated_help}
+    {yaml_example}
 
     """
 

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1003,6 +1003,7 @@ class DmesgTestConf(SimpleMultiSrcConf):
     Configuration class for :meth:`lisa.tests.base.DmesgTestBundle.test_dmesg`.
 
     {generated_help}
+    {yaml_example}
     """
     STRUCTURE = TopLevelKeyDesc('dmesg-test-conf', 'Dmesg test configuration', (
         KeyDesc('ignored-patterns', 'List of Python regex matching dmesg entries content to be whitelisted', [TypedList[str]]),

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -4943,6 +4943,7 @@ class FtraceConf(SimpleMultiSrcConf, HideExekallID):
 
     Available keys:
     {generated_help}
+    {yaml_example}
     """
     STRUCTURE = TopLevelKeyDesc('ftrace-conf', 'FTrace configuration', (
         KeyDesc('events', 'FTrace events to trace', [TypedList[str]]),

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -149,7 +149,7 @@ def get_subclasses(cls, only_leaves=False, cls_set=None):
     return cls_set
 
 
-def get_cls_name(cls, style=None):
+def get_cls_name(cls, style=None, fully_qualified=True):
     """
     Get a prettily-formated name for the class given as parameter
 
@@ -162,8 +162,13 @@ def get_cls_name(cls, style=None):
     """
     if cls is None:
         return 'None'
-    mod_name = inspect.getmodule(cls).__name__
-    mod_name = mod_name + '.' if mod_name not in ('builtins', '__main__') else ''
+
+    if fully_qualified or style == 'rst':
+        mod_name = inspect.getmodule(cls).__name__
+        mod_name = mod_name + '.' if mod_name not in ('builtins', '__main__') else ''
+    else:
+        mod_name = ''
+
     name = mod_name + cls.__qualname__
     if style == 'rst':
         name = ':class:`~{}`'.format(name)


### PR DESCRIPTION
Configuration classes docstrings can now use the {yaml_example}
placeholder in addition to {generated_help}.