### PR TITLE
lisa.wa: Include classifiers in WAResultsCollector

### DIFF
--- a/lisa/wa.py
+++ b/lisa/wa.py
@@ -458,6 +458,7 @@ class WAResultsCollector(WACollectorBase):
     def _get_job_df(cls, job):
         df = pd.DataFrame.from_records(
             {
+                **metric.classifiers,
                 'metric': metric.name,
                 'value': metric.value,
                 'unit': metric.units or '',


### PR DESCRIPTION
Some workloads in workload-automation (e.g. jankbench) include a field
in their results called 'classifiers'. It may contain the number of
repetitions, the name of the subtest being ran or other information.

Currently, Lisa completely ignores this field leading to situations such
as jankbench results not including the name of the test as it
uses 'metric' for the data type (e.g. mean, std_dev etc.) and
classifiers['test_name'] to keep the actual subtest name.

This patch includes classifiers expanded to separate columns in the df
containing WAOutput results when they are present. When classifiers are
not present or are empty, e.g. with pcmark, speedometer etc.,
the resulting df will not be affected by the change.