### PR TITLE
lisa.tests.base: Ignore empty dmesg lines in test_dmesg()

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1254,9 +1254,10 @@ class DmesgTestBundle(TestBundle):
             entry
             for entry in self.dmesg_entries
             if (
-                (entry.facility == facility if facility else True)
+                entry.msg.strip()
+                and (entry.facility == facility if facility else True)
                 and (entry.level in issue_levels)
-                and not any(regex.search(entry.msg) for regex in ignored_regex)
+                and not any(regex.search(entry.msg.strip()) for regex in ignored_regex)
             )
         ]
 


### PR DESCRIPTION
Entries with an empty message (or full of whitespaces) are ignored, to
avoid any issue with mulitline messages that might use such empty lines
for formatting.