### PR TITLE
lisa._kmod: Handle non-str make variables

### DIFF
--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -898,6 +898,12 @@ class KernelTree(Loggable, SerializeViaConstructor):
             **env,
             **dict(make_vars or {})
         }
+
+        make_vars = {
+            str(k): str(v)
+            for k, v in make_vars.items()
+        }
+
         if abi is None:
             abi = make_vars.get('ARCH', LISA_HOST_ABI)
 


### PR DESCRIPTION
FIX

Turn make variables into strings early in the processing to avoid any
issues if they come from Python or YAML as other types.