### PR TITLE
setup.py: Freeze jinja2 version to avoid breaking nbformat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,10 @@ setup(
         # Depdendencies that are shipped as part of the LISA repo as
         # subtree/submodule
         "devlib >= 1.3.1",
+
+        # Newer versions break nbformat used to build the doc:
+        #https://github.com/spatialaudio/nbsphinx/issues/563
+        'jinja2 < 3.0.1',
     ],
 
     extras_require=extras_require,


### PR DESCRIPTION
Avoid issue:
https://github.com/spatialaudio/nbsphinx/issues/563