### PR TITLE
lisa._kmod: Fix PATH in Alpine chroot

### DIFF
--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -311,7 +311,11 @@ def _make_chroot(make_vars, bind_paths=None, alpine_version='3.14.2', overlay_ba
 
 def _make_chroot_cmd(chroot, cmd):
     chroot = Path(chroot).resolve()
-    return ['chroot', chroot, *cmd]
+    cmd = ' '.join(map(quote, map(str, cmd)))
+    # Source /etc/profile to get sane defaults for e.g. PATH. Otherwise, we
+    # just inherit it from the host, which is broken.
+    cmd = f'source /etc/profile && exec {cmd}'
+    return ['chroot', chroot, 'sh', '-c', cmd]
 
 
 @contextlib.contextmanager

--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -173,7 +173,7 @@ def _subprocess_log(*args, env=None, extra_env=None, **kwargs):
 
 
 @contextlib.contextmanager
-def _make_chroot(make_vars, bind_paths=None, alpine_version='3.14.2', overlay_backend=None):
+def _make_chroot(make_vars, bind_paths=None, alpine_version='3.15.0', overlay_backend=None):
     """
     Create a chroot folder ready to be used to build a kernel.
     """


### PR DESCRIPTION
FIX

Previously, PATH was not set/reset to any specific value when running a
command in the Alpine chroot. This lead to PATH being inherited from the
user, even though it did not specifically make sense inside the chroot.

Fix that by running "source /etc/profile" to provide a sane default for
basic env var.