### PR TITLE
lisa.trace: Drop df.name attribute

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -3920,11 +3920,9 @@ class Trace(Loggable, TraceBase):
                 available_events=self.available_events,
             )
 
-        # Ensure the event name is set, as this sort of metadata might not be
-        # saved in the swap
-        df.name = event
-        # This is how it should be done. Keep the previous line in case someone
-        # depends on it.
+        # We used to set a ".name" attribute, but:
+        # 1. There is no central way of saving these metadata when serializing
+        # 2. It conflicts with a "name" column in the dataframe.
         df.attrs['name'] = event
         return df
 


### PR DESCRIPTION
BREAKING CHANGE

Trace.df_event() used to set a .name attribute on dataframes it returns.
This is unfortunately problematic, as it will also set the value of a
column named "name" if it exists.

The replacement is df.attrs['name'] and has been there for a while now.
It's also the recommended way of doing it by pandas documentation
itself.