### PR TITLE
lisa.stats: Avoid warning triggered by numpy

### DIFF
--- a/lisa/stats.py
+++ b/lisa/stats.py
@@ -914,6 +914,14 @@ class Stats(Loggable):
                 ]
             except KeyError:
                 error = None
+            else:
+                # Avoid warning from numpy inside matplotlib when there is no
+                # confidence interval value at all
+                if all(
+                    series.isna().all()
+                    for series in error
+                ):
+                    error = None
 
             if kind == 'horizontal_bar':
                 error_bar = dict(xerr=error)


### PR DESCRIPTION
When giving a Series of NaN to matplotlib for the error bars, it will
trigger a warning from numpy deep down the stack. Avoid that by removing
the error bar altogether in that case.