### PR TITLE
sched_tp: Allow sched_cpu_capacity() for arm32 platforms

### DIFF
--- a/lisa/_assets/kmodules/sched_tp/sched_events.h
+++ b/lisa/_assets/kmodules/sched_tp/sched_events.h
@@ -301,7 +301,7 @@ TRACE_EVENT_CONDITION(uclamp_util_cfs,
 #define trace_uclamp_util_cfs_enabled() false
 #endif /* CONFIG_UCLAMP_TASK */
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && defined(CONFIG_ARM64)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && (defined(CONFIG_ARM64) || defined(CONFIG_ARM))
 TRACE_EVENT(sched_cpu_capacity,
 
 	TP_PROTO(struct rq *rq),

--- a/lisa/_assets/kmodules/sched_tp/sched_tp.c
+++ b/lisa/_assets/kmodules/sched_tp/sched_tp.c
@@ -160,7 +160,7 @@ static void sched_util_est_se(void *data, struct sched_entity *se)
 		_trace_se(se, trace_sched_util_est_se);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && defined(CONFIG_ARM64)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && (defined(CONFIG_ARM64) || defined(CONFIG_ARM))
 static void sched_cpu_capacity(void *data, struct rq *rq)
 {
 	trace_sched_cpu_capacity(rq);
@@ -178,7 +178,7 @@ static int sched_tp_init(void)
 	register_trace_sched_update_nr_running_tp(sched_update_nr_running, NULL);
 	register_trace_sched_util_est_cfs_tp(sched_util_est_cfs, NULL);
 	register_trace_sched_util_est_se_tp(sched_util_est_se, NULL);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && defined(CONFIG_ARM64)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && (defined(CONFIG_ARM64) || defined(CONFIG_ARM))
 	register_trace_sched_cpu_capacity_tp(sched_cpu_capacity, NULL);
 #endif
 
@@ -196,7 +196,7 @@ static void sched_tp_exit(void)
 	unregister_trace_sched_update_nr_running_tp(sched_update_nr_running, NULL);
 	unregister_trace_sched_util_est_cfs_tp(sched_util_est_cfs, NULL);
 	unregister_trace_sched_util_est_se_tp(sched_util_est_se, NULL);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && defined(CONFIG_ARM64)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) && (defined(CONFIG_ARM64) || defined(CONFIG_ARM))
 	unregister_trace_sched_cpu_capacity_tp(sched_cpu_capacity, NULL);
 #endif
 }


### PR DESCRIPTION
They should work too and were accidentally omitted.

Signed-off-by: Qais Yousef <qais.yousef@arm.com>

---

Only tested against arm64 still