### PR TITLE
utilclamp.py: Don't consider migration margin in test_placement

### DIFF
--- a/lisa/tests/staging/utilclamp.py
+++ b/lisa/tests/staging/utilclamp.py
@@ -273,7 +273,6 @@ class UtilClamp(RTATestBundle, TestBundle):
 
         metrics = {}
         test_failures = []
-        capacity_margin = self.CAPACITY_MARGIN
         cpu_max_capacities = self.plat_info['cpu-capacities']['rtapp']
 
         def parse_phase(df, phase):
@@ -286,7 +285,7 @@ class UtilClamp(RTATestBundle, TestBundle):
             fitting_cpus = {
                 cpu
                 for cpu, cap in cpu_max_capacities.items()
-                if (cap == PELT_SCALE) or (cap * capacity_margin) > uclamp_val
+                if (cap == PELT_SCALE) or cap > uclamp_val
             }
 
             failures = df[(df['cpu'].isin(cpus - fitting_cpus))].index.tolist()


### PR DESCRIPTION
By design, migration margin shouldn't be considered when comparing uclamp with capacities as explained in this series:

	https://lore.kernel.org/lkml/20220804143609.515789-1-qais.yousef@arm.com/

It is considered a bug - that the above series fixes it.

Integration branch was failing with this series applied because of this margin.

Fix the test to ignore the margin to reflect the actual uclamp design.

Older kernels without the series might fail now, which is the correct result.

The series should trickle to stable kernels once merged in mainline Linux. The failure should signal to any user that they need to backport this series.

Signed-off-by: Qais Yousef <qais.yousef@arm.com>