### PR TITLE
lisa.trace: Fix TxtEventParser regex for named ring buffer

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -465,9 +465,10 @@ class TxtEventParser(EventParserBase):
 
     Parses events with the following format::
 
-          <idle>-0     [001]    76.214046: sched_wakeup: something here: comm=watchdog/1 pid=15 prio=0 success=1 target_cpu=1
-          \\____________________________________________/ \\____________/  \\__________________________________________________/
-                             header                        positional                          fields
+          devlib:     <idle>-0     [001]    76.214046: sched_wakeup: something here: comm=watchdog/1 pid=15 prio=0 success=1 target_cpu=1
+          \\____/     \\___________________________________________/ \\____________/ \\_________________________________________________/
+          buffer                          header                        positional                          fields
+        (optional)
 
     """
 
@@ -590,7 +591,7 @@ class TxtEventParser(EventParserBase):
             if field in ('__timestamp', '__event')
         )
 
-        regex = r'^{blank}{__comm}-{__pid}{blank}\[{__cpu}\]{blank}{__timestamp}:{blank}{__event}:'.format(**compos, blank=blank)
+        regex = r'^.*:?{blank}{__comm}-{__pid}{blank}\[{__cpu}\]{blank}{__timestamp}:{blank}{__event}:'.format(**compos, blank=blank)
         return regex
 
     def _get_regex(self, event, fields, positional_field, greedy_field):


### PR DESCRIPTION
FIX

Using named ring buffer in ftrace makes trace-cmd report display the name of the buffer at the beginning of each event. Adjust the parsing regex to ignore it.