### PR TITLE
lisa.wlgen.rta: Fix a RecursionError

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -886,6 +886,13 @@ class CPUMigrationBase(LoadTrackingBase):
         """
         # Iterate over descending CPU capacity groups
         nr_required_cpu = cls.get_nr_required_cpu(plat_info)
+
+        # Cap to avoid combinatory explosion
+        max_cpus = 5
+        if nr_required_cpu > max_cpus:
+            cls.get_logger().debug(f'Only using {max_cpus} instead  of {nr_required_cpu} to avoid combinatory explosion')
+            nr_required_cpu = max_cpus
+
         cpu_classes = plat_info["capacity-classes"]
 
         # If the CPU capacities are writeable, it's better to give priority to

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -2923,7 +2923,7 @@ class SimpleHash:
         elif isinstance(x, Iterable):
             return tuple(map(coerce, x))
         # Check at the end, so that we recurse in common structures
-        if isinstance(x, Hashable):
+        elif isinstance(x, Hashable):
             return x
         else:
             raise TypeError(f'Cannot hash value "{x}" of type {x.__class__.__qualname__}')

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -2949,7 +2949,12 @@ class SimpleHash:
             return False
 
     def __hash__(self):
-        return hash(tuple(sorted(map(functools.partial(self._hash_coerce, visited={}), self.__dict__.items()))))
+        try:
+            return self.__hash
+        except AttributeError:
+            hash_ = hash(tuple(sorted(map(functools.partial(self._hash_coerce, visited={}), self.__dict__.items()))))
+            self.__hash = hash_
+            return hash_
 
 
 # Inherit from ABCMeta to avoid the most common metaclass conflict

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -2856,7 +2856,7 @@ class FrozenDict(Mapping):
 
         self._dct = dct
         # We cannot use memoized() since it would create an infinite loop
-        self._hash = hash(tuple(sorted(self._dct.items())))
+        self._hash = hash(tuple(self._dct.items()))
 
     def __getitem__(self, key):
         return self._dct[key]

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -2944,7 +2944,13 @@ class SimpleHash:
         if self is other:
             return True
         elif self.__class__ is other.__class__:
-            return self.__dict__ == other.__dict__
+            d1 = self.__dict__
+            d2 = other.__dict__
+            # This improves the performance on average
+            if d1.values() != d2.values():
+                return False
+            else:
+                return d1 == d2
         else:
             return False
 

--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -3537,6 +3537,11 @@ class RTAPhaseTree(_RTAPhaseTreeBase):
         self._children = children
         super().__init__(properties=properties, **kwargs)
 
+        # pre-compute the memoized property ahead of time, as it will
+        # recursively compute its grand-children. This can lead to
+        # RecursionError if it's not done when the object is created.
+        self.children
+
     def __str__(self):
         sep = '\n'
         try:


### PR DESCRIPTION
Fix possible RecursionError in RTAPhaseTree.children property on deeply
nested trees, such as the ones resulting from repeated accumulation
using + operator.

Computing the children when the object is created fixes the issue since
the recursion will always hit the memoization cache, avoiding an actual
deep recursion that would happen the first time the whole tree is
inspected.