### PR TITLE
lisa.analysis.frequency: 'Time' as an index name for df_cpus_frequency

### DIFF
--- a/lisa/analysis/frequency.py
+++ b/lisa/analysis/frequency.py
@@ -112,6 +112,7 @@ class FrequencyAnalysis(TraceAnalysisBase):
 
         df = pd.concat([first_df, df])
         df.sort_index(inplace=True)
+        df.index.name = 'Time'
         return check_empty(df, None)
 
     @df_cpus_frequency.used_events


### PR DESCRIPTION
When no cpu_frequency event has been found, df_cpus_frequency will try to
get the devlib ones. In that case, the returned DataFrame won't use 'Time'
as an index. Some tests are relying on this name, so let's harmonize it.