### PR TITLE
doc/setup.rst: Add BTF kernel config

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -173,6 +173,7 @@ way to configure LISA for building the module is:
       CONFIG_DEBUG_INFO=y
       CONFIG_DEBUG_INFO_BTF=y
       CONFIG_DEBUG_INFO_REDUCED=n
+      CONFIG_BPF_SYSCALL=y
 
   * Target configuration (:class:`lisa.target.TargetConf`):
 


### PR DESCRIPTION
Add a missing config that appears to be necessary according to:
https://patchwork.kernel.org/project/netdevbpf/patch/20211115191840.496263-2-memxor@gmail.com/