### PR TITLE
lisa.trace: De-hardcode tracefs location

### DIFF
--- a/lisa/tests/base.py
+++ b/lisa/tests/base.py
@@ -2042,14 +2042,6 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
                 if event.startswith('userspace@rtapp_')
             ]
 
-        # Coarse-grained detection, but that should be enough for our use
-        try:
-            target.execute('ls /sys/kernel/debug/tracing/')
-        except TargetStableError:
-            debugfs_needs_root = True
-        else:
-            debugfs_needs_root = False
-
         wload = RTA.from_profile(
             target=target,
             profile=profile,
@@ -2079,7 +2071,7 @@ class RTATestBundle(FtraceTestBundle, DmesgTestBundle):
         logger.debug(f'rt-app JSON:\n{wload.conf.json}')
         cgroup = cls._target_configure_cgroup(target, cg_cfg)
         as_root = bool(
-            cgroup is not None or (trace_events and debugfs_needs_root)
+            cgroup is not None or trace_events
         )
 
         wload = wload(

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -5513,7 +5513,8 @@ class FtraceCollector(CollectorBase, Configurable):
             if Trace._is_meta_event(event)
         }
 
-        available_events = self._target_available_events(target)
+        tracing_path = devlib.FtraceCollector.find_tracing_path(target)
+        available_events = self._target_available_events(target, tracing_path)
 
         # trace-cmd start complains if given these events, even though they are
         # valid
@@ -5664,6 +5665,7 @@ class FtraceCollector(CollectorBase, Configurable):
                 # Prevent devlib from pushing its own trace-cmd since we provide
                 # our own binary
                 no_install=True,
+                tracing_path=tracing_path,
                 **kwargs
             )
         super().__init__(collector, output_path=output_path)
@@ -5738,8 +5740,8 @@ class FtraceCollector(CollectorBase, Configurable):
         return x
 
     @staticmethod
-    def _target_available_events(target):
-        events = target.read_value('/sys/kernel/debug/tracing/available_events')
+    def _target_available_events(target, tracing_path):
+        events = target.read_value(target.path.join(tracing_path, 'available_events'))
         return set(
             event.split(':', 1)[1]
             for event in events.splitlines()


### PR DESCRIPTION
FIX

Detect tracefs location automatically.

relies on devlib PR: https://github.com/ARM-software/devlib/pull/590

~~LISA branch that comes with the devlib change as well for testing: 
remote: `https://github.com/douglas-raillard-arm/lisa.git`
branch: `detect_tracefs`~~
The devlib PR is merged and subtree in lisa repo updated, so this PR can be used directly