### PR TITLE
lisa.analysis.base: Fix analysis HTML output

### DIFF
--- a/lisa/analysis/base.py
+++ b/lisa/analysis/base.py
@@ -666,6 +666,10 @@ class AnalysisHelpers(Loggable, abc.ABC):
             # written for Sphinx using docutils, which only understands
             # plain reStructuredText
             'report_level': 4,
+            # Set the line length to always accept our document, since it has a
+            # large base64-encoded image in it and docutils will otherwise just
+            # replace the document body with an error
+            'line_length_limit': len(rst) + 1,
         }
         parts = docutils.core.publish_parts(
             source=rst, source_path=None,


### PR DESCRIPTION
Avoid an empty HTML document with an error when the line length is too
long.