### PR TITLE
lisa.utils: Speedup Loggable.get_logger()

### DIFF
--- a/tests/test_wlgen_rtapp.py
+++ b/tests/test_wlgen_rtapp.py
@@ -313,9 +313,7 @@ class TestRTACalibrationConf(RTABase):
             self.target, name='test', res_dir=self.res_dir, profile=profile,
             calibration=calibration)
 
-        rtapp.deploy()
-
-        with open(rtapp.local_json) as fh:
+        with rtapp, open(rtapp.local_json) as fh:
             return json.load(fh)['global']['calibration']
 
     def test_calibration_conf_pload_nodata(self):


### PR DESCRIPTION
FIX

Logging directly or indirectly inside a destructor (__del__) is
problematic as they are invoked when the world is breaking down around
them, which can trigger some harmless exceptions. For this reason,
get_logger() was returning a dummy logger if __del__ was found in the
stack.

inspect.stack() is unfortunately really slow (150ms to get a stack frame
of depth 25), which is enough to really slowdown the import of some
modules and runtime code as well.

Fix that by returning a wrapped logger object that will only inpsect the
stack if an exception is raised.