### PR TITLE
tools/bisector: Fix ruamel usage of DEFAULT_MAPPING_TAG

### DIFF
--- a/tools/bisector/bisector/bisector.py
+++ b/tools/bisector/bisector/bisector.py
@@ -3856,7 +3856,7 @@ class Report(Serializable):
             return collections.OrderedDict(loader.construct_pairs(node))
 
         yaml.representer.add_representer(collections.OrderedDict, map_representer)
-        yaml.constructor.add_constructor(yaml.resolver.DEFAULT_MAPPING_TAG, map_constructor)
+        yaml.constructor.add_constructor(str(yaml.resolver.DEFAULT_MAPPING_TAG), map_constructor)
 
         # Since strings are immutable, we can memoized the output to deduplicate
         # strings.


### PR DESCRIPTION
FIX

Recent versions of ruamel.yaml changed DEFAULT_MAPPING_TAG from a string to a new non-hashable object. Ensure we use the tag name to avoid any exception.