### PR TITLE
exekall: engine: Handle lack of "__builtins__" in a callable's __glob…

### DIFF
--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -2461,7 +2461,11 @@ class Operator:
 
         # Work around this bug:
         # https://bugs.python.org/issue43102
-        globals_['__builtins__'] = globals_['__builtins__'] or {}
+        try:
+            globals_['__builtins__'] = globals_['__builtins__'] or {}
+        except KeyError:
+            pass
+
         return globals_
 
     @property


### PR DESCRIPTION
…als__

Since __builtins__ might not be present, ensure we handle this case.