### PR TITLE
lisa/_assets/kmodules/lisa: Add symbol namespace for kernel_read()

### DIFF
--- a/lisa/_assets/kmodules/lisa/Makefile
+++ b/lisa/_assets/kmodules/lisa/Makefile
@@ -103,6 +103,7 @@ $(VMLINUX_H): $(VMLINUX_TXT) $(VMLINUX)
 # procfs, so we rely on that hack for now.
 $(SYMBOL_NAMESPACES_H):
 	find $(KERNEL_SRC) '(' -name '*.c' -o -name '*.h' ')' -print0 | xargs -0 sed -n 's/MODULE_IMPORT_NS([^;]*;/\0/p' | sort -u > $@
+	echo "MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);" >> $@
 
 # Make all object files depend on the generated sources
 $(addprefix $(MODULE_OBJ)/,$($(LISA_KMOD_NAME)-y)): $(VMLINUX_H) $(SYMBOL_NAMESPACES_H)


### PR DESCRIPTION
FIX

The VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver namespace is necessary to have access to kernel_read() on some Android kernels. That function is required to be able to read the energy measurements exposed in sysfs by Pixel 6 builtin energy meter driver.