### PR TITLE
lisa-build-asset: Improve --build-dir help

### DIFF
--- a/tools/lisa-build-asset
+++ b/tools/lisa-build-asset
@@ -337,7 +337,7 @@ def main():
             help=f'Name of the toolchain for {arch} (CROSS_COMPILE without trailing dash)',
         )
 
-    parser.add_argument('--build-dir', help='Build director. Defaults to temp folder')
+    parser.add_argument('--build-dir', help='Build director. Defaults to temp folder. WARNING: Do not simply delete the build directory, as it contains bind mounts for the parent git repository.')
     args = parser.parse_args()
 
     native_build = args.native_build


### PR DESCRIPTION
Warn that it is dangerous to delete the build directory, as it contains
bind mounts to the current repo. This would result in deleting the
repository itself.