### PR TITLE
Fix LISA android target with latest

### DIFF
--- a/lisa/target.py
+++ b/lisa/target.py
@@ -633,9 +633,9 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
                 device = 'DEFAULT'
 
             conn_settings['device'] = device
-            # If the username was explicitly set to "root", root the target as
-            # early as possible
-            conn_settings['adb_as_root'] = (username == 'root')
+            # If the username was explicitly set to "root", or username is None,
+            # root the target as early as possible
+            conn_settings['adb_as_root'] = (username == 'root' or username is None)
 
         elif kind == 'linux':
             devlib_target_cls = devlib.LinuxTarget
@@ -691,14 +691,6 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
         )
 
         target.connect(check_boot_completed=wait_boot, timeout=wait_boot_timeout)
-
-        # None as username means adb root will be attempted, but failure will
-        # not prevent from connecting to the target.
-        if kind == 'android' and username is None:
-            try:
-                target.adb_root(enable=True)
-            except Exception as e: # pylint: disable=broad-except
-                logger.warning(f'"adb root" failed: {e}')
 
         logger.debug(f'Target info: {dict(abi=target.abi, cpuinfo=target.cpuinfo, workdir=target.working_directory)}')
 

--- a/lisa/target.py
+++ b/lisa/target.py
@@ -215,6 +215,10 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
         ],
         'android': [
             'sh', 'adbd',
+            # AOSP 'mount' command needs to communicate with 'emulated' threads,
+            # the threads are spawn by the process 'rs.media.module', so need to
+            # avoid freezing it to avoid stuck with execute 'mount' command.
+            'rs.media.module',
             'usb', 'transport',
             # We don't actually need this task but on Google Pixel it apparently
             # cannot be frozen, so the cgroup state gets stuck in FREEZING if we


### PR DESCRIPTION
These two patches are to address the issue found with executing command:

  lisa-test 'OneSmallTask*'

The first patch is to address the issue introduced by the latest AOSP with emulated daemons for storage; the second patch is to fix the root permission issue which is caused by the change in devlib.

After applying these two patches, the lisa-test command can execute successfully on my Hikey960 board.