### PR TITLE
.github: Add read permissions to debugfs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,5 @@ jobs:
 
       - run: sudo ./install_base.sh --install-all
       - run: echo "$(python3 --version)"
+      - run: sudo chmod o+rx /sys/kernel/debug
       - run: bash ./tools/tests.sh


### PR DESCRIPTION
FIX

Ubuntu seems to have changed the permissions of debugfs at
/sys/kernel/debug to remove all permissions except for the root user.
This unfortunately breaks (among other things) the CPU capacities
reading, which is necessary to generate rt-app workloads.

Workaround the problem by restoring permissions until a better fix is
found.