### PR TITLE
lisa.stats: Add plotly support for plot_stats()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,8 @@ setup(
         # Depdendencies that are shipped as part of the LISA repo as
         # subtree/submodule
         "devlib",
+
+        "plotly"
     ],
 
     extras_require=extras_require,

--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -193,7 +193,8 @@ function _lisa-install-nbextensions {
         echo "Installing jupyter lab extensions..."
         jupyter labextension install --minimize=False   \
             @jupyter-widgets/jupyterlab-manager         \
-            jupyter-matplotlib
+            jupyter-matplotlib                          \
+            jupyterlab-plotly
         return
     fi
 


### PR DESCRIPTION
Plotly is a data visualization framework which offers a more user friendly
interface, compared to Matplotlib. This patch allows to use this framework
with the Stats plot_stats() function. The later still defaults to
Matplotlib. Plotly can be enabled by passing backend='plotly'.