### PR TITLE
lisa/_assets/kmodules/lisa: Support in-tree builds

### DIFF
--- a/lisa/_assets/kmodules/lisa/Makefile
+++ b/lisa/_assets/kmodules/lisa/Makefile
@@ -25,9 +25,6 @@ else
 	KERNEL_SRC ?= /lib/modules/`uname -r`/build
 endif
 
-VMLINUX_H = $(MODULE_OBJ)/vmlinux.h
-SYMBOL_NAMESPACES_H = $(MODULE_OBJ)/symbol_namespaces.h
-
 # kbuild part of makefile. Only Kbuild-related targets should be used here to
 # avoid any sort of clash.
 ifneq ($(KERNELRELEASE),)
@@ -35,12 +32,28 @@ ifneq ($(KERNELRELEASE),)
 LISA_KMOD_NAME ?= lisa
 obj-m := $(LISA_KMOD_NAME).o
 $(LISA_KMOD_NAME)-y := main.o tp.o wq.o features.o pixel6.o
-ldflags-y += -T "$(M)/features.lds"
-
-clean-files := vmlinux.h
 
 # -fno-stack-protector is needed to possibly undefined __stack_chk_guard symbol
 ccflags-y = "-I$(MODULE_SRC)" -std=gnu11 -fno-stack-protector -Wno-declaration-after-statement
+
+FEATURES_LDS := features.lds
+
+SYMBOL_NAMESPACES_H = $(MODULE_OBJ)/symbol_namespaces.h
+
+# in-tree build
+ifneq ($(srctree),.)
+
+ccflags-y += -I$(srctree) -D_IN_TREE_BUILD
+ldflags-y += -T $(srctree)/$(obj)/$(FEATURES_LDS)
+
+# out-of-tree build
+else
+
+VMLINUX_H = $(MODULE_OBJ)/vmlinux.h
+
+ldflags-y += -T $(M)/$(FEATURES_LDS)
+
+clean-files := vmlinux.h
 
 VMLINUX_TXT = $(MODULE_SRC)/private_types.txt
 
@@ -91,6 +104,9 @@ $(VMLINUX_H): $(VMLINUX_TXT) $(VMLINUX)
 	sed -r -n 's/.*(struct|union|enum) ([0-9a-zA-Z_]*) .*/#define TYPE_DEFINED_\1_\2/p' _header_no_comment | sort -u >> _fwd_decl
 	cat _fwd_decl _header > $@
 # cat $@
+
+# out-of-tree build
+endif
 
 # Some kernels require the use of MODULE_IMPORT_NS() before using symbols that are part of the given namespace:
 # https://docs.kernel.org/core-api/symbol-namespaces.html

--- a/lisa/_assets/kmodules/lisa/Makefile
+++ b/lisa/_assets/kmodules/lisa/Makefile
@@ -39,6 +39,7 @@ ccflags-y = "-I$(MODULE_SRC)" -std=gnu11 -fno-stack-protector -Wno-declaration-a
 FEATURES_LDS := features.lds
 
 SYMBOL_NAMESPACES_H = $(MODULE_OBJ)/symbol_namespaces.h
+MODULE_VERSION_H = $(MODULE_OBJ)/module_version.h
 
 # in-tree build
 ifneq ($(srctree),.)
@@ -121,8 +122,13 @@ $(SYMBOL_NAMESPACES_H):
 	find "$(KERNEL_SRC)" '(' -name '*.c' -o -name '*.h' ')' -print0 | xargs -0 sed -n 's/MODULE_IMPORT_NS([^;]*;/\0/p' | sort -u > $@
 	echo "MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);" >> $@
 
+$(MODULE_VERSION_H):
+	echo -n '#ifndef _MODULE_VERSION_H\n#define _MODULE_VERSION_H\n#define LISA_MODULE_VERSION "' > $@
+	cat $$(find $(KERNEL_SRC)/$(MODULE_SRC)/ -name '*.*' | sort) | sha1sum | awk '{printf "%s\"\n", $$1}' >> $@
+	echo '#endif' >> $@
+
 # Make all object files depend on the generated sources
-$(addprefix $(MODULE_OBJ)/,$($(LISA_KMOD_NAME)-y)): $(VMLINUX_H) $(SYMBOL_NAMESPACES_H)
+$(addprefix $(MODULE_OBJ)/,$($(LISA_KMOD_NAME)-y)): $(VMLINUX_H) $(SYMBOL_NAMESPACES_H) $(MODULE_VERSION_H)
 
 # Non-Kbuild part
 else

--- a/lisa/_assets/kmodules/lisa/main.c
+++ b/lisa/_assets/kmodules/lisa/main.c
@@ -3,6 +3,7 @@
 
 #include "main.h"
 #include "features.h"
