### PR TITLE
lisa.wa: Fix (again) the common prefix for wa_path

### DIFF
--- a/lisa/wa.py
+++ b/lisa/wa.py
@@ -359,10 +359,13 @@ class WACollectorBase(StatsProp, Loggable, abc.ABC):
             ''
         )
 
-        wa_outputs = {
-            str(name.relative_to(common_prefix.resolve())): wa_output
-            for name, wa_output in wa_outputs.items()
-        }
+        try:
+            wa_outputs = {
+                    str(name.relative_to(common_prefix.resolve())): wa_output
+                    for name, wa_output in wa_outputs.items()
+            }
+        except ValueError:
+            pass
 
         dfs = [
             self._add_output_info(wa_output, name, df)


### PR DESCRIPTION
The previous commit:

  39146d8d (lisa.wa: Fix common prefix for wa_path)

Resolved common_prefix to get an absolute path. When we have a single WA
folder in wa_outputs, common_prefix will be PosixPath('.'). This path is
resolved to the current interpreter path. This is fine as long as the
interpreter is in the same path as the WA folder... This problematic if
it is not.

Fix the later use-case by catching the ValueError, raised by relative_to()
and do not try to reduce wa_path if that issue is raised i.e. there are no
relation between the interpreter path (PosixPath('.')) and the WA folder.

e.g.

  Interpreter: /foo/lisa/
  WAOutput:    /foo/lisa/wa-output/ # contains __meta
  wa_path:     wa-output

  Interpreter: /foo/lisa/
  WAOutput:    /bar/wa-output/ # contains __meta
  wa_path:     /bar/wa-output