### PR TITLE
lisa.tests.starting.utilclamp: Fix for pandas 2.0.0

### DIFF
--- a/lisa/tests/staging/utilclamp.py
+++ b/lisa/tests/staging/utilclamp.py
@@ -172,7 +172,7 @@ class UtilClamp(RTATestBundle, TestBundle):
 
         df_freq = self.trace.ana.frequency.df_cpus_frequency()
         df_freq = df_freq[['cpu', 'frequency']]
-        df_freq = df_freq.pivot(index=None, columns='cpu', values='frequency')
+        df_freq = df_freq.pivot(columns='cpu', values='frequency')
         df_freq.reset_index(inplace=True)
         df_freq.set_index('Time', inplace=True)
 


### PR DESCRIPTION
DataFrame.pivot(index=None) seems to have changed behavior: https://github.com/pandas-dev/pandas/issues/52436

Remove index=None so that it works across pandas versions.