### PR TITLE
lisa.trace: Fix MissingTraceEventError invocations

### DIFF
--- a/lisa/analysis/load_tracking.py
+++ b/lisa/analysis/load_tracking.py
@@ -124,8 +124,10 @@ class LoadTrackingAnalysis(TraceAnalysisBase):
             except MissingTraceEventError as e:
                 missing.append(e.missing_events)
 
-        missing = OrTraceEventChecker.from_events(missing)
-        raise MissingTraceEventError(missing, self.trace.available_events)
+        raise MissingTraceEventError(
+            OrTraceEventChecker(missing),
+            self.trace.available_events
+        )
 
     @may_use_events(
         requires_one_event_of(*_SCHED_PELT_CFS_NAMES),


### PR DESCRIPTION
Ensure it is always called with either a TraceEventCheckerBase or an
iterable of strings, that are then combined with AndTraceEventChecker.