### PR TITLE
lisa.tests.hotplug: Fix HotplugRollback MRO

### DIFF
--- a/lisa/tests/hotplug.py
+++ b/lisa/tests/hotplug.py
@@ -276,7 +276,7 @@ class HotplugTorture(HotplugBase):
             yield cpu, 1
 
 
-class HotplugRollback(TestBundle, HotplugDmesgTestBundle, FtraceTestBundle):
+class HotplugRollback(HotplugDmesgTestBundle, FtraceTestBundle, TestBundle):
 
     @classmethod
     def _online(cls, target, cpu, online, verify=True):

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,8 @@ testpaths=tests
 filterwarnings =
     error
     ignore::DeprecationWarning:past.builtins.misc
+	# Avoid:
+	# .lisa-venv-3.9/lib/python3.9/site-packages/pkg_resources/_vendor/packaging/version.py:111: in __init__
+	#   warnings.warn(
+	#   DeprecationWarning: Creating a LegacyVersion has been deprecated and will be removed in the next major release
+	ignore::DeprecationWarning:pkg_resources.*:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
 [flake8]
 ignore = E501,E128,E124,E402,E721,E712
 filename = lisa/*.py,tests/*.py,tools/bisector/*.py,tools/exekall/*.py,doc/*.py
-exclude = lisa/tests/deprecated/*.py


### PR DESCRIPTION
FIX

Inheriting from TestBundle should come last in order to override methods
provided by OptinalFtraceTestBundle & friends by the non-optional
variant.