### PR TITLE
lisa.tests.hotplug: Ignore all "IRQ" related messages in Dmesg

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -1431,8 +1431,6 @@ class DmesgTestBundleBase(TestBundleBase):
         # On kernel >= 5.6, executable stack will trigger this issue:
     	# kern: warn: [555.927466] process 'root/devlib-target/bin/busybox' started with executable stack
         'executable-stack': 'started with executable stack',
-        'hotplug-irq-affinity': 'no longer affine to',
-        'hotplug-irq-affinity-failed': 'set affinity failed',
     }
     """
     Mapping of canned patterns to avoid repetition while defining

--- a/lisa/tests/hotplug.py
+++ b/lisa/tests/hotplug.py
@@ -44,8 +44,7 @@ class CPUHPSequenceError(Exception):
 class HotplugDmesgTestBundle(DmesgTestBundle):
     DMESG_IGNORED_PATTERNS = [
         *DmesgTestBundle.DMESG_IGNORED_PATTERNS,
-        DmesgTestBundle.CANNED_DMESG_IGNORED_PATTERNS['hotplug-irq-affinity'],
-        DmesgTestBundle.CANNED_DMESG_IGNORED_PATTERNS['hotplug-irq-affinity-failed'],
+        'irq|IRQ',
     ]
 
 


### PR DESCRIPTION
We tried to have an accurate filtering for IRQ related messages during
hotplug ... But more piles up. It makes it simply untestable and
none of those messages follows a pattern we could easily match. Let's
just ignore any that contains the word IRQ.