### PR TITLE
doc: lisa.wa.WATraceCollector: Fix example error

### DIFF
--- a/lisa/wa.py
+++ b/lisa/wa.py
@@ -517,7 +517,7 @@ class WATraceCollector(WAArtifactCollectorBase):
 
         def trace_idle_analysis(trace):
             cpu = 0
-            df = trace.analysis.idle.df_cluster_idle_state_residency(cpu)
+            df = trace.analysis.idle.df_cluster_idle_state_residency([cpu])
             df = df.reset_index()
             df['cpu'] = cpu
 


### PR DESCRIPTION
The example given for lisa.wa.WATraceCollector currently passes an
int to trace.analysis.idle.df_cluster_idle_state_residency(), which
expects a list(int). Because of that, attempts to run the example fail.

Wrapping the cpu id in a list during the function call solves the issue
without changing what the example is supposed to do.