### PR TITLE
lisa._assets.kmodules.sched_tp: Hide UTIL_AVG_UNCHANGED in sched_util…

### DIFF
--- a/lisa/_assets/kmodules/sched_tp/ftrace_events.h
+++ b/lisa/_assets/kmodules/sched_tp/ftrace_events.h
@@ -192,7 +192,7 @@ TRACE_EVENT(sched_util_est_se,
 		strlcpy(__entry->path, path, PATH_SIZE);
 		strlcpy(__entry->comm, comm, TASK_COMM_LEN);
 		__entry->pid		= pid;
-		__entry->enqueued	= avg->util_est.enqueued;
+		__entry->enqueued	= avg->util_est.enqueued & ~UTIL_AVG_UNCHANGED;
 		__entry->ewma		= avg->util_est.ewma;
 		__entry->util		= avg->util_avg;
 	),


### PR DESCRIPTION
…_est_se

UTIL_AVG_UNCHANGED is an internal util_est state bit and should not be exposed via util_est.enqueued in the sched_util_est_se trace event.

Signed-off-by: Dietmar Eggemann <dietmar.eggemann@arm.com>