### PR TITLE
lisa.pelt: Fixup simulate_pelt() clock on task enqueue/dequeue

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -27,7 +27,7 @@ from lisa.tests.base import (
     RTATestBundle, CannotCreateError
 )
 from lisa.target import Target
-from lisa.utils import ArtifactPath, groupby, ExekallTaggable, add
+from lisa.utils import ArtifactPath, groupby, ExekallTaggable, add, memoized
 from lisa.datautils import series_mean, df_window, df_filter_task_ids, series_refit_index, df_split_signals, df_refit_index, series_dereference
 from lisa.wlgen.rta import RTA, RTAPhase, PeriodicWload
 from lisa.trace import FtraceCollector, requires_events, may_use_events, MissingTraceEventError
@@ -422,6 +422,7 @@ class InvarianceItem(LoadTrackingBase, ExekallTaggable):
         return res
 
     @get_simulated_pelt.used_events
+    @memoized
     def _test_correctness(self, signal_name, mean_error_margin_pct, max_error_margin_pct):
 
         task = self.task_name

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -649,7 +649,7 @@ class Invariance(TestBundle, LoadTrackingHelpers):
                 mean_error_margin_pct=mean_error_margin_pct,
                 max_error_margin_pct=max_error_margin_pct,
             )
-        return self._test_all_freq(item_test)
+        return self._test_all_items(item_test)
 
     @InvarianceItem.test_load_correctness.used_events
     def test_load_correctness(self, mean_error_margin_pct=2, max_error_margin_pct=5) -> AggregatedResultBundle:
@@ -661,7 +661,7 @@ class Invariance(TestBundle, LoadTrackingHelpers):
                 mean_error_margin_pct=mean_error_margin_pct,
                 max_error_margin_pct=max_error_margin_pct,
             )
-        return self._test_all_freq(item_test)
+        return self._test_all_items(item_test)
 
     @InvarianceItem.test_util_behaviour.used_events
     def test_util_behaviour(self, error_margin_pct=5) -> AggregatedResultBundle:
@@ -672,7 +672,7 @@ class Invariance(TestBundle, LoadTrackingHelpers):
             return test_item.test_util_behaviour(
                 error_margin_pct=error_margin_pct,
             )
-        return self._test_all_freq(item_test)
+        return self._test_all_items(item_test)
 
     @InvarianceItem.test_load_behaviour.used_events
     def test_load_behaviour(self, error_margin_pct=5) -> AggregatedResultBundle:
@@ -683,9 +683,9 @@ class Invariance(TestBundle, LoadTrackingHelpers):
             return test_item.test_load_behaviour(
                 error_margin_pct=error_margin_pct,
             )
-        return self._test_all_freq(item_test)
+        return self._test_all_items(item_test)
 
-    def _test_all_freq(self, item_test):
+    def _test_all_items(self, item_test):
         """
         Apply the `item_test` function on all instances of
         :class:`InvarianceItem` and aggregate the returned


### PR DESCRIPTION
The PELT clock is typically not available on task enqueue/dequeue,
but aligning the activations on the preceding PELT events makes the
sleep time inaccurate.

Fix that by providing a fake clock sample based on the ftrace clock
delta, rescaled using the nearest time scaling factor.