### PR TITLE
setup.py: Force Sphinx > 2 for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,6 +20,10 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.10"
+  apt_packages:
+    - graphviz
+    - plantuml
+    - pandoc
 
 python:
   install:

--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -1,5 +1,5 @@
 
-sphinx==3.5.1
+sphinx==6.1.3
 
 # A streamlined version of devmode_requirements.txt for doc building
 -e ./tools/exekall

--- a/setup.py
+++ b/setup.py
@@ -77,9 +77,9 @@ extras_require={
 }
 
 extras_require["doc"] = [
-    "sphinx >= 1.8",
     # Force ReadTheDocs to use a recent version, rather than the defaults used
     # for old projects.
+    "sphinx > 2",
     "sphinx_rtd_theme >= 0.5.2",
     "sphinxcontrib-plantuml",
     "nbsphinx",


### PR DESCRIPTION
FIX

readthedocs uses an old version of sphinx for projects created before 2020:
https://github.com/mgeier/sphinx-last-updated-by-git/issues/1

So force a newer version.