### PR TITLE
tools: batch-rebase: Add required positional argument

### DIFF
--- a/tools/batch-rebase
+++ b/tools/batch-rebase
@@ -496,7 +496,7 @@ def main():
                     url: git://linux-arm.org/linux-power.git
 
 
-        ''').format(manifest_doc=BatchRebaseManifest.get_help()),
+        ''').format(manifest_doc=BatchRebaseManifest.get_help(style=None)),
         formatter_class=argparse.RawDescriptionHelpFormatter,
 
     )


### PR DESCRIPTION
get_help() is missing the required positional argument 'style'. Add it.

Signed-off-by: Dietmar Eggemann <dietmar.eggemann@arm.com>