### PR TITLE
.github/workflows: Use concurrency group

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -11,6 +11,11 @@ permissions:
 jobs:
   mirror:
     name: mirror
+
+    # Ensure jobs queue in order, so that we don't get race conditions while
+    # pushing the branch
+    concurrency: mirror
+
     # Set the type of machine to run on
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,6 +20,11 @@ permissions:
 jobs:
   preview:
     name: preview
+
+    # Ensure jobs queue in order, so that we don't get race conditions while
+    # pushing the branch
+    concurrency: preview
+
     # Set the type of machine to run on
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-latest


### PR DESCRIPTION
Serialize jobs so that we don't have any ordering issues when updating branches.