### PR TITLE
tools/lisa-build-asset: Remove lisa.utils import

### DIFF
--- a/doc/man1/bisector.1
+++ b/doc/man1/bisector.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "BISECTOR" "1" "2022" "" "bisector"
+.TH "BISECTOR" "1" "2023" "" "bisector"
 .SH NAME
 bisector \- command sequencer
 .SH DESCRIPTION

--- a/doc/man1/exekall.1
+++ b/doc/man1/exekall.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "EXEKALL" "1" "2022" "" "exekall"
+.TH "EXEKALL" "1" "2023" "" "exekall"
 .SH NAME
 exekall \- test runner
 .SH DESCRIPTION

--- a/doc/man1/lisa.1
+++ b/doc/man1/lisa.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LISA" "1" "2022" "" "LISA shell"
+.TH "LISA" "1" "2023" "" "LISA shell"
 .SH NAME
 lisa \- LISA shell commands
 .SH DESCRIPTION

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -2711,20 +2711,9 @@ def guess_format(path):
     return guessed_format
 
 
-@contextlib.contextmanager
-def nullcontext(enter_result=None):
-    """
-    Backport of Python 3.7 ``contextlib.nullcontext``
-
-    This context manager does nothing, so it can be used as a default
-    placeholder for code that needs to select at runtime what context manager
-    to use.
-
-    :param enter_result: Object that will be bound to the target of the with
-        statement, or `None` if nothing is specified.
-    :type enter_result: object
-    """
-    yield enter_result
+# lisa.utils used to provide its own version of nullcontext, so it's part of
+# its public API.
+nullcontext = contextlib.nullcontext
 
 
 @contextlib.contextmanager

--- a/tools/lisa-build-asset
+++ b/tools/lisa-build-asset
@@ -7,8 +7,7 @@ import tempfile
 import shutil
 import sys
 
-from lisa.utils import nullcontext
-from contextlib import contextmanager
+from contextlib import nullcontext, contextmanager
 from shlex import quote
 
 LISA_HOME = os.environ['LISA_HOME']


### PR DESCRIPTION
Since Python 3.7, nullcontext is provided by contextlib directly so there is no need to pull that from lisa.