### PR TITLE
lisa.trace: Fix FtraceCollector(events=['print'])

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     # Cancel current runs of the workflow if we trigger it again for the same
     # ref.
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.ref }}
       cancel-in-progress: true
 
 


### PR DESCRIPTION
FIX

Fix event validation when using FtraceCollector with some events that ftrace does not allow to configure.