### PR TITLE
ipynb: Update typical_experiment.ipynb to collect task_rename

### DIFF
--- a/ipynb/examples/typical_experiment.ipynb
+++ b/ipynb/examples/typical_experiment.ipynb
@@ -539,7 +539,14 @@
     "available_events = target.execute(\"cat /sys/kernel/debug/tracing/available_events\").splitlines()\n",
     "\n",
     "# That's gonna be a pretty big list, let's focus on the scheduler events\n",
-    "sched_events = [event for event in available_events if event.startswith(\"sched:\")]\n",
+    "sched_events = [\n",
+    "    event\n",
+    "    for event in available_events\n",
+    "    if (\n",
+    "        event.startswith(\"sched:\") or\n",
+    "        event.startswith(\"task:\")\n",
+    "    )\n",
+    "]\n",
     "print(sched_events)"
    ]
   },
@@ -557,9 +564,10 @@
    "outputs": [],
    "source": [
     "events = [\n",
-    "    \"sched_switch\",\n",
-    "    \"sched_wakeup\",\n",
-    "    \"sched_wakeup_new\"\n",
+    "    'sched_switch',\n",
+    "    'sched_wakeup',\n",
+    "    'sched_wakeup_new',\n",
+    "    'task_rename',\n",
     "]"
    ]
   },
@@ -1727,7 +1735,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Collect task_rename ftrace event since that is now necessary for some of
the tasks analysis.