### PR TITLE
lisa.wlgen.workload: Propagate exception from _run()'s exit path

### DIFF
--- a/lisa/wlgen/workload.py
+++ b/lisa/wlgen/workload.py
@@ -208,10 +208,16 @@ class _WorkloadRunCM(Loggable):
                 action()
             except StopIteration as e:
                 output = e.value
+                excep = None
             except Exception as e:
                 output = _NotSet(e)
+                excep = e
+            else:
+                excep = None
 
             self._output = output
+            if excep is not None:
+                raise excep
 
 
 class _WorkloadBase:


### PR DESCRIPTION
Re-raise immediately the exceptions of Workload._run() from within
Workload.__exit__(), instead of just raising upon access to the "output"
attribute of the context manager.