### PR TITLE
lisa.trace: Improve FtraceCollector docstring

### DIFF
--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -1226,8 +1226,15 @@ class KernelTree(Loggable, SerializeViaConstructor):
                     logger.debug(f'Loaded kernel tree using loader {loader.__name__}')
 
             else:
+                def format_excep(e):
+                    # We expect stderr to be merged in stdout
+                    if isinstance(e, subprocess.CalledProcessError) and e.stdout:
+                        return f'{e}:\n{e.stdout}'
+                    else:
+                        return str(e)
+
                 excep_str = "\n".join(
-                    f"{loader.__name__}: {e.__class__.__name__}: {e}"
+                    f"{loader.__name__}: {e.__class__.__name__}: {format_excep(e)}"
                     for loader, e in exceps
                 )
                 raise ValueError(f'Could not load kernel trees:\n{excep_str}')

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -5484,6 +5484,12 @@ class FtraceCollector(CollectorBase, Configurable):
     """
     Thin wrapper around :class:`devlib.collector.ftrace.FtraceCollector`.
 
+    .. note:: Events are expected to be provided by the target's kernel, but if
+        they are not :class:`lisa._kmod.LISAFtraceDynamicKmod` will build a
+        kernel module to attempt to satisfy the missing events. This will
+        typically require correct target setup, see
+        :class:`lisa.target.TargetConf` ``kernel/src`` configurations.
+
     {configurable_params}
     """
 


### PR DESCRIPTION
FEATURE

Mention that FtraceCollector will attempt to build the kernel module if
some events are missing and that it will require proper configuration to
succeed.