### PR TITLE
Add TimerWload

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -2689,6 +2689,23 @@ class SleepWload(DurationWload):
     _ACTION = 'sleep'
 
 
+class TimerWload(DurationWload):
+    """
+    Workload for the ``timer`` event.
+
+    :param duration: Duration of the timer period in seconds.
+    :type duration: float
+    """
+    _ACTION = 'timer'
+
+    @property
+    def json_value(self):
+        return {
+            # This special reference ensures each thread get their own timer
+            'ref': 'unique',
+            'period': _to_us(self.duration)
+        }
+
 class BarrierWload(_SingleWloadBase):
     """
     Workload for the ``barrier`` event.


### PR DESCRIPTION
The effect of `PeriodicWload(guaranteed_time='sleep')` can be seen with:
```

from lisa.platforms.platinfo import PlatformInfo
from lisa.wlgen.rta import *

task1 = RTAPhase(
    prop_wload=PeriodicWload(
        duty_cycle_pct=10,
        period=16e-3,
        duration=1,
        # guaranteed_time='period',
        guaranteed_time='sleep',
    ),
)

profile = {'task1': task1}

plat_info = PlatformInfo.from_yaml_map('./doc/traces/plat_info.yml')
conf = RTAConf.from_profile(profile, plat_info=plat_info)
print(conf.json)
````