### PR TITLE
Fix plot_peripheral_frequency

### DIFF
--- a/doc/plot_conf.yml
+++ b/doc/plot_conf.yml
@@ -112,7 +112,7 @@ doc-plot-conf:
                 # Either refer to the existing anchor, or make a new plat_info for the board that was used
                 plat_info: *plat_info1
             kwargs:
-                clk_name: juno:uartclk
+                clk_name: aplclk
 
         CpusAnalysis.plot_orig_capacity:
             kwargs:

--- a/lisa/analysis/frequency.py
+++ b/lisa/analysis/frequency.py
@@ -579,7 +579,7 @@ class FrequencyAnalysis(TraceAnalysisBase):
 
     @TraceAnalysisBase.plot_method
     @df_peripheral_clock_effective_rate.used_events
-    def plot_peripheral_frequency(self, clk_name, average: bool=True):
+    def plot_peripheral_frequency(self, clk_name: str, average: bool=True):
         """
         Plot frequency for the specified peripheral clock frequency
 

--- a/lisa/analysis/frequency.py
+++ b/lisa/analysis/frequency.py
@@ -592,15 +592,15 @@ class FrequencyAnalysis(TraceAnalysisBase):
 
         """
         df = self.df_peripheral_clock_effective_rate(clk_name)
+        freq = df['effective_rate']
+        freq = series_refit_index(freq, window=self.trace.window)
 
-        freq = series_refit_index(df['effective_rate'], window=self.trace.window)
-        avg = series_mean(freq)
+        fig = plot_signal(freq, name=f'Frequency of {clk_name} (Hz)')
 
-        df = df_refit_index(df, window=self.trace.window)
-        fig = plot_signal(df['effective_rate'], name=f'Frequency of {clk_name} (Hz)')
-
-        if avg > 0:
-            fig *= hv.HLine(avg, group='average').opts(color='red')
+        if average:
+            avg = series_mean(freq)
+            if avg > 0:
+                fig *= hv.HLine(avg, group='average').opts(color='red')
 
         return fig
 

--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -417,7 +417,7 @@ def df_merge(df_list, drop_columns=None, drop_inplace=False, filter_columns=None
         ]
 
     if any(
-        not (df1.columns & df2.columns).empty
+        not (df1.columns.intersection(df2.columns)).empty
         for (df1, df2)  in itertools.combinations(df_list, 2)
     ):
         df = pd.concat(df_list)
@@ -471,7 +471,7 @@ def df_delta(pre_df, post_df, group_on=None):
     post_df["is_pre"] = False
 
     # Merge on columns common to the two dfs to avoid overlapping of names.
-    on_col = sorted(pre_df.columns & post_df.columns)
+    on_col = sorted(pre_df.columns.intersection(post_df.columns))
 
     # Merging on nullable types converts columns to object.
     # Merging on non-nullable types converts integer/boolean to float.


### PR DESCRIPTION
@Leo-Yan I made a few changes to plot_peripheral_frequency/df_peripheral_clock_effective_rate, let me know if everything still works for you.

Wrt to the trace for the documentation plot, it seems that `juno:uartclk` does not have any event for `clk_set_rate`, so I switched to `aplclk` to get a more interesting plot.

The plot can be quickly viewed (with that PR) using:
```
lisa-plot doc/traces/trace_peripheral_clk.dat --plot frequency:peripheral-frequency interactive -X clk_name aplclk
```