### PR TITLE
lisa.analysis.notebook: Avoid using DataFrame.iteritems()

### DIFF
--- a/lisa/analysis/notebook.py
+++ b/lisa/analysis/notebook.py
@@ -134,7 +134,7 @@ class NotebookAnalysis(TraceAnalysisBase):
             def make_info_row(row, event):
                 fields = field_sep.join(
                     f'{key}={value}'
-                    for key, value in row.iteritems()
+                    for key, value in row.items()
                     if key not in fields_as_cols_set
                 )
                 return fmt.format(

--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -2017,7 +2017,7 @@ def df_find_redundant_cols(df, col, cols=None):
     return {
         _col: dict(map(
             lambda x: (x[0], x[1][0]),
-            series.iteritems()
+            series.items()
         ))
         for _col, series in (
             (

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -3384,7 +3384,10 @@ class PartialInit(metaclass=_PartialInitMeta):
         # empty instance, e.g. using cls.__new__(cls), in which case we want to
         # allow calling methods on it to initialize it
         initialized, missing_kwargs = dct.get('_initialized', (True, set()))
-        if initialized or attr in ('__class__',):
+        if initialized or attr in set(
+            attr
+            for attr, _ in inspect.getmembers(get('__class__'))
+        ) | {'__name__', '__qualname__'}:
             return get(attr)
         else:
             params = ', '.join(


### PR DESCRIPTION
FIX

iteritems() has been deprecated in favor of items()