### PR TITLE
lisa._assets.kmodules.lisa: Rename feature event__pixel6_emeter to ev…

### DIFF
--- a/lisa/_assets/kmodules/lisa/pixel6.c
+++ b/lisa/_assets/kmodules/lisa/pixel6.c
@@ -186,7 +186,7 @@ static int disable_p6_emeter(struct feature* feature) {
 	return ret;
 };
 
-DEFINE_FEATURE(event__pixel6_emeter, enable_p6_emeter, disable_p6_emeter);
+DEFINE_FEATURE(event__lisa__pixel6_emeter, enable_p6_emeter, disable_p6_emeter);
 
 
 


### PR DESCRIPTION
…ent__lisa__pixel6_emeter

FIX

Ensure all features follow the same naming convention as the event they enable.