### PR TITLE
lisa.analysis: Fix doc comments relating to task_states

### DIFF
--- a/lisa/analysis/latency.py
+++ b/lisa/analysis/latency.py
@@ -65,7 +65,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         :returns: a :class:`pandas.DataFrame` with:
 
           * A ``wakeup_latency`` column (the wakeup latency at that timestamp)
-          * A ``cpu`` column (the CPU where the task was on)
+          * A ``cpu`` column (the CPU where the event took place)
           * A ``target_cpu`` column (the CPU where the task has been scheduled)
         """
         return self._df_latency(
@@ -86,7 +86,7 @@ class LatencyAnalysis(TraceAnalysisBase):
         :returns: a :class:`pandas.DataFrame` with:
 
           * A ``preempt_latency`` column (the preemption latency at that timestamp)
-          * A ``cpu`` column (the CPU where the task was on)
+          * A ``cpu`` column (the CPU where the event took place)
         """
         return self._df_latency(
             task,

--- a/lisa/analysis/tasks.py
+++ b/lisa/analysis/tasks.py
@@ -446,7 +446,7 @@ class TasksAnalysis(TraceAnalysisBase):
 
         :returns: a :class:`pandas.DataFrame` with:
 
-          * A ``cpu`` column (the CPU where the task was on)
+          * A ``cpu`` column (the CPU where the event took place)
           * A ``pid`` column (the PID of the task)
           * A ``comm`` column (the name of the task)
           * A ``target_cpu`` column (the CPU where the task has been scheduled).
@@ -479,7 +479,7 @@ class TasksAnalysis(TraceAnalysisBase):
 
         :returns: a :class:`pandas.DataFrame` with:
 
-          * A ``cpu`` column (the CPU where the task was on)
+          * A ``cpu`` column (the CPU where the event took place)
           * A ``target_cpu`` column (the CPU where the task has been scheduled).
             Will be ``-1`` for non-wakeup events
           * A ``curr_state`` column (the current task state, see :class:`~TaskState`)


### PR DESCRIPTION
FIX

Adjust doc comments for df_tasks_states and related functions to clarify that 'cpu' corresponds to the CPU on which the trace event was fired. In the case of some events it does not necessarily correspond to where the task was running previously.