### PR TITLE
lisa-install: Avoid minimizing jupyter lab extensions

### DIFF
--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -191,7 +191,7 @@ function _lisa-install-nbextensions {
     if which node &>/dev/null; then
         echo
         echo "Installing jupyter lab extensions..."
-        jupyter labextension install                    \
+        jupyter labextension install --minimize=False   \
             @jupyter-widgets/jupyterlab-manager         \
             jupyter-matplotlib
         return


### PR DESCRIPTION
Minimizing takes a very long time and is not needed since the install is
local, there is no point in minimizing network traffic.