### PR TITLE
lisa._kmod: Explicitly pass module/kernel path when building module

### DIFF
--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -1581,6 +1581,9 @@ class KmodSrc(Loggable):
             make_vars.update(
                 M=mod_path,
                 LISA_KMOD_NAME=self.mod_name,
+                KERNEL_SRC=tree_path,
+                MODULE_SRC=mod_path,
+                MODULE_OBJ=mod_path,
             )
             make_vars = [
                 f'{name}={value}'


### PR DESCRIPTION
FEATURE

Pass path to module and kernel path instead of relying on Kbuild's $(src) and $(srctree) variables, as they seem to be broken on some android's kernel.