### PR TITLE
lisa.wlgen.rta: Fix phase_default typo

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -3340,7 +3340,7 @@ class _RTAPhaseTreeBase(RTAPhaseBase, abc.ABC):
                         # attempt to remove it or not
                         (
                             key not in phase and
-                            key not in phase_defaults
+                            key not in phase_default
                         ) or
                         (
                             # If the key is in phase and not phase_default or


### PR DESCRIPTION
phase_default, not phase_defaults. This affected the generation of multiple
phases when LISA tries to optimize the rt-app json file.