### PR TITLE
lisa.wa: Fix common prefix for wa_path

### DIFF
--- a/lisa/wa.py
+++ b/lisa/wa.py
@@ -360,7 +360,7 @@ class WACollectorBase(StatsProp, Loggable, abc.ABC):
         )
 
         wa_outputs = {
-            str(name.relative_to(common_prefix)): wa_output
+            str(name.relative_to(common_prefix.resolve())): wa_output
             for name, wa_output in wa_outputs.items()
         }
 


### PR DESCRIPTION
When filling wa_path, WAOutput is looking for the longest common path,
shared by all the WA folder path. e.g

  foo/bar foo/bar2 would become respectively bar and bar2.

A problem occurs when using a path with WAOutput that is the root of a
WA folder. (e.g. foobar where foobar/__meta exists). This common path
(common_prefix) would then be PosixPath('.'). Pathlib cannot use a such
path with relative_to() and raises the following error:

   ValueError: '/foo/bar/' does not start with ''

Fixing this problem by converting common_prefix to an absolute path.