### PR TITLE
lisa.pelt: Fix simulate_pelt()

### DIFF
--- a/lisa/pelt.py
+++ b/lisa/pelt.py
@@ -353,7 +353,7 @@ def pelt_swing(period, duty_cycle, window=PELT_WINDOW, half_life=PELT_HALF_LIFE,
     sleep =  period - run
 
     # We only compute one sample per period, so it's as efficient as it can get
-    activations = pd.Series([1, 0] * nr_period)
+    activations = pd.Series([0, 1] * nr_period)
     activations.index = pd.Series([run, sleep] * nr_period).cumsum()
 
     simulated = simulate_pelt(

--- a/lisa/pelt.py
+++ b/lisa/pelt.py
@@ -176,6 +176,10 @@ def simulate_pelt(activations, init=0, index=None, clock=None, capacity=None, wi
     window_series = df['clock'] // window
     df['crossed_windows'] = window_series.diff()
 
+    # We want to have the entity state in the window between the previous
+    # sample and now.
+    df['activations'] = df['activations'].shift()
+
     # First row of "delta" is NaN, and activations reindex may have produced
     # some NaN at the beginning of the dataframe as well
     df.dropna(inplace=True)


### PR DESCRIPTION
Shift the activations signal so that it describes the state of the
entity until now, rather than the state of the entity over the next
period.