### PR TITLE
lisa.tests.hotplug: Catch incompatible kernels for rollback

### DIFF
--- a/lisa/tests/hotplug.py
+++ b/lisa/tests/hotplug.py
@@ -32,7 +32,7 @@ from devlib.module.hotplug import HotplugModule
 from devlib.exception import TargetNotRespondingError, TargetStableError
 
 from lisa.datautils import df_merge
-from lisa.tests.base import TestMetric, ResultBundle, TestBundle, DmesgTestBundle, FtraceTestBundle
+from lisa.tests.base import TestMetric, ResultBundle, TestBundle, DmesgTestBundle, FtraceTestBundle, CannotCreateError
 from lisa.target import Target
 from lisa.trace import requires_events
 from lisa.utils import ArtifactPath
@@ -396,6 +396,14 @@ class HotplugRollback(FtraceTestBundle, DmesgTestBundle):
         finally:
             cls._reset_fail(target, cpu)
             cls._online(target, cpu, online=True)
+
+    @classmethod
+    def check_from_target(cls, target):
+        try:
+            cls._reset_fail(target, 0)
+        except TargetStableError:
+            raise CannotCreateError(
+                "Target can't reset the hotplug fail interface")
 
     @classmethod
     def _get_expected_states(cls, df, up):


### PR DESCRIPTION
The rollback testing setup on the kernel side has been improved recently
and is required to run LISA's hotplug.rollback. Catch where the feature is
missing and raise the appropriate CannotCreateError.