### PR TITLE
batch-rebase: rename to lisa._generic

### DIFF
--- a/tools/batch-rebase
+++ b/tools/batch-rebase
@@ -32,7 +32,7 @@ import logging
 import contextlib
 
 from lisa.conf import SimpleMultiSrcConf, KeyDesc, LevelKeyDesc, TopLevelKeyDesc
-from lisa.generic import TypedList
+from lisa._generic import TypedList
 
 def info(msg):
     logging.info(msg)


### PR DESCRIPTION
"f4ae7be5  lisa.generic: Rename to lisa._generic" missed one file that
needed lisa.generic renamed to lisa._generic. Fix it here.

Signed-off-by: Ionela Voinescu <ionela.voinescu@arm.com>