### PR TITLE
ipynb: Add missing use of Workload as a context manager

### DIFF
--- a/ipynb/examples/typical_experiment.ipynb
+++ b/ipynb/examples/typical_experiment.ipynb
@@ -587,14 +587,8 @@
    "source": [
     "ftrace_coll = FtraceCollector(target, events=events, buffer_size=10240)\n",
     "\n",
-    "# This is just nifty Python syntactic sugar that starts/stops\n",
-    "# the recording for us. You could just do:\n",
-    "#     ftrace.start()\n",
-    "#     wload.run()\n",
-    "#     ftrace.stop()\n",
-    "#     ftrace.get_trace(trace_path)\n",
     "trace_path = os.path.join(wload.res_dir, \"trace.dat\")\n",
-    "with ftrace_coll:\n",
+    "with wload, ftrace_coll:\n",
     "    wload.run()\n",
     "ftrace_coll.get_trace(trace_path)"
    ]


### PR DESCRIPTION
Using the workload as a context manager is important to ensure cleanup
and correct process handling.