### PR TITLE
Expose jobs in WAOutput & traces in WATraceCollector

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -3845,4 +3845,34 @@ class SerializeViaConstructor(metaclass=_SerializeViaConstructorMeta):
         return (self._make_instance, (self._ctor, dct))
 
 
+class LazyMapping(Mapping):
+    """
+    Lazy Mapping dict-like class for elements evaluated on the fly.
+
+    It takes the same set of arguments as a dict with keys as the mapping keys
+    and values as closures that take a key and return the value. The class does
+    no automatic memoization but memoization can easily be achieved using
+    :func:`functools.lru_cache`, as shown in the example below.
+
+    **Example**::
+
+        LazyMapping({
+            x: lru_cache()(lambda k: k + 42)
+            for x in [1, 2, 3, 4]
+        })
+
+    """
+    def __init__(self, *args, **kwargs):
+        self._closures = dict(*args, **kwargs)
+
+    def __getitem__(self, key):
+        return self._closures[key](key)
+
+    def __iter__(self):
+        return iter(self._closures)
+
+    def __len__(self):
+        return len(self._closures)
+
+
 # vim :set tabstop=4 shiftwidth=4 textwidth=80 expandtab

--- a/lisa/wa.py
+++ b/lisa/wa.py
@@ -22,6 +22,7 @@ import abc
 import contextlib
 import sqlite3
 import pathlib
+import warnings
 from functools import lru_cache
 
 import pandas as pd
@@ -286,6 +287,9 @@ class WAOutput(StatsProp, Mapping, Loggable):
         :class:`wa.framework.RunOutput` objects.
         """
         wa_outputs = list(discover_wa_outputs(self.path))
+
+        if len(wa_outputs) > 1:
+            warnings.warn('Passing a directory containing multiple outputs of "wa run" to WAOutput is deprecated. Please, create one object per run.', DeprecationWarning)
 
         wa_outputs = {
             pathlib.Path(


### PR DESCRIPTION
This PR allows acessing a list of jobs in the WAOutput through
wa_output.jobs along with a LazyMapping of raw Trace objects in WATraceCollector
through wa_output['trace'].traces.

Additionally, add deprecation warnings for creating WAOutputs containing multiple different WA runs. This is meant to determine whether any of the existing workflows or use cases rely on the feature with the ultimate goal of removing it and achieving the same functionality in a cleaner, less error-prone way.
