### PR TITLE
lisa.wlgen.rta: Fix uclamp defaults on older kernels

### DIFF
--- a/doc/traces/plat_info.yml
+++ b/doc/traces/plat_info.yml
@@ -6277,7 +6277,7 @@ platform-info:
                     CONFIG_ZYNQMP_PM_DOMAINS=y
                     CONFIG_ZYNQMP_POWER=y
             version: !call:devlib.target.KernelVersion
-                version_string: 'Linux 5.3.0-rc1-00050-g02b329bf560e #20 SMP PREEMPT Mon Aug 19 14:25:43 BST 2019'
+                version_string: '5.3.0-rc1-00050-g02b329bf560e #20 SMP PREEMPT Mon Aug 19 14:25:43 BST 2019'
 
         name: juno-r0
         os: linux

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -2230,7 +2230,7 @@ class UclampProperty(ComposableMultiConcretePropertyBase):
     def to_json(self, plat_info):
         min_ = self.min_
         max_ = self.max_
-        if (min_, max_) != (None, None) and min_ > max_:
+        if None not in (min_, max_) and min_ > max_:
             raise ValueError(f'{self.__class__.__qualname__}: min={min_} cannot be higher than max={max_}')
 
         def_min, def_max = self._get_default(plat_info)


### PR DESCRIPTION
Use (0, 1024) on kernels not supporting clamp removal with (-1, -1)