### PR TITLE
lisa/_assets/kmodules/sched_tp/Makefile: Improve pahole output

### DIFF
--- a/lisa/_assets/kmodules/sched_tp/Makefile
+++ b/lisa/_assets/kmodules/sched_tp/Makefile
@@ -57,8 +57,20 @@ $(VMLINUX_H): $(VMLINUX_TXT) $(VMLINUX)
 # Some options are not upstream (yet) but they have all be published on the
 # dwarves mailing list
 #
-# Use BTF first, as there seems to be some duplicated fields issues with DWARF (at least with Android's clang)
-	pahole -F btf,dwarf -E --suppress_force_paddings --skip_missing --forward_decl --expand_types_once --expanded_prefix "KERNEL_PRIVATE_" -C file://$(VMLINUX_TXT) $(VMLINUX) > _header
+# Options:
+# -F btf,dwarf: Use BTF first
+# -E: Expand nested type definitions
+# --suppress_force_paddings: Remove the "artificial" padding members pahole adds
+#   to make padding more visible. They are not always valid C syntax and can
+#   break build
+# --skip_missing: Keep going if one of the types is not found
+# --forward_decl: (non upstream) Include forward declaration of union and struct
+# --expand_types_once: Only expand a given type once, to avoid type redefinition
+#   (C does not care about nesting types, there is a single namespace).
+# --expanded_prefix: Add a prefix to all the types that are expanded by -E. This
+#   avoids conflicting with type definitions that would come from public kernel
+#   headers, while still allowing easy attribute access, anonymous types etc.
+	pahole -F btf,dwarf -E --suppress_force_paddings --show_only_data_members --skip_missing --forward_decl --expand_types_once --expanded_prefix "KERNEL_PRIVATE_" -C file://$(VMLINUX_TXT) $(VMLINUX) > _header
 # Create forward declaration of every type
 	sed -r -n 's/.*(struct|union|enum) ([0-9a-zA-Z_]*) .*/\1 \2;/p' _header | sort -u > _fwd_decl
 # Create TYPED_DEFINED_struct_foo macros for every type, so the client code can


### PR DESCRIPTION
Use --show_only_data_members to avoid having useless anonymous type
declaration in the middle of e.g. a struct.

Consider the following type:

    struct foo {
       struct { int a; } bar;
    };

GCC emits DWARF info looking this way:

    DW_TAG_structure_type
       DW_AT_name "foo"
       DW_TAG_member
	  DW_AT_name "bar"
	  DW_AT_type "struct "
	  DW_AT_data_member_location <0x42 - curr_loc>
       NULL

    0x42:
    DW_TAG_structure_type
       DW_TAG_member
	  DW_AT_name "a"
	  DW_AT_type "int "
	  DW_AT_data_member_location ...
       NULL

Clang emits:

    DW_TAG_structure_type
       DW_AT_name "foo"
       DW_TAG_member
	  DW_AT_name "bar"
	  DW_AT_type "struct "
	  DW_AT_data_member_location 0x0

       DW_TAG_structure_type
	  DW_TAG_member
	     DW_AT_name "a"
	     DW_AT_type "int "
	     DW_AT_data_member_location ...
	  NULL
       NULL

When pahole sees clang's output, it will emit something like that:

    struct foo {
       struct { int a; }; <------useless
       struct { int a; } bar;
    };

But with --show_only_data_members, it will ignore any child of
DW_TAG_structure_type that is not a DW_TAG_member and will print the
expected code.