### PR TITLE
exekall: Fix exception unpickling for Python < 3.8

### DIFF
--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -66,7 +66,6 @@ class IndentationManager:
     def __str__(self):
         return str(self.style) * self.level
 
-
 class _ExceptionPickler(pickle.Pickler):
     """
     Fix pickling of exceptions so they can be reloaded without troubles, even
@@ -74,6 +73,23 @@ class _ExceptionPickler(pickle.Pickler):
 
     https://bugs.python.org/issue40917
     """
+
+    class _DispatchTable:
+        """
+        For Python < 3.8 (i.e. before Pickler.reducer_override is available)
+        """
+        def __init__(self, pickler):
+            self.pickler = pickler
+
+        def __getitem__(self, cls):
+            try:
+                return self.pickler._get_reducer(cls)
+            except ValueError:
+                raise KeyError
+
+    def __init__(self, *args, **kwargs):
+        self.dispatch_table = self._DispatchTable(self)
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def _make_excep(excep_cls, dct):
@@ -93,21 +109,34 @@ class _ExceptionPickler(pickle.Pickler):
         new.__dict__ = dct
         return new
 
+    @classmethod
+    def _reduce_excep(cls, obj):
+        # The __dict__ of exceptions does not contain "args", so shoe-horn
+        # it in there so it's passed as a regular attribute.
+        dct = obj.__dict__.copy()
+        try:
+            dct['args'] = obj.args
+        except AttributeError:
+            pass
+        return (cls._make_excep, (obj.__class__, dct))
+
+    # Only for Python >= 3.8, otherwise self.dispatch_table is used
     def reducer_override(self, obj):
-        # Workaround this bug:
-        # https://bugs.python.org/issue43460
-        if isinstance(obj, BaseException):
-            # The __dict__ of exceptions does not contain "args", so shoe-horn
-            # it in there so it's passed as a regular attribute.
-            dct = obj.__dict__.copy()
-            try:
-                dct['args'] = obj.args
-            except AttributeError:
-                pass
-            return (self._make_excep, (obj.__class__, dct))
-        else:
+        try:
+            reducer = self._get_reducer(type(obj))
+        except ValueError:
             # Fallback to default behaviour
             return NotImplemented
+        else:
+            return reducer(obj)
+
+    def _get_reducer(self, cls):
+        # Workaround this bug:
+        # https://bugs.python.org/issue43460
+        if issubclass(cls, BaseException):
+            return self._reduce_excep
+        else:
+            raise ValueError('Class not handled')
 
     @classmethod
     def dump_bytestring(cls, obj, **kwargs):


### PR DESCRIPTION
Use the legacy Pickler.dispatch_table API for Python < 3.8