### PR TITLE
lisa.tests.hotplug: Ignore IRQs related Dmesg

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1344,6 +1344,8 @@ class DmesgTestBundleBase(TestBundleBase):
         # On kernel >= 5.6, executable stack will trigger this issue:
     	# kern: warn: [555.927466] process 'root/devlib-target/bin/busybox' started with executable stack
         'executable-stack': 'started with executable stack',
+        'hotplug-irq-affinity': 'no longer affine to',
+        'hotplug-irq-affinity-failed': 'set affinity failed',
     }
     """
     Mapping of canned patterns to avoid repetition while defining

--- a/lisa/tests/hotplug.py
+++ b/lisa/tests/hotplug.py
@@ -42,7 +42,15 @@ class CPUHPSequenceError(Exception):
     pass
 
 
-class HotplugBase(DmesgTestBundle, TestBundle):
+class HotplugDmesgTestBundle(DmesgTestBundle):
+    DMESG_IGNORED_PATTERNS = [
+        *DmesgTestBundle.DMESG_IGNORED_PATTERNS,
+        DmesgTestBundle.CANNED_DMESG_IGNORED_PATTERNS['hotplug-irq-affinity'],
+        DmesgTestBundle.CANNED_DMESG_IGNORED_PATTERNS['hotplug-irq-affinity-failed'],
+    ]
+
+
+class HotplugBase(HotplugDmesgTestBundle, TestBundle):
     def __init__(self, res_dir, plat_info, target_alive, hotpluggable_cpus, live_cpus):
         super().__init__(res_dir, plat_info)
         self.target_alive = target_alive
@@ -270,7 +278,7 @@ class HotplugTorture(HotplugBase):
             yield cpu, 1
 
 
-class HotplugRollback(FtraceTestBundle, DmesgTestBundle):
+class HotplugRollback(TestBundle, HotplugDmesgTestBundle, FtraceTestBundle):
 
     @classmethod
     def _online(cls, target, cpu, online, verify=True):


### PR DESCRIPTION
During the hotplug sequence it is very likely that some IRQ messages,
related to affinity, will trigger due to the IRQs migration. They are
harmless and we can ignore them.