### PR TITLE
setup.py: Add <3.0 pandas version bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
             # Pandas >= 1.0.0 has support for new nullable dtypes
             # Pandas 1.2.0 has broken barplots:
             # https://github.com/pandas-dev/pandas/issues/38947
-            "pandas >= 1.0.0",
+            "pandas >=1.0.0, <3.0",
             "numpy",
             "scipy",
             # Earlier versions have broken __slots__ deserialization


### PR DESCRIPTION
Avoid breakage of published package at the next major pandas release, since pandas more or less follows semantic versionning.