### PR TITLE
lisa.tests.scheduler.eas_behaviour: Fix _get_rtapp_profile() prototype

### DIFF
--- a/lisa/tests/scheduler/eas_behaviour.py
+++ b/lisa/tests/scheduler/eas_behaviour.py
@@ -869,7 +869,7 @@ class RampDown(EASBehaviour):
             capacity_margin_pct=capacity_margin_pct)
 
     @classmethod
-    def _get_rtapp_profile(cls, plat_info):
+    def _get_rtapp_profile(cls, plat_info, big_task_duty_cycle=None):
         little = cls.get_little_cpu(plat_info)
         start_pct = cls.get_big_duty_cycle(plat_info, big_task_duty_cycle=big_task_duty_cycle)
         end_pct = cls.unscaled_utilization(plat_info, little, 10)


### PR DESCRIPTION
commit 487e1ac46ea6 ("lisa.tests.scheduler.eas_behaviour: Add big-task-duty-cycle platform parameter")
modified the prototype of _get_rtapp_profile(), but an implementation was left with the initial prototype, triggering errors. Fix that.

Notes:
- Another mistake was made in the initial commit: the platform where this can be seen is not a rb5, but a db845c.
- The value for big-task-duty-cycle for the db84c should be set to 50.
- It seems that on a rb5, get_big_duty_cycle() normally selects a duty cycle of ~73%. The capacity of the medium CPU is ~870. This means that a big task cannot fit in a medium CPU. Maybe a custom value should be set for this platform aswell.
