### PR TITLE
lisa.target: Remove adb rooting attempt

### DIFF
--- a/lisa/target.py
+++ b/lisa/target.py
@@ -687,19 +687,8 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
         )
 
         target.connect(check_boot_completed=wait_boot, timeout=wait_boot_timeout)
-
-        # None as username means adb root will be attempted, but failure will
-        # not prevent from connecting to the target.
-        if kind == 'android' and username is None:
-            try:
-                target.adb_root(enable=True)
-            except Exception as e: # pylint: disable=broad-except
-                logger.warning(f'"adb root" failed: {e}')
-
         logger.debug(f'Target info: {dict(abi=target.abi, cpuinfo=target.cpuinfo, workdir=target.working_directory)}')
-
         target.setup()
-
         logger.info(f"Connected to target {(name or '')}")
         return target
 


### PR DESCRIPTION
FIX

Remove attempt to call target.adb_root() when username is None. Devlib
API has changed and this is now a connection method. Calling that method
on the connection is not a fix as connections are created and destroyed
per thread, so applying it for the main thread is only kicking the can
down the road.

Since connecting as root can be achieved by simply using username='root'
and feeding that information into the connection settings, remove the
automatic attempt.