### PR TITLE
lisa.target: Allow mount to work on Android

### DIFF
--- a/lisa/target.py
+++ b/lisa/target.py
@@ -235,6 +235,11 @@ class Target(Loggable, HideExekallID, ExekallTaggable, Configurable):
             # Similar issue with HiKey960, the board will crash if this is frozen
             # for too long.
             'watchdogd',
+            # AOSP 'mount' command needs to communicate with 'emulated'
+            # threads, the threads are spawn by the process 'rs.media.module',
+            # so need to avoid freezing it to avoid stuck with execute 'mount'
+            # command.
+            'rs.media.module',
         ]
     }
     """


### PR DESCRIPTION
FIX

It has been reported that rs.media.module process is necessary for the
mount command to work on Android, so add it to the list of critical
tasks to not freeze.