### PR TITLE
.gitignore: Add cache/ and kernel module artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ _build
 custom_requirements.txt
 extra_requirements.txt
 tools/alpine-chroot-install
+cache/
+*.o
+*.mod
+*.ko
+*.mod.c
+*.order
+*.symvers


### PR DESCRIPTION
FIX

Update gitignore to exclude git cache that can be generated inside the directory and slow down git commands inside the lisa directory.

Also exclude some of the artifacts that can be generated by building the Lisa kernel module.