### PR TITLE
tools/batch-rebase: Fix tag action

### DIFF
--- a/tools/batch-rebase
+++ b/tools/batch-rebase
@@ -253,11 +253,26 @@ def _do_cherry_pick(repo, conf, persistent_tags, tags_suffix):
         git(['tag', '-f', '--', tag_name])
         return tag_name
 
+    def resolve_action(topic):
+        return topic.get('action', 'cherry-pick')
+
+    def resolve_name(topic):
+        action = resolve_action(topic)
+        if action == 'tag':
+            return topic['name']
+        elif action == 'cherry-pick':
+            return topic.get('name', topic['tip'])
+        else:
+            raise ValueError(f'Could not handle action={action} in topic: {topic}')
+
     persistent_refs = set()
-    topics = conf['topics']
+    topics = conf['topics'].copy()
 
     for topic in topics:
-        topic.setdefault('name', topic['tip'])
+        topic.update(
+            action=resolve_action(topic),
+            name=resolve_name(topic),
+        )
 
     # If we are resuming after a conflict
     if 'conflict-topic' in conf['resume']:
@@ -296,7 +311,7 @@ def _do_cherry_pick(repo, conf, persistent_tags, tags_suffix):
 
     # Cherry pick topic branches in the specified order
     for topic in topics:
-        action = topic.get('action', 'cherry-pick')
+        action = topic['action']
         name = topic['name']
 
         if action == 'tag':

--- a/tools/batch-rebase
+++ b/tools/batch-rebase
@@ -23,6 +23,7 @@ import argparse
 import subprocess
 import sys
 from collections.abc import Mapping
+from collections import Counter
 import tempfile
 from pathlib import Path
 import datetime
@@ -273,6 +274,12 @@ def _do_cherry_pick(repo, conf, persistent_tags, tags_suffix):
             action=resolve_action(topic),
             name=resolve_name(topic),
         )
+
+    for key, cnt in Counter(topic['name'] for topic in topics).items():
+        if cnt > 1:
+            raise ValueError(
+                f'Found {cnt} topics named "{key}", but names must be unique.'
+            )
 
     # If we are resuming after a conflict
     if 'conflict-topic' in conf['resume']:

--- a/tools/batch-rebase
+++ b/tools/batch-rebase
@@ -522,7 +522,7 @@ def main():
 
             topics:
                 -
-                    name: foo
+                    name: foo # The name will default to the value of "tip" if not provided
                     remote: myremote
                     base: mybase
                     tip: mytip


### PR DESCRIPTION
FIX

Fix tag action that were resulting in an exception: KeyError: 'tip'