### PR TITLE
lisa.datautils: Add SignalDesc for clk_* events

### DIFF
--- a/lisa/analysis/frequency.py
+++ b/lisa/analysis/frequency.py
@@ -340,6 +340,10 @@ class FrequencyAnalysis(TraceAnalysisBase):
     @TraceAnalysisBase.cache
     @requires_events('clk_set_rate', 'clk_enable', 'clk_disable')
     def df_peripheral_clock_effective_rate(self, clk_name):
+
+        # Note: the kernel still defines a "clock_*" variant for each of these,
+        # but it's not actually used anywhere in the code. The new "clk_*"
+        # events are the ones we are interested about.
         rate_df = self.trace.df_event('clk_set_rate')
         enable_df = self.trace.df_event('clk_enable')
         disable_df = self.trace.df_event('clk_disable')

--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -2047,6 +2047,10 @@ _SIGNALS = [
     SignalDesc('userspace@cpu_frequency_devlib', ['cpu_id']),
     SignalDesc('sched_compute_energy', ['comm', 'pid']),
 
+    SignalDesc('clk_set_rate', ['name']),
+    SignalDesc('clk_enable', ['name']),
+    SignalDesc('clk_disable', ['name']),
+
     SignalDesc('sched_pelt_se', ['comm', 'pid']),
     SignalDesc('sched_load_se', ['comm', 'pid']),
     SignalDesc('sched_util_est_se', ['comm', 'pid']),


### PR DESCRIPTION
FIX

Add SignalDesc for clk_set_rate, clk_enable, clk_disable so that
requesting the dataframe for one of these will always provide the
occurence before the beginning of the trace window for each clock name.