### PR TITLE
Improve tests' collector handling

### DIFF
--- a/doc/kernel_tests.rst
+++ b/doc/kernel_tests.rst
@@ -124,14 +124,14 @@ although you'll find more details in the API documentation of these classes.
   ' This forces a longer arrow ------------v
   ResultBundle "1" *- "1..*" TestMetric : "          "
 
-  class TestBundle {
-      # _from_target() : TestBundle
-      + from_target() : TestBundle
-      + from_dir() : TestBundle
+  class TestBundleBase {
+      # _from_target() : TestBundleBase
+      + from_target() : TestBundleBase
+      + from_dir() : TestBundleBase
   }
 
-  note right of TestBundle {
-      Methods returning <b>TestBundle</b>
+  note right of TestBundleBase {
+      Methods returning <b>TestBundleBase</b>
       are alternative constructors
 
       <b>from_target()</b> does some generic
@@ -141,20 +141,20 @@ although you'll find more details in the API documentation of these classes.
   }
 
   class MyTestBundle {
-	# _from_target() : TestBundle
+	# _from_target() : TestBundleBase
 	+ test_foo_is_bar() : ResultBundle
   }
 
   note right of MyTestBundle {
-      Non-abstract <b>TestBundle</b> classes
+      Non-abstract <b>TestBundleBase</b> classes
       must define test methods that return
       a <b>ResultBundle</b>
   }
 
-  TestBundle <|-- MyTestBundle
+  TestBundleBase <|-- MyTestBundle
   MyTestBundle .. ResultBundle
 
-Implementations of :class:`~lisa.tests.base.TestBundle._from_target` can
+Implementations of :class:`~lisa.tests.base.TestBundleBase._from_target` can
 execute any sort of arbitry Python code. This means that you are free to
 manipulate sysfs entries, or to execute arbitray binaries on the target. The
 :class:`~lisa.wlgen.workload.Workload` class has been created to
@@ -206,7 +206,7 @@ EAS tests
 ---------
 
 .. inheritance-diagram:: lisa.tests.scheduler.eas_behaviour
-   :top-classes: lisa.tests.base.TestBundle
+   :top-classes: lisa.tests.base.TestBundleBase
    :parts: 1
 
 |
@@ -218,7 +218,7 @@ Load tracking tests
 -------------------
 
 .. inheritance-diagram:: lisa.tests.scheduler.load_tracking
-   :top-classes: lisa.tests.base.TestBundle
+   :top-classes: lisa.tests.base.TestBundleBase
    :parts: 1
 
 |
@@ -229,7 +229,7 @@ Load tracking tests
 |
 
 .. inheritance-diagram:: lisa.tests.scheduler.util_tracking
-   :top-classes: lisa.tests.base.TestBundle
+   :top-classes: lisa.tests.base.TestBundleBase
    :parts: 1
 
 |
@@ -241,7 +241,7 @@ Misfit tests
 ------------
 
 .. inheritance-diagram:: lisa.tests.scheduler.misfit
-   :top-classes: lisa.tests.base.TestBundle
+   :top-classes: lisa.tests.base.TestBundleBase
    :parts: 1
 
 |
@@ -253,7 +253,7 @@ Sanity tests
 ------------
 
 .. inheritance-diagram:: lisa.tests.scheduler.sanity
-   :top-classes: lisa.tests.base.TestBundle
+   :top-classes: lisa.tests.base.TestBundleBase
    :parts: 1
 
 |
@@ -265,7 +265,7 @@ Hotplug tests
 +++++++++++++
 
 .. inheritance-diagram:: lisa.tests.hotplug.torture
-   :top-classes: lisa.tests.base.TestBundle
+   :top-classes: lisa.tests.base.TestBundleBase
    :parts: 1
 
 |
@@ -277,7 +277,7 @@ Cpufreq tests
 +++++++++++++
 
 .. inheritance-diagram:: lisa.tests.cpufreq.sanity
-   :top-classes: lisa.tests.base.TestBundle
+   :top-classes: lisa.tests.base.TestBundleBase
    :parts: 1
 
 |

--- a/ipynb/examples/typical_experiment.ipynb
+++ b/ipynb/examples/typical_experiment.ipynb
@@ -585,12 +585,11 @@
     }
    ],
    "source": [
-    "ftrace_coll = FtraceCollector(target, events=events, buffer_size=10240)\n",
-    "\n",
     "trace_path = os.path.join(wload.res_dir, \"trace.dat\")\n",
+    "ftrace_coll = FtraceCollector(target, events=events, buffer_size=10240, output_path=trace_path)\n",
+    "\n",
     "with wload, ftrace_coll:\n",
-    "    wload.run()\n",
-    "ftrace_coll.get_trace(trace_path)"
+    "    wload.run()"
    ]
   },
   {
@@ -1728,7 +1727,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/ipynb/profiling/kernel_functions_profiling.ipynb
+++ b/ipynb/profiling/kernel_functions_profiling.ipynb
@@ -411,7 +411,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ftrace_coll = FtraceCollector(target, events=events, functions=functions, buffer_size=10240)\n",
+    "trace_path = os.path.join(wload.res_dir, 'trace.dat')\n",
+    "ftrace_coll = FtraceCollector(target, events=events, functions=functions, buffer_size=10240, output_path=trace_path)\n",
     "\n",
     "with wload, ftrace_coll:\n",
     "    wload.run()\n"
@@ -1474,7 +1475,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/lisa/test_example.py
+++ b/lisa/test_example.py
@@ -59,7 +59,7 @@ class ExampleTestBundle(RTATestBundle):
         self.shell_output = shell_output
 
     @classmethod
-    def _from_target(cls, target: Target, *, res_dir: ArtifactPath, ftrace_coll: FtraceCollector = None) -> 'ExampleTestBundle':
+    def _from_target(cls, target: Target, *, res_dir: ArtifactPath, collector=None) -> 'ExampleTestBundle':
         """
         :meta public:
 
@@ -69,6 +69,15 @@ class ExampleTestBundle(RTATestBundle):
         :class:`lisa.target.Target` object. It can be used to manipulate a
         remote device such as a development board, to run workloads on it,
         manipulate sysfs entries and so on.
+
+        The ``collector`` parameter is a context manager to be used once around
+        while running the workload. It is created "magically": it's filled
+        automatically by the :class:`lisa.tests.base.TestBundleMeta` machinery,
+        based on the mixin base classes. For example, inheriting from
+        :class:`lisa.tests.base.DmesgTestBundle` and
+        :class:`lisa.tests.base.FtraceTestBundle` will lead to getting a
+        :class:`lisa.trace.ComposedCollector` that saves both an ftrace trace
+        and dmesg log.
 
         **All other parameters are keyword-only**
         This means they must appear after the lone ``*`` in the parameter list.
@@ -112,7 +121,7 @@ class ExampleTestBundle(RTATestBundle):
             # RTATestBundle.run_rtapp()
             # https://lisa-linux-integrated-system-analysis.readthedocs.io/en/master/kernel_tests.html#lisa.tests.base.RTATestBundle.run_rtapp
             #
-            # It allows running the rt-app profile on the target. ftrace_coll
+            # It allows running the rt-app profile on the target. "collector"
             # is the object used to control the recording of the trace, and is
             # setup by the test runner. This allows the final user to extend
             # the list of ftrace events collected. If no collector is provided,
@@ -121,7 +130,7 @@ class ExampleTestBundle(RTATestBundle):
             # ExampleTestBundle. Note that it will also freeze all the tasks on
             # the target device, so that the scheduler signals are not
             # disturbed. Some critical tasks are not frozen though.
-            cls.run_rtapp(target, res_dir, rtapp_profile, ftrace_coll=ftrace_coll)
+            cls.run_rtapp(target, res_dir, rtapp_profile, collector=collector)
 
         # Execute a silly shell command on the target device as well
         output = target.execute('echo $((21+21))').split()
@@ -181,7 +190,7 @@ class ExampleTestBundle(RTATestBundle):
 
     # ftrace events necessary for that test method to run must be specified here.
     # This information will be used in a number of places:
-    # * To build the ExampleTestBundle.ftrace_conf attribute, which is then used by RTATestBundle.run_rtapp()
+    # * To build the ExampleTestBundle.FTRACE_CONF attribute, which is then used by RTATestBundle.run_rtapp()
     # * To parse the ftrace trace
     # * In the Sphinx documentation.
     # * To check that the events are available in the trace. A clear exception

--- a/lisa/test_example.py
+++ b/lisa/test_example.py
@@ -19,7 +19,7 @@ from lisa.utils import ArtifactPath
 from lisa.datautils import df_filter_task_ids
 from lisa.trace import FtraceCollector, requires_events
 from lisa.wlgen.rta import RTAPhase, PeriodicWload
-from lisa.tests.base import RTATestBundle, ResultBundle
+from lisa.tests.base import TestBundle, RTATestBundle, ResultBundle
 from lisa.target import Target
 from lisa.analysis.load_tracking import LoadTrackingAnalysis
 
@@ -38,7 +38,7 @@ how to use the main APIs.
 ################################################################################
 
 
-class ExampleTestBundle(RTATestBundle):
+class ExampleTestBundle(RTATestBundle, TestBundle):
     """
     The test bundle contains the data the test will work on. See
     :class:`lisa.tests.base.TestBundle` for design notes.

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -898,6 +898,15 @@ class TestBundleBase(Serializable, ExekallTaggable, abc.ABC, metaclass=TestBundl
     Data required by the object to run test assertions should be exposed as
     ``__init__`` parameters.
 
+    .. note:: All subclasses are considered as "application" code, as opposed
+        to most of the rest of :mod:`lisa` which is treated as a library. This
+        means that the classes and their API is subject to change when needs
+        evolve, which is not always backward compatible. It's rarely an issue
+        since these classes are used "manually" mostly for debugging, which is
+        a version-specific activity. Likewise, the set of tests will evolve as
+        existing tests are replaced by more general implementations, that could
+        be organized and named differently.
+
     **Design notes:**
 
       * :meth:`from_target` will collect whatever artifacts are required

--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -606,6 +606,7 @@ class TestBundleMeta(abc.ABCMeta):
 
                 if not filter_res:
                     res.result = Result.UNDECIDED
+                    res.add_metric('undecided-reason', f'{func.__qualname__} failed')
 
                 return res
 

--- a/lisa/tests/cpufreq/sanity.py
+++ b/lisa/tests/cpufreq/sanity.py
@@ -64,7 +64,7 @@ class UserspaceSanityItem(TestBundle):
         return cls(res_dir, target.plat_info, cpu, freq, work)
 
 
-class UserspaceSanity(DmesgTestBundle):
+class UserspaceSanity(DmesgTestBundle, TestBundle):
     """
     A class for making sure the userspace governor behaves sanely
 

--- a/lisa/tests/hotplug/torture.py
+++ b/lisa/tests/hotplug/torture.py
@@ -28,7 +28,7 @@ from operator import itemgetter
 from devlib.module.hotplug import HotplugModule
 from devlib.exception import TargetNotRespondingError
 
-from lisa.tests.base import TestMetric, ResultBundle, DmesgTestBundle
+from lisa.tests.base import TestMetric, ResultBundle, TestBundle, DmesgTestBundle
 from lisa.target import Target
 from lisa.utils import ArtifactPath
 
@@ -37,7 +37,7 @@ class CPUHPSequenceError(Exception):
     pass
 
 
-class HotplugBase(DmesgTestBundle):
+class HotplugBase(DmesgTestBundle, TestBundle):
     def __init__(self, res_dir, plat_info, target_alive, hotpluggable_cpus, live_cpus):
         super().__init__(res_dir, plat_info)
         self.target_alive = target_alive

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -32,7 +32,6 @@ from lisa.datautils import series_integrate, df_deduplicate
 from lisa.energy_model import EnergyModel, EnergyModelCapacityError
 from lisa.trace import requires_events
 from lisa.target import Target
-from lisa.trace import FtraceCollector
 from lisa.pelt import PELT_SCALE, pelt_swing
 from lisa.datautils import df_refit_index
 
@@ -125,7 +124,7 @@ class EASBehaviour(RTATestBundle):
             raise CannotCreateError("Energy model not available")
 
     @classmethod
-    def _from_target(cls, target: Target, *, res_dir: ArtifactPath = None, ftrace_coll: FtraceCollector = None) -> 'EASBehaviour':
+    def _from_target(cls, target: Target, *, res_dir: ArtifactPath = None, collector=None) -> 'EASBehaviour':
         """
         :meta public:
 
@@ -141,7 +140,7 @@ class EASBehaviour(RTATestBundle):
         # so make sure this is what's being used
         with target.disable_idle_states():
             with target.cpufreq.use_governor("schedutil"):
-                cls.run_rtapp(target, res_dir, rtapp_profile, ftrace_coll=ftrace_coll)
+                cls.run_rtapp(target, res_dir, rtapp_profile, collector=collector)
 
         return cls(res_dir, plat_info)
 

--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -26,7 +26,7 @@ from devlib.target import KernelVersion
 from lisa.wlgen.rta import RTAPhase, PeriodicWload, DutyCycleSweepPhase
 from lisa.analysis.rta import RTAEventsAnalysis
 from lisa.analysis.tasks import TasksAnalysis
-from lisa.tests.base import ResultBundle, CannotCreateError, RTATestBundle
+from lisa.tests.base import ResultBundle, CannotCreateError, TestBundle, RTATestBundle
 from lisa.utils import ArtifactPath, memoized
 from lisa.datautils import series_integrate, df_deduplicate
 from lisa.energy_model import EnergyModel, EnergyModelCapacityError
@@ -36,7 +36,7 @@ from lisa.pelt import PELT_SCALE, pelt_swing
 from lisa.datautils import df_refit_index
 
 
-class EASBehaviour(RTATestBundle):
+class EASBehaviour(RTATestBundle, TestBundle):
     """
     Abstract class for EAS behavioural testing.
 

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -23,8 +23,8 @@ from statistics import mean
 import pandas as pd
 
 from lisa.tests.base import (
-    TestMetric, Result, ResultBundle, AggregatedResultBundle, TestBundle,
-    RTATestBundle, CannotCreateError
+    TestMetric, Result, ResultBundle, AggregatedResultBundle, TestBundleBase,
+    TestBundle, RTATestBundle, CannotCreateError
 )
 from lisa.target import Target
 from lisa.utils import ArtifactPath, groupby, ExekallTaggable, add, memoized, kwargs_forwarded_to
@@ -118,7 +118,7 @@ class LoadTrackingHelpers:
         return signal_value * orig_capacities[cpu] / rtapp_capacities[cpu]
 
 
-class LoadTrackingBase(RTATestBundle, LoadTrackingHelpers):
+class LoadTrackingBase(RTATestBundle, LoadTrackingHelpers, TestBundle):
     """
     Base class for shared functionality of load tracking tests
     """
@@ -520,7 +520,7 @@ class InvarianceItem(LoadTrackingBase, ExekallTaggable):
         return self._test_behaviour('load', error_margin_pct)
 
 
-class Invariance(TestBundle, LoadTrackingHelpers):
+class Invariance(TestBundleBase, LoadTrackingHelpers):
     """
     Basic check for frequency invariant load and utilization tracking
 

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -652,9 +652,11 @@ class Invariance(TestBundle, LoadTrackingHelpers):
             list(cls._build_invariance_items(target, res_dir, **kwargs))
         )
 
-    def get_trace(self, cpu, freq):
+    def get_item(self, cpu, freq):
         """
-        :returns: The trace generated when running at a given frequency
+        :returns: The
+            :class:`~lisa.tests.scheduler.load_tracking.InvarianceItem`
+            generated when running at a given frequency
         """
         for item in self.invariance_items:
             if item.cpu == cpu and item.freq == freq:

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -25,14 +25,14 @@ from lisa.utils import memoized, ArtifactPath
 from lisa.datautils import df_squash, df_add_delta
 from lisa.trace import Trace, FtraceConf, requires_events
 from lisa.wlgen.rta import RTAPhase, RunWload, SleepWload
-from lisa.tests.base import RTATestBundle, Result, ResultBundle, CannotCreateError, TestMetric
+from lisa.tests.base import TestBundle, RTATestBundle, Result, ResultBundle, CannotCreateError, TestMetric
 from lisa.target import Target
 from lisa.analysis.tasks import TasksAnalysis, TaskState
 from lisa.analysis.idle import IdleAnalysis
 from lisa.analysis.rta import RTAEventsAnalysis
 
 
-class MisfitMigrationBase(RTATestBundle):
+class MisfitMigrationBase(RTATestBundle, TestBundle):
     """
     Abstract class for Misfit behavioural testing
 

--- a/lisa/tests/scheduler/misfit.py
+++ b/lisa/tests/scheduler/misfit.py
@@ -23,7 +23,7 @@ from devlib.module.sched import SchedDomain, SchedDomainFlag
 
 from lisa.utils import memoized, ArtifactPath
 from lisa.datautils import df_squash, df_add_delta
-from lisa.trace import Trace, FtraceConf, FtraceCollector, requires_events
+from lisa.trace import Trace, FtraceConf, requires_events
 from lisa.wlgen.rta import RTAPhase, RunWload, SleepWload
 from lisa.tests.base import RTATestBundle, Result, ResultBundle, CannotCreateError, TestMetric
 from lisa.target import Target

--- a/lisa/tests/scheduler/sanity.py
+++ b/lisa/tests/scheduler/sanity.py
@@ -38,7 +38,7 @@ class CapacitySanity(TestBundle):
         self.capacity_work = capacity_work
 
     @classmethod
-    def _from_target(cls, target: Target, *, res_dir: ArtifactPath = None) -> 'CapacitySanity':
+    def _from_target(cls, target: Target, *, res_dir: ArtifactPath = None, collector=None) -> 'CapacitySanity':
         """
         :meta public:
 
@@ -50,7 +50,8 @@ class CapacitySanity(TestBundle):
             cpu_capacities = target.sched.get_capacities()
             capa_work = {capa: sys.maxsize for capa in list(cpu_capacities.values())}
             for cpu in list(cpu_capacities.keys()):
-                output = sysbench(cpus=[cpu], max_duration_s=1).run()
+                with collector:
+                    output = sysbench(cpus=[cpu], max_duration_s=1).run()
                 # We could save the work done on each CPU, but we can make
                 # things simpler and just store the smallest amount of work done
                 # per capacity value.

--- a/lisa/tests/scheduler/util_tracking.py
+++ b/lisa/tests/scheduler/util_tracking.py
@@ -20,7 +20,7 @@ import functools
 
 from devlib.target import KernelVersion
 
-from lisa.tests.base import ResultBundle, RTATestBundle
+from lisa.tests.base import ResultBundle, TestBundle, RTATestBundle
 from lisa.target import Target
 from lisa.utils import ArtifactPath, memoized, namedtuple
 from lisa.wlgen.rta import RTAPhase, PeriodicWload, DutyCycleSweepPhase
@@ -33,7 +33,7 @@ from lisa.datautils import df_window, df_refit_index, series_mean, df_filter_tas
 from lisa.tests.scheduler.load_tracking import LoadTrackingHelpers
 
 
-class UtilTrackingBase(RTATestBundle, LoadTrackingHelpers):
+class UtilTrackingBase(RTATestBundle, LoadTrackingHelpers, TestBundle):
     """
     Base class for shared functionality of utilization tracking tests
     """

--- a/lisa/tests/scheduler/util_tracking.py
+++ b/lisa/tests/scheduler/util_tracking.py
@@ -24,7 +24,7 @@ from lisa.tests.base import ResultBundle, RTATestBundle
 from lisa.target import Target
 from lisa.utils import ArtifactPath, memoized, namedtuple
 from lisa.wlgen.rta import RTAPhase, PeriodicWload, DutyCycleSweepPhase
-from lisa.trace import FtraceCollector, requires_events
+from lisa.trace import requires_events
 from lisa.analysis.rta import RTAEventsAnalysis
 from lisa.analysis.tasks import TaskState, TasksAnalysis
 from lisa.analysis.load_tracking import LoadTrackingAnalysis
@@ -39,9 +39,11 @@ class UtilTrackingBase(RTATestBundle, LoadTrackingHelpers):
     """
 
     @classmethod
-    def _from_target(cls, target: Target, *,
-                     res_dir: ArtifactPath = None,
-                     ftrace_coll: FtraceCollector = None) -> 'UtilTrackingBase':
+    def _from_target(cls,
+        target: Target, *,
+        res_dir: ArtifactPath = None,
+        collector=None,
+    ) -> 'UtilTrackingBase':
         plat_info = target.plat_info
         rtapp_profile = cls.get_rtapp_profile(plat_info)
 
@@ -55,7 +57,7 @@ class UtilTrackingBase(RTATestBundle, LoadTrackingHelpers):
         # behaviour of the signal on running/not-running tasks.
         with target.disable_idle_states():
             with target.cpufreq.use_governor('performance'):
-                cls.run_rtapp(target, res_dir, rtapp_profile, ftrace_coll)
+                cls.run_rtapp(target, res_dir, rtapp_profile, collector=collector)
 
         return cls(res_dir, plat_info)
 

--- a/lisa/tests/staging/numa_behaviour.py
+++ b/lisa/tests/staging/numa_behaviour.py
@@ -16,11 +16,11 @@
 #
 
 from lisa.wlgen.rta import RTAPhase, PeriodicWload
-from lisa.tests.base import ResultBundle, RTATestBundle, TestMetric, CannotCreateError
+from lisa.tests.base import ResultBundle, TestBundle, RTATestBundle, TestMetric, CannotCreateError
 from lisa.datautils import df_deduplicate
 from lisa.analysis.tasks import TasksAnalysis
 
-class NUMABehaviour(RTATestBundle):
+class NUMABehaviour(RTATestBundle, TestBundle):
     """
     Abstract class for NUMA related scheduler testing.
     """

--- a/lisa/tests/staging/sched_android.py
+++ b/lisa/tests/staging/sched_android.py
@@ -28,7 +28,7 @@ from lisa.analysis.frequency import FrequencyAnalysis
 from lisa.analysis.tasks import TasksAnalysis
 
 
-class SchedTuneItemBase(RTATestBundle):
+class SchedTuneItemBase(RTATestBundle, TestBundle):
     """
     Abstract class enabling rtapp execution in a schedtune group
 

--- a/lisa/tests/staging/schedutil.py
+++ b/lisa/tests/staging/schedutil.py
@@ -22,7 +22,7 @@ import itertools
 import pandas as pd
 
 from lisa.wlgen.rta import DutyCycleSweepPhase
-from lisa.tests.base import ResultBundle, Result, RTATestBundle
+from lisa.tests.base import ResultBundle, Result, TestBundle, RTATestBundle
 from lisa.target import Target
 from lisa.trace import requires_events
 from lisa.datautils import df_merge, series_mean
@@ -35,7 +35,7 @@ from lisa.analysis.rta import RTAEventsAnalysis
 from lisa.analysis.tasks import TasksAnalysis, TaskState
 
 
-class RampBoostTestBase(RTATestBundle):
+class RampBoostTestBase(RTATestBundle, TestBundle):
     """
     Test schedutil's ramp boost feature.
     """

--- a/lisa/tests/staging/schedutil.py
+++ b/lisa/tests/staging/schedutil.py
@@ -24,7 +24,7 @@ import pandas as pd
 from lisa.wlgen.rta import DutyCycleSweepPhase
 from lisa.tests.base import ResultBundle, Result, RTATestBundle
 from lisa.target import Target
-from lisa.trace import requires_events, FtraceCollector
+from lisa.trace import requires_events
 from lisa.datautils import df_merge, series_mean
 from lisa.utils import ArtifactPath
 
@@ -281,7 +281,7 @@ class LargeStepUp(RampBoostTestBase):
         return self.get_rtapp_profile(self.plat_info, cpu=self.cpu, nr_steps=self.nr_steps)
 
     @classmethod
-    def _from_target(cls, target: Target, *, res_dir: ArtifactPath = None, ftrace_coll: FtraceCollector = None, cpu=None, nr_steps=1) -> 'LargeStepUp':
+    def _from_target(cls, target: Target, *, res_dir: ArtifactPath = None, collector=None, cpu=None, nr_steps=1) -> 'LargeStepUp':
         plat_info = target.plat_info
 
         # Use a big CPU by default to allow maximum range of utilization
@@ -293,7 +293,7 @@ class LargeStepUp(RampBoostTestBase):
         # boards. This helps having predictable execution.
         with target.disable_idle_states():
             with target.cpufreq.use_governor("schedutil"):
-                cls.run_rtapp(target, res_dir, rtapp_profile, ftrace_coll=ftrace_coll)
+                cls.run_rtapp(target, res_dir, rtapp_profile, collector=collector)
 
         return cls(res_dir, plat_info, cpu, nr_steps)
 

--- a/lisa/tests/staging/utilclamp.py
+++ b/lisa/tests/staging/utilclamp.py
@@ -26,11 +26,11 @@ from lisa.analysis.frequency import FrequencyAnalysis
 from lisa.analysis.load_tracking import LoadTrackingAnalysis
 from lisa.datautils import df_add_delta, series_mean, df_window
 from lisa.pelt import PELT_SCALE
-from lisa.tests.base import ResultBundle, RTATestBundle, TestMetric
+from lisa.tests.base import ResultBundle, TestBundle, RTATestBundle, TestMetric
 from lisa.wlgen.rta import RTAPhase, PeriodicWload
 
 
-class UtilClamp(RTATestBundle):
+class UtilClamp(RTATestBundle, TestBundle):
     """
     Validate that UtilClamp min values are honoured properly by the kernel.
 

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -5172,8 +5172,6 @@ class CollectorBase(Loggable):
         self._output_path = output_path
         self._install_tools(collector.target)
 
-    # Run once for each instance
-    @lru_cache(maxsize=None)
     def _install_tools(self, target):
         target.install_tools(self.TOOLS)
 

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -1655,6 +1655,8 @@ def kwargs_forwarded_to(f, ignore=None):
             # of the "self" parameter.
             if isinstance(f, UnboundMethodType):
                 f = f.__get__(0)
+            elif isinstance(f, (classmethod, staticmethod)):
+                f = f.__func__
             return inspect.signature(f)
 
         # Expand all of f's parameters as keyword-only parameters, since the

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -2039,17 +2039,18 @@ def kwargs_dispatcher(f_map, ignore=None, allow_overlap=True):
                 for param in params
             ]
 
+            def unify(params, attr):
+                first, *others = list(map(attrgetter(attr), params))
+                if all(x == first for x in others):
+                    return first
+                else:
+                    return None
+
             # If they all share the same default (could be "param.empty"), use
             # it, otherwise use None
-            first, *others = list(map(attrgetter('default'), params))
-            if all(x == first for x in others):
-                default = first
-            else:
-                default = None
-
             param = params[0].replace(
-                default=default,
-                annotation=inspect.Parameter.empty,
+                default=unify(params, 'default'),
+                annotation=unify(params, 'annotation'),
             )
             return param
 

--- a/tests/test_test_bundle.py
+++ b/tests/test_test_bundle.py
@@ -39,8 +39,9 @@ class DummyTestBundle(TestBundle):
         self.shell_output = shell_output
 
     @classmethod
-    def _from_target(cls, target, *, res_dir) -> 'DummyTestBundle':
-        output = target.execute('echo $((21+21))').split()
+    def _from_target(cls, target, *, res_dir, collector=None) -> 'DummyTestBundle':
+        with collector:
+            output = target.execute('echo $((21+21))').split()
         return cls(res_dir, output)
 
     def test_output(self):

--- a/tools/tests.sh
+++ b/tools/tests.sh
@@ -19,14 +19,6 @@
 
 # Script run by github CI, VM setup check etc.
 
-commit_whitelist='496b859d1a64e5195500aa52040abafb241657ab'
-illegal_location="external/"
-illegal_commits=$(find "$illegal_location" -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 git log --no-merges --format='%H %s' | grep -v "$commit_whitelist")
-
-if [[ -n "$illegal_commits" ]]; then
-    echo -e "The following commits are touching $illegal_location, which is not allowed apart from updates:\n$illegal_commits"
-    exit 1
-fi;
 
 # Some commands are allowed to fail in init_env, e.g. to probe for installed
 # tools. However, the overall script has to succeed.
@@ -53,3 +45,16 @@ if ! git diff --exit-code doc/man1/; then
     echo "Please regenerate man pages in doc/man1 and commit them"
     exit 1
 fi
+
+(
+    set +e
+    # Check for commits touching subtrees
+    commit_whitelist='496b859d1a64e5195500aa52040abafb241657ab'
+    illegal_location="external/"
+    illegal_commits=$(find "$illegal_location" -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 git log --no-merges --format='%H %s' | grep -v "$commit_whitelist")
+
+    if [[ -n "$illegal_commits" ]]; then
+        echo -e "The following commits are touching $illegal_location, which is not allowed apart from updates:\n$illegal_commits"
+        exit 1
+    fi;
+)


### PR DESCRIPTION
Create a composed collector from generic infrastructure to pass to `_from_target`, so that:
* Tests don't have to fiddle with the details of the collector they use, which can then be fully encapsulated in a mixin class.
* Mixin classes like FtraceTestBundle and DmesgTestBundle can register their own collector automatically
* The user can pass a custom collector that will be ran as well