### PR TITLE
lisa.trace: Fix HRTxtTraceParser regex for timestamp parsing

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -1911,7 +1911,7 @@ class HRTxtTraceParser(SimpleTxtTraceParser):
         ),
     }
 
-    HEADER_REGEX = r'(?P<__comm>.+)-(?P<__pid>\d+)[^[]*\[(?P<__cpu>\d*)\].*(?P<__timestamp>\d+\.\d+): +(?P<__event>\w+):'
+    HEADER_REGEX = r'\s*(?P<__comm>.+)-(?P<__pid>\d+)[^[]*\[(?P<__cpu>\d*)\][^\d]+(?P<__timestamp>\d+\.\d+): +(?P<__event>\w+):'
 
 
 class SysTraceParser(HRTxtTraceParser):


### PR DESCRIPTION
A Systrace generated by the Perfetto's `traceconv` tool has records with this format:
```
<idle>-0     (-----) [000] .... 608397.919018: sched_wakeup: comm=traced pid=403293 prio=120 target_cpu=000
 ```
which timestamp gets parsed as `7.919018`, i.e. by ignoring all the digits but one before the second.

Fix the timestamp regexp by ensuring that, after the `__cpu` filed has been
parsed, we skip all and only the non digit chars following it.