### PR TITLE
exekall: Set package attribute when importing submodule

### DIFF
--- a/tools/exekall/exekall/_utils.py
+++ b/tools/exekall/exekall/_utils.py
@@ -657,8 +657,11 @@ def import_file(python_src, module_name=None, is_package=False):
             # Set __path__ for namespace packages
             spec.submodule_search_locations = submodule_search_locations
         else:
-            spec = importlib.util.spec_from_file_location(module_name, str(python_src),
-                submodule_search_locations=submodule_search_locations)
+            spec = importlib.util.spec_from_file_location(
+                module_name,
+                str(python_src),
+                submodule_search_locations=submodule_search_locations,
+            )
             if spec is None:
                 raise ModuleNotFoundError(
                     'Could not find module "{module}" at {path}'.format(
@@ -685,6 +688,21 @@ def import_file(python_src, module_name=None, is_package=False):
                 with contextlib.suppress(KeyError):
                     del sys.modules[module_name]
                 raise
+            else:
+
+                # Set the attribute on the parent package, so that this works:
+                #
+                #    import foo.bar
+                #    print(foo.bar)
+                try:
+                    parent_name, last = module_name.rsplit('.', 1)
+                except ValueError:
+                    pass
+                else:
+                    parent = sys.modules[parent_name]
+                    setattr(parent, last, module)
+
+
 
     #  Python <= v3.4 style
     else:


### PR DESCRIPTION
FIX

Set attribute on parent package when importing a module. This allows
doing:

    # Exekall imports foo.bar itself using something like:
    # import_file(module_name='foo.bar', ...)

    # Then in another module:
    import foo
    # This used to raise, as exekall incorrectly did not set "bar"
    # attribute on "foo" when importing it.
    print(foo.bar)