### PR TITLE
lisa._assets.kmodules.sched_tp: Add sched_pelt_thermal trace event

### DIFF
--- a/lisa/_assets/kmodules/sched_tp/ftrace_events.h
+++ b/lisa/_assets/kmodules/sched_tp/ftrace_events.h
@@ -95,6 +95,10 @@ DEFINE_EVENT(sched_pelt_rq_template, sched_pelt_irq,
 	TP_PROTO(int cpu, const struct sched_avg *avg),
 	TP_ARGS(cpu, avg));
 
+DEFINE_EVENT(sched_pelt_rq_template, sched_pelt_thermal,
+	TP_PROTO(int cpu, const struct sched_avg *avg),
+	TP_ARGS(cpu, avg));
+
 TRACE_EVENT(sched_pelt_se,
 
 	TP_PROTO(int cpu, char *path, char *comm, int pid, const struct sched_avg *avg),

--- a/lisa/_assets/kmodules/sched_tp/sched_helpers.h
+++ b/lisa/_assets/kmodules/sched_tp/sched_helpers.h
@@ -165,6 +165,15 @@ static inline const struct sched_avg *sched_tp_rq_avg_irq(struct rq *rq)
 #endif
 }
 
+static inline const struct sched_avg *sched_tp_rq_avg_thermal(struct rq *rq)
+{
+#if defined(CONFIG_SMP) && defined(CONFIG_SCHED_THERMAL_PRESSURE)
+	return rq ? (struct sched_avg *)&rq->avg_thermal : NULL;
+#else
+	return NULL;
+#endif
+}
+
 static inline int sched_tp_rq_cpu(struct rq *rq)
 {
 	return rq ? cpu_of(rq) : -1;

--- a/lisa/_assets/kmodules/sched_tp/tp.c
+++ b/lisa/_assets/kmodules/sched_tp/tp.c
@@ -95,6 +95,18 @@ static void sched_pelt_irq_probe(struct feature *feature, struct rq *rq)
 }
 DEFINE_TP_EVENT_FEATURE(sched_pelt_irq, pelt_irq_tp, sched_pelt_irq_probe);
 
+static void sched_pelt_thermal_probe(struct feature *feature, struct rq *rq)
+{
+	const struct sched_avg *avg = sched_tp_rq_avg_thermal(rq);
+	int cpu = sched_tp_rq_cpu(rq);
+
+	if (!avg)
+		return;
+
+	trace_sched_pelt_thermal(cpu, avg);
+}
+DEFINE_TP_EVENT_FEATURE(sched_pelt_thermal, pelt_thermal_tp, sched_pelt_thermal_probe);
+
 static void sched_pelt_se_probe(struct feature *feature, struct sched_entity *se)
 {
 	_trace_se(se, trace_sched_pelt_se);

--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -2062,6 +2062,7 @@ _SIGNALS = [
     SignalDesc('sched_pelt_irq', ['cpu']),
     SignalDesc('sched_pelt_rt', ['cpu']),
     SignalDesc('sched_pelt_dl', ['cpu']),
+    SignalDesc('sched_pelt_thermal', ['cpu']),
 
     SignalDesc('uclamp_util_se', ['pid', 'comm']),
     SignalDesc('uclamp_util_cfs', ['cpu']),

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -1486,6 +1486,14 @@ class TxtTraceParser(TxtTraceParserBase):
                 'util': _KERNEL_DTYPE['util'],
             },
         ),
+        'sched_pelt_thermal': dict(
+            fields={
+                'cpu': _KERNEL_DTYPE['cpu'],
+                'load': _KERNEL_DTYPE['util'],
+                'rbl_load': _KERNEL_DTYPE['util'],
+                'util': _KERNEL_DTYPE['util'],
+            },
+        ),
         'sched_process_wait': dict(
             fields={
                 'comm': _KERNEL_DTYPE['comm'],


### PR DESCRIPTION
The corresponding trace point is already supported in Linux kernel mainline:

Commit 77cf151b7bbdf ("sched/core: Export pelt_thermal_tp") Commit 765047932f153 ("sched/pelt: Add support to track thermal pressure")

Signed-off-by: Dietmar Eggemann <dietmar.eggemann@arm.com>