### PR TITLE
doc: Avoid warnings while emitting test list

### DIFF
--- a/doc/kernel_tests.rst
+++ b/doc/kernel_tests.rst
@@ -38,6 +38,8 @@ The following tests are available. They can be used as:
 .. run-command::
   :capture-stderr:
 
+  # Disable warnings to avoid dependencies to break the reStructuredText output
+  export PYTHONWARNINGS="ignore"
   exekall run lisa.tests --rst-list --inject-empty-target-conf
 
 Running tests


### PR DESCRIPTION
Silence Python warnings while emitting test list to avoid breaking the
reStructuredText output.