+
 /* Import all the symbol namespaces that appear to be defined in the kernel
  * sources so that we won't trigger any warning
  */

--- a/lisa/_assets/kmodules/lisa/main.c
+++ b/lisa/_assets/kmodules/lisa/main.c
@@ -29,7 +29,7 @@ static int __init modinit(void) {
 	pr_info("Loading Lisa module version %s\n", LISA_MODULE_VERSION);
 	if (strcmp(version, LISA_MODULE_VERSION)) {
 		pr_err("Lisa module version check failed. Got %s, expected %s\n", version, LISA_MODULE_VERSION);
-		return -EINVAL;
+		return -EPROTO;
 	}
 
 	ret = init_features(features, features_len);

--- a/lisa/_assets/kmodules/lisa/pixel6.c
+++ b/lisa/_assets/kmodules/lisa/pixel6.c
@@ -4,6 +4,10 @@
 #include <linux/fs.h>
 #include <linux/types.h>
 
+#ifdef _IN_TREE_BUILD
+#include <kernel/sched/sched.h>
+#endif
+
 #include "main.h"
 #include "features.h"
 #include "wq.h"

--- a/lisa/_assets/kmodules/lisa/pixel6.c
+++ b/lisa/_assets/kmodules/lisa/pixel6.c
@@ -5,6 +5,7 @@
 #include <linux/types.h>
 
 #ifdef _IN_TREE_BUILD
+#include <linux/sched/cputime.h>
 #include <kernel/sched/sched.h>
 #endif
 

--- a/lisa/_assets/kmodules/lisa/sched_helpers.h
+++ b/lisa/_assets/kmodules/lisa/sched_helpers.h
@@ -7,8 +7,11 @@
 
 #include <linux/cgroup.h>
 
-/* private kernel headers are missing, redefine some functions */
-#ifndef cap_scale
+#ifdef _IN_TREE_BUILD
+
+#include <kernel/sched/autogroup.h>
+
+#else
 
 #include "vmlinux.h"
 
@@ -79,7 +82,7 @@ unsigned long uclamp_rq_util_with(struct rq *rq, unsigned long util,
 #endif
 }
 
-#endif /* cap_scale */
+#endif /* _IN_TREE_BUILD */
 
 static inline void cfs_rq_tg_path(struct cfs_rq *cfs_rq, char *path, int len)
 {

--- a/lisa/_assets/kmodules/lisa/tp.c
+++ b/lisa/_assets/kmodules/lisa/tp.c
@@ -1,6 +1,10 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 #include <linux/slab.h>
+#ifndef _IN_TREE_BUILD
 #include <linux/sched.h>
+#else
+#include <kernel/sched/sched.h>
+#endif
 #include <trace/events/sched.h>
 
 #define CREATE_TRACE_POINTS

--- a/lisa/_assets/kmodules/lisa/tp.c
+++ b/lisa/_assets/kmodules/lisa/tp.c
@@ -1,8 +1,10 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 #include <linux/slab.h>
+
 #ifndef _IN_TREE_BUILD
 #include <linux/sched.h>
 #else
+#include <linux/sched/cputime.h>
 #include <kernel/sched/sched.h>
 #endif
 #include <trace/events/sched.h>

--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -1708,17 +1708,35 @@ class KmodSrc(Loggable):
             if name.endswith('.c')
         }
 
+    def _checksum(self, sources_only=False):
+        m = hashlib.sha1()
+        sources = {
+            name: content
+            for name, content
+            in self.src.items()
+            if '.' in name
+        } if sources_only else self.src
+        for name, content in sorted(sources.items()):
+            if not sources_only:
+                m.update(name.encode('utf-8'))
+            m.update(content)
+        return m.hexdigest()
+
     @property
     @memoized
     def checksum(self):
         """
+        Checksum of the module's sources & Makefile.
+        """
+        return self._checksum(sources_only=False)
+
+    @property
+    @memoized
+    def checksum_sources(self):
+        """
         Checksum of the module's sources.
         """
-        m = hashlib.sha256()
-        for name, content in sorted(self.src.items()):
-            m.update(name.encode('utf-8'))
-            m.update(content)
-        return m.hexdigest()
+        return self._checksum(sources_only=True)
 
     @property
     @memoized

--- a/tools/kmodules/lisa-in-tree/android/0002-arm-vh-Include-Lisa-module-in-the-vendor-modules.patch
+++ b/tools/kmodules/lisa-in-tree/android/0002-arm-vh-Include-Lisa-module-in-the-vendor-modules.patch
@@ -1,0 +1,38 @@
+From ef77f0e015f41cf5b53e9d6089044b8a260e4831 Mon Sep 17 00:00:00 2001
+From: Kajetan Puchalski <kajetan.puchalski@arm.com>
+Date: Tue, 27 Jun 2023 14:07:42 +0000
+Subject: [PATCH] arm: vh: Include Lisa module in the vendor modules
+
+Include lisa.ko (the Lisa tracing module) in the list of
+vendor modules included in the kernel so that it is copied
+to dist and loaded at boot time automatically alongside all
+the other vendor modules on Pixel 6.
+---
+ BUILD.bazel               | 1 +
+ vendor_boot_modules.gs101 | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 2c6b1564d390..5a3070bb5653 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -210,6 +210,7 @@ kernel_build(
+         "zcomp_eh.ko",
+         "zram.ko",
+         "zsmalloc.ko",
++        "lisa.ko",
+     ],
+     deps = [
+         "//prebuilts/misc/linux-x86/libufdt:mkdtimg",
+diff --git a/vendor_boot_modules.gs101 b/vendor_boot_modules.gs101
+index 4d913d9d4788..79447f2d5de0 100644
+--- a/vendor_boot_modules.gs101
++++ b/vendor_boot_modules.gs101
+@@ -209,3 +209,4 @@ zcomp_cpu.ko
+ zcomp_eh.ko
+ zram.ko
+ zsmalloc.ko
++lisa.ko
+-- 
+2.34.1
+

--- a/tools/kmodules/lisa-in-tree/android/abi/0001-abi-Allow-GKI-restricted-symbols.patch
+++ b/tools/kmodules/lisa-in-tree/android/abi/0001-abi-Allow-GKI-restricted-symbols.patch
@@ -1,0 +1,29 @@
+From 7b6f4db61675012148ce872b1e86bbe0806e57ba Mon Sep 17 00:00:00 2001
+From: Kajetan Puchalski <kajetan.puchalski@arm.com>
+Date: Mon, 31 Jul 2023 11:18:50 +0000
+Subject: [PATCH] abi: Allow GKI restricted symbols
+
+---
+ abi/symbols.deny | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/abi/symbols.deny b/abi/symbols.deny
+index fd643b7..b15771c 100644
+--- a/abi/symbols.deny
++++ b/abi/symbols.deny
+@@ -17,9 +17,9 @@
+ # File access symbols that are forbidden because drivers should never
+ # try to access files directly.  Instead proper user/kernel apis should
+ # always be used.
+-filp_open	Drivers should not open files directly
+-kernel_read	Drivers should never read from a file
+-kernel_write	Drivers should never write to a file
++# filp_open	Drivers should not open files directly
++# kernel_read	Drivers should never read from a file
++# kernel_write	Drivers should never write to a file
+ 
+ # Kprobe needs to be left alone
+ disable_kprobe		kprobe should not be touched by any driver
+-- 
+2.34.1
+

--- a/tools/kmodules/lisa-in-tree/fetch_lisa_module.py
+++ b/tools/kmodules/lisa-in-tree/fetch_lisa_module.py
@@ -1,0 +1,74 @@
+#! /usr/bin/env python3
+
+import shutil
+import argparse
+import subprocess
+
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="""
+    Fetch the Lisa module from GitHub or a local copy and integrate it
+    inside the kernel tree.
+
+    Method 1 - using LISA_HOME.
+
+    If the script finds the LISA_HOME environment variable (present after sourcing the Lisa shell)
+    it will symlink the Lisa module sources from the local Lisa git checkout into the kernel tree.
+    That way updating the local Lisa tree will automatically update the module sources in the kernel
+    tree and the changes will be present after the next kernel rebuild.
+    In this case, the script only needs to be run once.
+
+    Method 2 - Sparse checkout.
+
+    If the script doesn't find LISA_HOME (e.g. building on an external server without a Lisa checkout)
+    the alternative mode is to directly clone the module sources into the tree.
+                                     """)
+    parser.add_argument('-g', '--git-ref', help='Lisa git reference to checkout')
+    parser.add_argument('-f', '--force', action='store_true', help='Override the module checkout if it already exists')
+    parser.add_argument('--module-kernel-path',
+                        help='Path relative to the kernel tree root where the module will be stored')
+    parser.add_argument('--git-remote', help='Git remote to pull the module from',
+                        default='git@github.com:ARM-software/lisa.git')
+    args = parser.parse_args()
+
+    module_kernel_path = Path(args.module_kernel_path).resolve()
+
+    # --git-ref passed, clone the sparse checkout
+    if args.git_ref:
+        module_git_path = module_kernel_path.parent / f"{module_kernel_path.name}-git"
+
+        # module has already been cloned
+        if module_git_path.exists():
+            if not args.force:
+                parser.error('Module checkout already exists, pass --force to override')
+            shutil.rmtree(module_git_path)
+            module_kernel_path.unlink()
+
+        clone_cmd = [
+            'git', 'clone', '--verbose', '--no-checkout', '--no-tags', '--filter=tree:0',
+            args.git_remote, module_git_path
+        ]
+        subprocess.check_call(clone_cmd)
+        subprocess.check_call(['git', '-C', module_git_path,
+                               'sparse-checkout', 'set', 'lisa/_assets/kmodules/'])
+        subprocess.check_call(['git', '-C', module_git_path, 'checkout', args.git_ref])
+
+        module_src_kernel_git_path = module_git_path / 'lisa/_assets/kmodules/lisa'
+        module_kernel_path.symlink_to(
+            module_src_kernel_git_path.relative_to(module_kernel_path.parent)
+        )
+        return
+
+    # --git-ref not passed, try linking from LISA_HOME
+    try:
+        import lisa._assets.kmodules.lisa as kmod_mod
+    except ImportError:
+        parser.error('Either lisa Python package needs to be importable or --git-ref needs to be used')
+    else:
+        module_src_lisa_path = Path(kmod_mod.__path__[0]).resolve()
+        module_kernel_path.symlink_to(module_src_lisa_path)
+
+
+main()

--- a/tools/kmodules/lisa-in-tree/linux/0001-arm-vh-Include-Lisa-module-stub.patch
+++ b/tools/kmodules/lisa-in-tree/linux/0001-arm-vh-Include-Lisa-module-stub.patch
@@ -1,0 +1,56 @@
+From 4251bcc1e0641992e3a99f19c654245d2b6aff87 Mon Sep 17 00:00:00 2001
+From: Kajetan Puchalski <kajetan.puchalski@arm.com>
+Date: Tue, 27 Jun 2023 14:05:40 +0000
+Subject: [PATCH] arm: vh: Include Lisa module stub
+
+Include the directory structure and necessary makefile changes
+for a stub Lisa module to be built in-tree as part of the kernel.
+For the module to work this commit requires fetching the actual
+sources from GitHub either manually or using a script.
+
+Signed-off-by: Kajetan Puchalski <kajetan.puchalski@arm.com>
+---
+ drivers/soc/Makefile                 | 1 +
+ drivers/soc/arm/Makefile             | 1 +
+ drivers/soc/arm/vh/kernel/.gitignore | 2 ++
+ drivers/soc/arm/vh/kernel/Makefile   | 2 ++
+ 4 files changed, 6 insertions(+)
+ create mode 100644 drivers/soc/arm/Makefile
+ create mode 100644 drivers/soc/arm/vh/kernel/.gitignore
+ create mode 100644 drivers/soc/arm/vh/kernel/Makefile
+
+diff --git a/drivers/soc/Makefile b/drivers/soc/Makefile
+index 71ef89c79ea7..af7be45a2776 100644
+--- a/drivers/soc/Makefile
++++ b/drivers/soc/Makefile
+@@ -30,3 +30,4 @@ obj-$(CONFIG_PLAT_VERSATILE)	+= versatile/
+ obj-y				+= xilinx/
+ obj-$(CONFIG_ARCH_ZX)		+= zte/
+ obj-$(CONFIG_SOC_KENDRYTE)	+= kendryte/
++obj-y += arm/
+diff --git a/drivers/soc/arm/Makefile b/drivers/soc/arm/Makefile
+new file mode 100644
+index 000000000000..022ec9498e15
+--- /dev/null
++++ b/drivers/soc/arm/Makefile
+@@ -0,0 +1 @@
++obj-y += vh/kernel/
+diff --git a/drivers/soc/arm/vh/kernel/.gitignore b/drivers/soc/arm/vh/kernel/.gitignore
+new file mode 100644
+index 000000000000..1a7fe6a32c57
+--- /dev/null
++++ b/drivers/soc/arm/vh/kernel/.gitignore
+@@ -0,0 +1,2 @@
++lisa-module-git/
++lisa
+diff --git a/drivers/soc/arm/vh/kernel/Makefile b/drivers/soc/arm/vh/kernel/Makefile
+new file mode 100644
+index 000000000000..742b33b05dc4
+--- /dev/null
++++ b/drivers/soc/arm/vh/kernel/Makefile
+@@ -0,0 +1,2 @@
++# ARM Lisa module
++obj-y += lisa/
+-- 
+2.34.1
+


### PR DESCRIPTION
FEATURE

Modify the Makefile for the lisa module to distinguish between in-tree and out-of-tree building. Adjust the imports and definitions in the source files accordingly.

With this change, the module can now be copy-pasted into a kernel tree and built with kbuild like any other kernel module. The default, out-of-tree build method with Lisa should work unchanged as before.