### PR TITLE
sched_tp: Handle a couple of compilation errors

### DIFF
--- a/lisa/_assets/kmodules/sched_tp/sched_events.h
+++ b/lisa/_assets/kmodules/sched_tp/sched_events.h
@@ -301,6 +301,7 @@ TRACE_EVENT_CONDITION(uclamp_util_cfs,
 #define trace_uclamp_util_cfs_enabled() false
 #endif /* CONFIG_UCLAMP_TASK */
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && defined(CONFIG_ARM64)
 TRACE_EVENT(sched_cpu_capacity,
 
 	TP_PROTO(struct rq *rq),
@@ -327,6 +328,7 @@ TRACE_EVENT(sched_cpu_capacity,
 	TP_printk("cpu=%d capacity=%lu capacity_orig=%lu capacity_curr=%lu",
 		  __entry->cpu, __entry->capacity, __entry->capacity_orig, __entry->capacity_curr)
 );
+#endif
 
 #endif /* _SCHED_EVENTS_H */
 

--- a/lisa/_assets/kmodules/sched_tp/sched_tp.c
+++ b/lisa/_assets/kmodules/sched_tp/sched_tp.c
@@ -160,10 +160,12 @@ static void sched_util_est_se(void *data, struct sched_entity *se)
 		_trace_se(se, trace_sched_util_est_se);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && defined(CONFIG_ARM64)
 static void sched_cpu_capacity(void *data, struct rq *rq)
 {
 	trace_sched_cpu_capacity(rq);
 }
+#endif
 
 static int sched_tp_init(void)
 {
@@ -176,7 +178,9 @@ static int sched_tp_init(void)
 	register_trace_sched_update_nr_running_tp(sched_update_nr_running, NULL);
 	register_trace_sched_util_est_cfs_tp(sched_util_est_cfs, NULL);
 	register_trace_sched_util_est_se_tp(sched_util_est_se, NULL);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && defined(CONFIG_ARM64)
 	register_trace_sched_cpu_capacity_tp(sched_cpu_capacity, NULL);
+#endif
 
 	return 0;
 }
@@ -192,7 +196,9 @@ static void sched_tp_exit(void)
 	unregister_trace_sched_update_nr_running_tp(sched_update_nr_running, NULL);
 	unregister_trace_sched_util_est_cfs_tp(sched_util_est_cfs, NULL);
 	unregister_trace_sched_util_est_se_tp(sched_util_est_se, NULL);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && defined(CONFIG_ARM64)
 	unregister_trace_sched_cpu_capacity_tp(sched_cpu_capacity, NULL);
+#endif
 }
 
 


### PR DESCRIPTION
sched_cpu_capacity depends on a tracepoint that was added on 5.10, so
protect it with the right kernel version.

Also the tracepoint makes a call to arch_scale_freq_capacity() which
doesn't compile on x86 as it points to non-exported function. Just wrap
it with a warning until someone who cares finds a better alternative for
those archs.

Signed-off-by: Qais Yousef <qais.yousef@arm.com>