### PR TITLE
lisa.wlgen.sysbench: Fix docstring

### DIFF
--- a/lisa/wlgen/sysbench.py
+++ b/lisa/wlgen/sysbench.py
@@ -55,16 +55,21 @@ class Sysbench(Workload):
     """
     A sysbench workload
 
+    :param target: The Target on which to execute this workload
+    :type target: Target
+
     :param max_duration_s: Maximum duration in seconds
     :type max_duration_s: int
 
-    :param: max_requests: Maximum number of event requests
+    :param max_requests: Maximum number of event requests
     :type max_requests: int
 
     :param cli_options: Dictionary of cli_options passed to sysbench command line. Run
         ``sysbench --test=<test> help`` for available parameters. Character
         ``_`` in option names is replaced by ``-``.
     :type cli_options: dict(str, object)
+
+    :Variable keyword arguments: Forwarded to :class:`lisa.wlgen.workload.Workload`
     """
 
     REQUIRED_TOOLS = ['sysbench']

--- a/lisa/wlgen/workload.py
+++ b/lisa/wlgen/workload.py
@@ -280,15 +280,6 @@ class Workload(_WorkloadBase, PartialInit, Loggable):
 
     .. note:: A :class:`Workload` instance can be used as a context manager,
       which ensures :meth:`cleanup` is eventually invoked.
-
-    **Usage example**::
-
-        >>> printer = Printer(target, "test")
-        >>> output = printer.run()
-        INFO    : Printer      : Execution start: echo 42
-        INFO    : Printer      : Execution complete
-        >>> print(output)
-        42\r\n
     """
 
     REQUIRED_TOOLS = []


### PR DESCRIPTION
FIX

Document "target" parameter and the variable keyword arguments that are forwarded to the base class.