### PR TITLE
lisa.trace: Update HRTxtTraceParser skeleton regex

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -1910,7 +1910,7 @@ class HRTxtTraceParser(SimpleTxtTraceParser):
         ),
     }
 
-    HEADER_REGEX = r'(?P<__comm>.+)-(?P<__pid>\d+)\s*\[(?P<__cpu>\d*)\].*(?P<__timestamp>\d+\.\d+): +(?P<__event>\w+):'
+    HEADER_REGEX = r'(?P<__comm>.+)-(?P<__pid>\d+)[^[]*\[(?P<__cpu>\d*)\].*(?P<__timestamp>\d+\.\d+): +(?P<__event>\w+):'
 
 
 class SysTraceParser(HRTxtTraceParser):


### PR DESCRIPTION
FIX

Update HRTxtTraceParser skeleton regex to allow for a (---) TGID field, which is part of recent systrace files.