### PR TITLE
lisa.wlgen.rta: Run calibration at min freq

### DIFF
--- a/lisa/platforms/platinfo.py
+++ b/lisa/platforms/platinfo.py
@@ -89,7 +89,7 @@ class PlatformInfo(MultiSrcConf, HideExekallID):
     # we need.
     STRUCTURE = TopLevelKeyDesc('platform-info', 'Platform-specific information', (
         LevelKeyDesc('rtapp', 'RTapp configuration', (
-            KeyDesc('calib', 'RTapp calibration dictionary', [TypedDict[int,int]]),
+            KeyDesc('calib', 'RTapp calibration dictionary', [TypedDict[int, int], TypedDict[int, float]]),
         )),
 
         LevelKeyDesc('kernel', 'Kernel-related information', (


### PR DESCRIPTION
Avoid thermal capping while calibrating rt-app by running at the lowest
frequency, and then scaling back the calibration value we measured.