### PR TITLE
lisa._assets.kmodules.sched_tp: Add MODULE_IMPORT_NS()

### DIFF
--- a/lisa/_assets/kmodules/sched_tp/Makefile
+++ b/lisa/_assets/kmodules/sched_tp/Makefile
@@ -26,6 +26,7 @@ else
 endif
 
 VMLINUX_H = $(MODULE_OBJ)/vmlinux.h
+SYMBOL_NAMESPACES_H = $(MODULE_OBJ)/symbol_namespaces.h
 
 # kbuild part of makefile. Only Kbuild-related targets should be used here to
 # avoid any sort of clash.
@@ -86,8 +87,20 @@ $(VMLINUX_H): $(VMLINUX_TXT) $(VMLINUX)
 	cat _fwd_decl _header > $@
 # cat $@
 
+# Some kernels require the use of MODULE_IMPORT_NS() before using symbols that are part of the given namespace:
+# https://docs.kernel.org/core-api/symbol-namespaces.html
+# Unfortunately, Android kernels seem to define their own namespaces for GKI, so
+# in order to avoid issues and work on any kernel, we simply attempt to list all
+# of the namespaces this kernel seems to rely on by looking at the sources.
+# We could use Module.symvers file, but it can only be generated when building a
+# kernel so it would be way to slow.
+# There does not seem to be any other source for the info in e.g. sysfs or
+# procfs, so we rely on that hack for now.
+$(SYMBOL_NAMESPACES_H):
+	find $(KERNEL_SRC) '(' -name '*.c' -o -name '*.h' ')' -print0 | xargs -P0 -n4096 -0 sed -n 's/MODULE_IMPORT_NS([^;]*;/\0/p' | sort -u > $@
+
 # Make all object files depend on the generated sources
-$(addprefix $(MODULE_OBJ)/,$($(LISA_KMOD_NAME)-y)): $(VMLINUX_H)
+$(addprefix $(MODULE_OBJ)/,$($(LISA_KMOD_NAME)-y)): $(VMLINUX_H) $(SYMBOL_NAMESPACES_H)
 
 # Non-Kbuild part
 else
@@ -103,6 +116,6 @@ install: build
 	$(MAKE) -C $(KERNEL_SRC) M=$(MODULE_SRC) modules_install
 
 clean:
-	rm -f $(VMLINUX_H)
+	rm -f $(VMLINUX_H) $(SYMBOL_NAMESPACES_H)
 
 endif

--- a/lisa/_assets/kmodules/sched_tp/main.c
+++ b/lisa/_assets/kmodules/sched_tp/main.c
@@ -3,6 +3,10 @@
 
 #include "main.h"
 #include "features.h"
+/* Import all the symbol namespaces that appear to be defined in the kernel
+ * sources so that we won't trigger any warning
+ */
+#include "symbol_namespaces.h"
 
 static char *features[MAX_FEATURES];
 unsigned int features_len = 0;


### PR DESCRIPTION
FIX

Some kernels require importing namespaces before using a symbol. An
example is some Android kernels that will refuse to load the module:

    [ 3357.743660] lisa: module uses symbol (filp_open) from namespace VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver, but does not import it.
    [ 3357.756891] lisa: Unknown symbol filp_open (err -22)
    [ 3357.761935] lisa: module uses symbol (kernel_write) from namespace VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver, but does not import it.
    [ 3357.775399] lisa: Unknown symbol kernel_write (err -22)
    [ 3357.780702] lisa: module uses symbol (kernel_read) from namespace VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver, but does not import it.
    [ 3357.794067] lisa: Unknown symbol kernel_read (err -22)

Fix the issue by adding an MODULE_IMPORT_NS() for each namespace that
the kernel appears to be using, so that we are never at loss. This
allows compatibility with the widest range of kernels.