### PR TITLE
lisa.wlgen.workload: Add missing wait() call in run()

### DIFF
--- a/lisa/wlgen/workload.py
+++ b/lisa/wlgen/workload.py
@@ -495,7 +495,10 @@ class Workload(_WorkloadBase, PartialInit, Loggable):
 
         self.deploy()
         with self._run() as x:
-            pass
+            # Wait on the command explicitly, as relying on x.__exit__() will
+            # close its standard streams (stdin/stdout/stderr), leading to an
+            # early termination.
+            x.wait()
 
         # Only there to satisfy a deprecated API, do not rely on that in any
         # new code


### PR DESCRIPTION
Similar to Popen, devlib's BackgroundCommand.__exit__ will close
stdin/stdout/stderr of the process before waiting on it. Since this will
usually result in early termination of the workload, wait() on it
explicitly so that we gracefully wait for the command to finish before
closing its streams.