### PR TITLE
lisa: Fix uses of Index.get_indexer()

### DIFF
--- a/lisa/analysis/rta.py
+++ b/lisa/analysis/rta.py
@@ -615,7 +615,7 @@ class RTAEventsAnalysis(TraceAnalysisBase):
         elif timestamp > last_phase_end:
             raise KeyError(f'timestamp={timestamp} is after last phase end: {last_phase_end}')
 
-        i = df.index.get_indexer([timestamp], method='ffill')
+        i = df.index.get_indexer([timestamp], method='ffill')[0]
         return PhaseWindow(*get_info(df.iloc[i]))
 
     ###########################################################################

--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -827,7 +827,7 @@ def _get_loc(index, x, method):
     # Also, if the index is not sorted, we need to fall back on the slow path
     # as well. Checking is_monotonic is cheap so it's ok to do it here.
     if method == 'nearest' or not index.is_monotonic:
-        return index.get_indexer([x], method=method)
+        return index.get_indexer([x], method=method)[0]
     else:
         if index.empty:
             raise KeyError(x)

--- a/lisa/notebook.py
+++ b/lisa/notebook.py
@@ -179,7 +179,7 @@ def axis_link_dataframes(axis, df_list, before=1, after=5, cursor_color='red', f
             elif loc > df.index[-1]:
                 iloc = -1
             else:
-                iloc = df.index.get_indexer([loc], method='ffill')
+                iloc = df.index.get_indexer([loc], method='ffill')[0]
             index_loc = df.index[iloc]
 
             begin = max(iloc - before, 0)
@@ -633,7 +633,7 @@ def _hv_link_dataframes(fig, dfs):
             for table in tables:
                 if x is not None:
                     df = table.value
-                    i = df.index.get_indexer([x], method='ffill')
+                    i = df.index.get_indexer([x], method='ffill')[0]
                     # This will automatically scroll in the table.
                     table.selection = [i]
             return hv.Points([])

--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -310,7 +310,7 @@ class InvarianceItemBase(RTATestBundle, LoadTrackingHelpers, TestBundle, Exekall
         df_activation = df_activation[df.index[0]:]
 
         # Get the initial signal value matching the first activation we will care about
-        init_iloc = df.index.get_indexer([df_activation.index[0]], method='ffill')
+        init_iloc = df.index.get_indexer([df_activation.index[0]], method='ffill')[0]
         init = df[signal_name].iloc[init_iloc]
 
         try:


### PR DESCRIPTION
FIX

Pandas currently recommands replacing uses of the deprecated
Index.get_loc(x) by Index.get_indexer([x]).

https://github.com/pandas-dev/pandas/issues/46763

This is unfortunately not accurate and results in breakages:

* get_loc(x) returns an integer
* get_indexer([x]) returns an array of integer

Using DataFrame.iloc[] on the output of get_indexer() will therefore
give a single-row dataframe instead of a series, which leads to various
issues.

Replace get_indexer([x]) by get_indexer([x])[0] instead.