### PR TITLE
lisa.tests.scheduler.load_tracking: Add assert to check duty_cycle_pc…

### DIFF
--- a/lisa/tests/scheduler/load_tracking.py
+++ b/lisa/tests/scheduler/load_tracking.py
@@ -216,6 +216,9 @@ class InvarianceItemBase(RTATestBundle, LoadTrackingHelpers, TestBundle, Exekall
         # task will fit even at the lowest OPP
         duty_cycle_pct //= 2
 
+        # Catch rt-app calibration induced issues early.
+        assert duty_cycle_pct > 0
+
         return {
             f"{cls.task_prefix}{cpu}": RTAPhase(
                 prop_wload=PeriodicWload(


### PR DESCRIPTION
…t > 0

Occasionally the load_tracking invariance tests
[load\|util]_[correctness\|behaviour] fail on rb5 little/medium CPUs on low frequencies.
The root cause is wrong rt-app calibration for these CPUs/frequencies. The reason for the rt-app calibration issue is not known at the moment. Add an assert in _get_rtapp_profile() of class InvarianceItemBase to catch the issue earlier.

Signed-off-by: Dietmar Eggemann <dietmar.eggemann@arm.com>