### PR TITLE
exekall: Handle PEP 604 annotation

### DIFF
--- a/doc/man1/bisector.1
+++ b/doc/man1/bisector.1
@@ -1,8 +1,5 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "BISECTOR" "1" "2021" "" "bisector"
-.SH NAME
-bisector \- command sequencer
 .
 .nr rst2man-indent-level 0
 .
@@ -30,6 +27,9 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
+.TH "BISECTOR" "1" "2021" "" "bisector"
+.SH NAME
+bisector \- command sequencer
 .SH DESCRIPTION
 .sp
 \fBbisector\fP is a \fBgit bisect run\fP [1] compatible tool used in LISA. Its goal is

--- a/doc/man1/exekall.1
+++ b/doc/man1/exekall.1
@@ -1,8 +1,5 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "EXEKALL" "1" "2021" "" "exekall"
-.SH NAME
-exekall \- test runner
 .
 .nr rst2man-indent-level 0
 .
@@ -30,6 +27,9 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
+.TH "EXEKALL" "1" "2021" "" "exekall"
+.SH NAME
+exekall \- test runner
 .SH DESCRIPTION
 .sp
 \fBexekall\fP is a python\-based test runner. The expressions it executes are

--- a/doc/man1/lisa.1
+++ b/doc/man1/lisa.1
@@ -1,8 +1,5 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "LISA" "1" "2021" "" "LISA shell"
-.SH NAME
-lisa \- LISA shell commands
 .
 .nr rst2man-indent-level 0
 .
@@ -30,6 +27,9 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
+.TH "LISA" "1" "2021" "" "LISA shell"
+.SH NAME
+lisa \- LISA shell commands
 .SH DESCRIPTION
 .sp
 Once you have all of the required dependencies installed, you can use the LISA

--- a/tools/exekall/exekall/engine.py
+++ b/tools/exekall/exekall/engine.py
@@ -2364,7 +2364,7 @@ class Expression(ExpressionBase):
 
 class AnnotationError(Exception):
     """
-    Exception raised when there is a missing PEP 484 annotation.
+    Exception raised when there is a missing or invalid PEP 484 annotation.
     """
     pass
 
@@ -2977,7 +2977,10 @@ class Operator:
             # If we get a string, evaluate it in the global namespace of the
             # module in which the callable was defined
             if isinstance(x, str):
-                x = eval(x, module_vars)
+                try:
+                    x = eval(x, module_vars)
+                except Exception as e:
+                    raise AnnotationError(f'Cannot handle annotation "{x}": {e}')
 
             # Handle associated types:
             # If the annotation is a typing.TypeVar, assume it was defined as a


### PR DESCRIPTION
PEP 604 annotation such as "int | None" raise a TypeError on older
versions of Python. Ignore such annotation by re-raising the appropriate
exception.

Fixes https://github.com/ARM-software/lisa/issues/1743