### PR TITLE
doc: re-enable Sphinx nitpicky mode

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,8 @@ version: 2
 sphinx:
   builder: html
   configuration: doc/conf.py
-  # intersphinx is broken for some dependencies like devlib
+  # Deploy and build the doc no matter what, we are supposed to catch warnings
+  # in other CIs.
   fail_on_warning: false
 
 
@@ -17,9 +18,9 @@ sphinx:
 formats: []
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
   apt_packages:
     - graphviz
     - plantuml

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -430,6 +430,12 @@ ignored_refs = {
     # that cannot be fixed because of Sphinx limitations and external
     # constraints on names.
     r'ITEM_CLS',
+
+    # Python <= 3.8 has a formatting issue in typing.Union[..., None] that
+    # makes it appear as typing.Union[..., NoneType], leading to a broken
+    # reference since the intersphinx inventory of the stdlib does not provide
+    # any link for NoneType.
+    r'NoneType',
 }
 ignored_refs.update(
     re.escape(f'{x.__module__}.{x.__qualname__}')

--- a/lisa/notebook.py
+++ b/lisa/notebook.py
@@ -395,7 +395,7 @@ def plot_signal(series, name=None, interpolation=None, add_markers=True, vdim=No
     :type add_markers: bool
 
     :param vdim: Value axis dimension.
-    :type vdim: holoviews.Dimension
+    :type vdim: holoviews.core.dimension.Dimension
     """
     if isinstance(series, pd.DataFrame):
         try:

--- a/lisa/stats.py
+++ b/lisa/stats.py
@@ -211,7 +211,7 @@ class Stats(Loggable):
     :param stats: Dictionnary of statistical functions to summarize each value
         group formed by tag columns along the aggregation columns. If ``None``
         is given as value, the name will be passed to
-        :meth:`pandas.core.groupby.GroupBy.agg`. Otherwise, the provided
+        :meth:`pandas.core.groupby.SeriesGroupBy.agg`. Otherwise, the provided
         function will be run.
 
         .. note:: One set of keys is special: ``'mean'``, ``'std'`` and

--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -3935,7 +3935,7 @@ class LazyMapping(Mapping):
 
 def mp_spawn_pool(import_main=False, **kwargs):
     """
-    Create a context manager wrapping :class:`multiprocessing.Pool` using the
+    Create a context manager wrapping :class:`multiprocessing.pool.Pool` using the
     ``spawn`` method, which is safe even in multithreaded applications.
 
     :param import_main: If ``True``, let the spawned process import the
@@ -3944,7 +3944,7 @@ def mp_spawn_pool(import_main=False, **kwargs):
         *lot* of time (actually, unbounded amount of time).
     :type import_main: bool
 
-    :Variable keyword arguments: Forwarded to :meth:`multiprocessing.Pool`.
+    :Variable keyword arguments: Forwarded to :class:`multiprocessing.pool.Pool`.
     """
     ctx = multiprocessing.get_context(method='spawn')
     empty_main = nullcontext if import_main else _empty_main

--- a/lisa/wa.py
+++ b/lisa/wa.py
@@ -284,7 +284,7 @@ class WAOutput(StatsProp, Mapping, Loggable):
     def outputs(self):
         """
         Dict containing a mapping of 'wa run' names to
-        :class:`wa.framework.RunOutput` objects.
+        :class:`RunOutput` objects.
         """
         wa_outputs = list(discover_wa_outputs(self.path))
 

--- a/tools/lisa-doc-build
+++ b/tools/lisa-doc-build
@@ -24,7 +24,7 @@ cd "$LISA_HOME/doc" || exit 1
 # Build the main documentation
 ##############################
 
-make SPHINXOPTS='-n --no-color --keep-going -T -j auto' html || ret=1
+make SPHINXOPTS='-n --no-color -W --keep-going -T -j auto' html || ret=1
 
 echo
 echo "Building man pages"


### PR DESCRIPTION
FIX

Sphinx nitpicky mode is required to detect broken references, so re-enable it and fix the currently broken refs and warnings.