### PR TITLE
doc/setup.rst: Remove kernel module patch directions

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -210,14 +210,6 @@ If you're rebuilding your kernel tree anyway, it might be easier to integrate
 the module into your kernel tree as a built-in module so that it's always
 present.
 
-Integrate using provided patch
-..............................
-
-.. code-block:: sh
-
-  cd path/to/kernel && git am path/to/patch
-
-
 Updating
 ========
 


### PR DESCRIPTION
Since we don't distribute a patch anymore, remove the associated
instructions.