### PR TITLE
lisa.wa: Fix getting jobs in WACollectorBase

### DIFF
--- a/lisa/wa.py
+++ b/lisa/wa.py
@@ -423,7 +423,7 @@ class WACollectorBase(StatsProp, Loggable, abc.ABC):
 
         dfs = [
             self._add_output_info(wa_output, name, df)
-            for name, (wa_output, jobs) in self._jobs.items()
+            for name, (wa_output, jobs) in self.wa_output._jobs.items()
             for df in [
                 load_df(job)
                 for job in jobs


### PR DESCRIPTION
FIX

The 'self' in WACollectorBase refers to the WACollectorBase and not the parent WAOutput, currently causing get_collector to crash because it can't find the _jobs property.
This looks like an omission from the recent wa.py changes so this commit just fixes the property being accessed.