### PR TITLE
setup.py: Bump minimal Python version to 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,12 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
+          #- ubuntu-18.04
           - ubuntu-20.04
         python-version:
-          - '3.6'
-          # Speed up the checks by skipping 3.7 and 3.8. Also github seems to
-          # always block 3 jobs these days, so maybe this will avoid that.
-          # - '3.7'
+          - '3.7'
+          # Speed up the checks by skipping 3.8. Also github seems to always
+          # block 3 jobs these days, so maybe this will avoid that.
           # - '3.8'
           - '3.9'
 

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     },
     description='A stick to probe the kernel with',
     long_description=long_description,
-    python_requires='>= 3.6',
+    python_requires='>= 3.7',
     install_requires=[
         "psutil >= 4.4.2",
         # Figure.savefig() (without pyplot) does not work in matplotlib <


### PR DESCRIPTION
Bump the minimum Python version to 3.7 in prevision of some changes in
devlib requiring 3.7 as well.