### PR TITLE
lisa.trace: Add TraceEventCheckerBase.__bool__

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -4879,6 +4879,10 @@ class TraceEventCheckerBase(abc.ABC, Loggable):
         wrapper.used_events = checker
         return wrapper
 
+    @abc.abstractmethod
+    def __bool__(self):
+        pass
+
     def __and__(self, other):
         """
         Combine two event checkers into one that checks the presence of both.
@@ -4946,6 +4950,9 @@ class TraceEventChecker(TraceEventCheckerBase):
         super().__init__(check=check)
         self.event = event
 
+    def __bool__(self):
+        return True
+
     def get_all_events(self):
         return {self.event}
 
@@ -5008,6 +5015,9 @@ class AssociativeTraceEventChecker(TraceEventCheckerBase):
         self.checkers = checker_list
         self.op_str = op_str
         self.prefix_str = prefix_str
+
+    def __bool__(self):
+        return any(map(bool, self.checkers))
 
     def map(self, f):
         new = copy.copy(self)
@@ -5593,6 +5603,8 @@ class FtraceCollector(CollectorBase, Configurable):
             self.logger.info(f'Optional events not found in the kernel: {str(e)}')
 
         self.events = sorted(events | meta_events)
+        if not self.events:
+            raise ValueError('No ftrace events selected')
         events = sorted(events)
 
         self._cm = None

--- a/tools/lisa-buildroot-create-rootfs
+++ b/tools/lisa-buildroot-create-rootfs
@@ -87,6 +87,8 @@ function br_post_patch {
 	ssh-keygen -A -f "$BUILDROOT_DIR/output/target/"
 	# Enable root login on sshd
 	sed -i 's/#PermitRootLogin.*/PermitRootLogin	yes/' "$BUILDROOT_DIR/output/target/etc/ssh/sshd_config"
+  # Increase the number of available channels so that devlib async code can exploit concurrency better
+	sed -i 's/#MaxSessions.*/MaxSessions	30/' "$BUILDROOT_DIR/output/target/etc/ssh/sshd_config"
 	# run udhcpc by default at startup
 	echo "null::once:/sbin/udhcpc # PATCHED BY LISA" >> "$BUILDROOT_DIR/output/target/etc/inittab"
 	# setup mdev rule to auto bringup ethernet devices


### PR DESCRIPTION
FIX

Ensure that TraceEventCheckerBase behaves like a container, so it can be
tested for emptiness easily.