### PR TITLE
exekall: Do not unwrap decorator stack when getting signature

### DIFF
--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -2465,8 +2465,22 @@ class Operator:
         assert callable(callable_)
         self.callable_ = callable_
 
-        self.annotations = copy.copy(self.resolved_callable.__annotations__)
-        self.signature = inspect.signature(self.resolved_callable)
+        if isinstance(callable_, UnboundMethod):
+            sig_f = callable_.__wrapped__
+        elif inspect.isclass(callable_):
+            sig_f = callable_.__init__
+        else:
+            sig_f = callable_
+        signature = inspect.signature(sig_f)
+        annotations = {
+            param.name: param.annotation
+            for param in signature.parameters.values()
+            if param.annotation != param.empty
+        }
+        if signature.return_annotation != signature.empty:
+            annotations['return'] = signature.return_annotation
+        self.annotations = annotations
+        self.signature = signature
 
         self.ignored_param = {
             param

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -2825,8 +2825,8 @@ class Operator:
         # their class. The method is bound to a class, which is not the case
         # if this is not a class method.
         return (
-            inspect.ismethod(self.unwrapped_callable) and
-            inspect.isclass(self.unwrapped_callable.__self__)
+            inspect.ismethod(self.callable_) and
+            inspect.isclass(self.callable_.__self__)
         )
 
     @property
@@ -2836,7 +2836,7 @@ class Operator:
         classmethod that returns objects of the class it is defined in (or of a
         subclass of it).
         """
-        return self.is_cls_method and issubclass(self.unwrapped_callable.__self__, self.value_type)
+        return self.is_cls_method and issubclass(self.callable_.__self__, self.value_type)
 
     def make_expr_val_iter(self, expr, param_map):
         """

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -2754,7 +2754,15 @@ class Operator:
         """
         ``True`` if the callable is a generator function.
         """
-        return inspect.isgeneratorfunction(self.resolved_callable)
+        x = self.callable_
+        while True:
+            if inspect.isgeneratorfunction(x):
+                return True
+            else:
+                try:
+                    x = x.__wrapped__
+                except AttributeError:
+                    return False
 
     @property
     def is_class(self):


### PR DESCRIPTION
Use the callable as-is when inspecting the signature, rather than
unwrapping the decorator stack. This allows the decorators to provide a
modified signature. functools.wraps() takes care of propagating the
signature properly for the other cases where the decorator does not
attempt to change the signature.