### PR TITLE
github: Only test on Pytohn 3.6 and 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,10 @@ jobs:
           - ubuntu-20.04
         python-version:
           - '3.6'
-          - '3.7'
-          - '3.8'
+          # Speed up the checks by skipping 3.7 and 3.8. Also github seems to
+          # always block 3 jobs these days, so maybe this will avoid that.
+          # - '3.7'
+          # - '3.8'
           - '3.9'
 
     # env:

--- a/lisa/analysis/functions.py
+++ b/lisa/analysis/functions.py
@@ -269,6 +269,7 @@ class FunctionsAnalysis(TraceAnalysisBase):
             index='Time',
         )
 
+    @df_calls.used_events
     def compare_with_traces(self, others, normalize=True, **kwargs):
         """
         Compare the :class:`~lisa.trace.Trace` it's called on with the other


### PR DESCRIPTION
Speed up the checks and hopefully avoid what seems to be github
throttling in the number of jobs.