### PR TITLE
bisector: Do not return None in Report.load()

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -4068,9 +4068,9 @@ class Report(Serializable):
                         download_service.download(url=url.geturl(), path=path)
                         return cls._load(path, steps_path, use_cache=False)
                     except Exception as e:
-                        error('Could not download report: ' + str(e))
+                        raise ValueError('Could not download report: ' + str(e)) from e
                 else:
-                    error('No download service available.')
+                    raise ValueError('No download service available.')
         else:
             return cls._load(path, steps_path, use_cache)
 

--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -3913,11 +3913,11 @@ class Report(Serializable):
                 # availibility of the "exekall" package, but this avoids
                 # copy-pasting a whole class so it should be ok.
                 try:
-                    from exekall.engine import _ExceptionPickler
+                    from exekall._utils import ExceptionPickler
                 except ImportError:
                     pickle.dump(pickle_data, f, protocol=4)
                 else:
-                    _ExceptionPickler.dump_file(f, pickle_data, protocol=4)
+                    ExceptionPickler.dump_file(f, pickle_data, protocol=4)
 
         # Rename the file once we know for sure that writing to the temporary
         # report completed with success


### PR DESCRIPTION
FIX

Raise an exception rather than returning None, which will only lead to
an exception in the caller.