### PR TITLE
lisa.wlgen.rta: Add WloadPropertyBase.__rmul__()

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -2605,6 +2605,9 @@ class WloadPropertyBase(ConcretePropertyBase):
         else:
             return WloadSequence(wloads=[self] * n)
 
+    def __rmul__(self, n):
+        return self.__mul__(n)
+
     @abc.abstractmethod
     def to_events(self, **kwargs):
         pass


### PR DESCRIPTION
FEATURE

WloadPropertyBase can be multiplied by an integer to obtain a loop behavior. Implement __rmul__ in addition to __mul__ so that N * x and x
* N both work.