### PR TITLE
exekall: Add support for associated types

### DIFF
--- a/doc/man1/exekall.1
+++ b/doc/man1/exekall.1
@@ -498,6 +498,37 @@ expressions \fBConf:Stage1:process_method\fP, \fBConf:Stage1:process1\fP and
 \fBConf:Stage1:process2(conf=Conf)\fP\&. The common subexpression \fBConf:Stage1\fP would be
 shared between these two by default.
 .sp
+Callables are assumed to not be polymorphic in their return value, as the
+methods that will be called on the resulting value is decided ahead of time. A
+limited form of polymorphism akin to Rust\(aqs Generic Associated Types (GATs) or
+Haskell\(aqs associated type families is supported:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+import typing
+
+class Base:
+    ASSOCIATED_CLS = typing.TypeVar(\(aqASSOCIATED_CLS\(aq)
+
+    # Methods are allowed to use this polymorphic type as a return type, as
+    # long as all subclasses override ASSOCIATED_CLS class attribute.
+    def foo(self) \-> \(aqBase.ASSOCIATED_CLS\(aq:
+        return X
+
+class Derived1(Base):
+    X = 1
+    ASSOCIATED_CLS = type(X)
+
+class Derived2(Base):
+    X = \(aqhello\(aq
+    ASSOCIATED_CLS = type(X)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
 If a parameter has a default value, its annotation can be omitted. If a
 parameter has both a default value and an annotation, \fBexekall\fP will try to
 provide a value for it, or use the default value if no subexpression has the right

--- a/tools/exekall/doc/man/man.rst
+++ b/tools/exekall/doc/man/man.rst
@@ -259,6 +259,29 @@ expressions ``Conf:Stage1:process_method``, ``Conf:Stage1:process1`` and
 ``Conf:Stage1:process2(conf=Conf)``. The common subexpression ``Conf:Stage1`` would be
 shared between these two by default.
 
+Callables are assumed to not be polymorphic in their return value, as the
+methods that will be called on the resulting value is decided ahead of time. A
+limited form of polymorphism akin to Rust's Generic Associated Types (GATs) or
+Haskell's associated type families is supported::
+
+    import typing
+
+    class Base:
+        ASSOCIATED_CLS = typing.TypeVar('ASSOCIATED_CLS')
+
+        # Methods are allowed to use this polymorphic type as a return type, as
+        # long as all subclasses override ASSOCIATED_CLS class attribute.
+        def foo(self) -> 'Base.ASSOCIATED_CLS':
+            return X
+
+    class Derived1(Base):
+        X = 1
+        ASSOCIATED_CLS = type(X)
+
+    class Derived2(Base):
+        X = 'hello'
+        ASSOCIATED_CLS = type(X)
+
 If a parameter has a default value, its annotation can be omitted. If a
 parameter has both a default value and an annotation, ``exekall`` will try to
 provide a value for it, or use the default value if no subexpression has the right

--- a/tools/exekall/exekall/_utils.py
+++ b/tools/exekall/exekall/_utils.py
@@ -264,21 +264,6 @@ def remove_indices(iterable, ignored_indices):
     return [v for i, v in enumerate(iterable) if i not in ignored_indices]
 
 
-def resolve_annotations(annotations, module_vars):
-    """
-    Basic reimplementation of typing.get_type_hints.
-
-    Some Python versions do not have a typing module available, and it also
-    avoids creating ``Optional[]`` when the parameter has a None default value.
-    """
-    return {
-        # If we get a string, evaluate it in the global namespace of the
-        # module in which the callable was defined
-        param: cls if not isinstance(cls, str) else eval(cls, module_vars)
-        for param, cls in annotations.items()
-    }
-
-
 def get_module_basename(path):
     """
     Get the module name of the module defined in source ``path``.

--- a/tools/exekall/exekall/tests/suite.py
+++ b/tools/exekall/exekall/tests/suite.py
@@ -624,3 +624,37 @@ class CloneTestCase(NoExcepTestCase):
             expr.clone_by_predicate(predicate)
             for expr in super().get_computable_expr_list()
         ]
+
+
+import typing
+
+class AssociatedBase:
+    ASSOCIATED_CLS = typing.TypeVar('ASSOCIATED_CLS')
+
+    def make_associated(self) -> 'AssociatedBase.ASSOCIATED_CLS':
+        return self.X
+
+    @classmethod
+    def make(cls) -> 'AssociatedBase':
+        return cls()
+
+class AssociatedDerived1_CLS:
+    def final(self) -> Final:
+        return Final()
+
+class AssociatedDerived1(AssociatedBase):
+    X = AssociatedDerived1_CLS()
+    ASSOCIATED_CLS = type(X)
+
+class AssociatedTypesTestCase(NoExcepTestCase):
+    CALLABLES = {
+        AssociatedDerived1.make,
+        engine.UnboundMethod(AssociatedBase.make_associated, AssociatedDerived1),
+        AssociatedDerived1_CLS.final,
+    }
+    EXPR_ID = {
+        (('qual', True),): 'exekall.tests.suite.AssociatedDerived1.make:exekall.tests.suite.AssociatedBase.make_associated:exekall.tests.suite.AssociatedDerived1_CLS.final',
+        (('qual', False),): 'AssociatedDerived1.make:AssociatedBase.make_associated:AssociatedDerived1_CLS.final',
+    }
+    # no tags used
+    EXPR_VAL_ID = EXPR_ID


### PR DESCRIPTION
Support methods polymorphic in their return values in the following
limited case:

    import typing

    class Base:
        ASSOCIATED_CLS = typing.TypeVar('ASSOCIATED_CLS')

        def foo(self) -> 'Base.ASSOCIATED_CLS':
            return X

    class Derived1(Base):
        X = 1
        ASSOCIATED_CLS = type(X)

    class Derived2(Base):
        X = 'hello'
        ASSOCIATED_CLS = type(X)

In that case, exekall will correctly infer that Derived1.foo() returns an
int and Derived2.foo() returns a string.