### PR TITLE
.readthedocs.yml: Bump Python version to 3.7

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,6 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
+  version: 3.7
   install:
     - requirements: doc/doc_requirements.txt

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -476,7 +476,7 @@ class TestBundleMeta(abc.ABCMeta):
 
         :Example:
 
-        .. code-block ::
+        .. code-block:: python
 
             class Foo(TestBundle):
                 @TestBundle.add_undecided_filter


### PR DESCRIPTION
New numpy pre-release version only supports Python >= 3.7, and for some
reason, pip seems to pick it despite not being told to do so with --pre.

Since we don't really *need* Python 3.6, just bump the version so the
doc keeps building.

https://github.com/numpy/numpy/issues/17909