### PR TITLE
Add support for the Pixel 6 emeter GPU channel

### DIFF
--- a/lisa/_assets/kmodules/sched_tp/ftrace_events.h
+++ b/lisa/_assets/kmodules/sched_tp/ftrace_events.h
@@ -336,25 +336,27 @@ TRACE_EVENT(sched_cpu_capacity,
 #define PIXEL6_EMETER_CHAN_NAME_MAX_SIZE 64
 
 TRACE_EVENT(pixel6_emeter,
-	TP_PROTO(unsigned long ts, unsigned int chan, char *chan_name, unsigned long value),
-	TP_ARGS(ts, chan, chan_name, value),
+	TP_PROTO(unsigned long ts, unsigned int device, unsigned int chan, char *chan_name, unsigned long value),
+	TP_ARGS(ts, device, chan, chan_name, value),
 
 	TP_STRUCT__entry(
 		__field(unsigned long,		ts			)
 		__field(unsigned long,		value			)
+		__field(unsigned int,		device			)
 		__field(unsigned int,		chan			)
 		__array(char,			chan_name,	PIXEL6_EMETER_CHAN_NAME_MAX_SIZE	)
 	),
 
 	TP_fast_assign(
-		__entry->ts		= ts;
+		__entry->ts		    = ts;
+		__entry->device		= device;
 		__entry->chan		= chan;
 		__entry->value		= value;
 		strlcpy(__entry->chan_name, chan_name, PIXEL6_EMETER_CHAN_NAME_MAX_SIZE);
 	),
 
-	TP_printk("ts=%lu chan=%u chan_name=%s value=%lu",
-		  __entry->ts, __entry->chan, __entry->chan_name, __entry->value)
+	TP_printk("ts=%lu device=%u chan=%u chan_name=%s value=%lu",
+		  __entry->ts, __entry->device, __entry->chan, __entry->chan_name, __entry->value)
 );
 
 #endif /* _FTRACE_EVENTS_H */

--- a/lisa/analysis/pixel6.py
+++ b/lisa/analysis/pixel6.py
@@ -36,9 +36,10 @@ class Pixel6Analysis(TraceAnalysisBase):
     name = 'pixel6'
 
     EMETER_CHAN_NAMES = {
-        'S4M_VDD_CPUCL0': 'little',
-        'S3M_VDD_CPUCL1': 'mid',
-        'S2M_VDD_CPUCL2': 'big',
+        'S4M_VDD_CPUCL0': 'CPU-Little',
+        'S3M_VDD_CPUCL1': 'CPU-Mid',
+        'S2M_VDD_CPUCL2': 'CPU-Big',
+        'S2S_VDD_G3D': 'GPU',
     }
 
 ###############################################################################


### PR DESCRIPTION
This PR adds support for the Pixel 6 emeter GPU channel in Lisa. It involves expanding the lisa sched_tp module to support passing private data down the parser chain. This functionality is then used to distinguish between the two different power meter devices when outputting trace events. Then, the pixel6_emeter parser logic is extended to parse both the power meter files (`device0` and `device1`), covering all the channels in the process. Finally, a `GPU` power channel is included in Lisa's pixel6 analysis to make use of the newly added functionality in trace analysis.