### PR TITLE
tools/lisa-build-asset: Avoid emptying --build-dir

### DIFF
--- a/tools/lisa-build-asset
+++ b/tools/lisa-build-asset
@@ -49,7 +49,7 @@ def get_env(asset=None, arch=None, build_dir=None, toolchain=None, recipe=None, 
         'LISA_ASSET': asset,
         'LISA_ASSET_RECIPE': recipe,
         'LISA_ARCH_ASSETS': os.path.join(LISA_HOME, 'lisa', '_assets', 'binaries', arch),
-        'BUILD_DIR': os.path.abspath(build_dir),
+        'BUILD_DIR': os.path.abspath(build_dir) if build_dir is not None else None,
         'CROSS_COMPILE': toolchain + '-' if toolchain else None,
         'CONFIGURE_HOST': os.path.basename(toolchain) if toolchain else None,
         'USE_MUSL_LIB': '1' if use_musl else None,
@@ -227,8 +227,10 @@ def make(asset, arch, actions, build_dir, recipe_dir, toolchain=None, arch_chroo
 
 def make_asset(asset, arch_list, build_dir, recipe_dir, toolchains=None, native_build=False):
     if build_dir:
-        shutil.rmtree(build_dir, ignore_errors=True)
-        os.makedirs(build_dir, exist_ok=True)
+        # We do not want to empty an existing directory, as it might contain
+        # bind mounts and deleting that recursively may end up deleting e.g.
+        # LISA_HOME.
+        os.makedirs(build_dir, exist_ok=False)
         cm = nullcontext(build_dir)
     else:
         cm = tempfile.TemporaryDirectory()

--- a/tools/lisa-build-asset
+++ b/tools/lisa-build-asset
@@ -156,31 +156,35 @@ def make_chroot(asset, arch, build_dir, recipe_dir, arch_chroot_dir):
     # List the required env variables.
     env_args = ('-k', ' '.join(env.keys())) if env else []
 
-    # Install the chroot.
-    subprocess.check_call(
-        [
-            'sudo', os.path.join(get_alpine_dir(), 'alpine-chroot-install'),
-            '-b', alpine_version,
-            '-d', arch_chroot_dir,
-            '-i', LISA_HOME,
-            '-a', QEMU_ARCH_NAMES.get(arch, arch),
-            *alpine_dependencies,
-            *env_args,
-        ],
-        cwd=build_dir,
-    )
+    def setup():
+        # Install the chroot.
+        subprocess.check_call(
+            [
+                'sudo', os.path.join(get_alpine_dir(), 'alpine-chroot-install'),
+                '-b', alpine_version,
+                '-d', arch_chroot_dir,
+                '-i', LISA_HOME,
+                '-a', QEMU_ARCH_NAMES.get(arch, arch),
+                *alpine_dependencies,
+                *env_args,
+            ],
+            cwd=build_dir,
+        )
 
-    def bind_mount(path):
-        # join() will ignore everything before an absolute path so make it
-        # relative first
-        rel = os.path.relpath(path, start='/')
-        path_ = os.path.join(arch_chroot_dir, rel)
-        subprocess.check_call(['sudo', 'mkdir', '-p', path_])
-        subprocess.check_call(['sudo', 'mount', '--bind', path, path_])
+        def bind_mount(path):
+            # join() will ignore everything before an absolute path so make it
+            # relative first
+            rel = os.path.relpath(path, start='/')
+            path_ = os.path.join(arch_chroot_dir, rel)
+            subprocess.check_call(['sudo', 'mkdir', '-p', path_])
+            subprocess.check_call(['sudo', 'mount', '--bind', path, path_])
 
-    bind_mount(build_dir)
+        bind_mount(build_dir)
 
     try:
+        # If setup fails, we still destroy the chroot so we give a chance to
+        # cleanup bind mounts.
+        setup()
         yield arch_chroot_dir
     finally:
         # Clean-up the chroot


### PR DESCRIPTION
FIX

--build-dir folder was emptied before being used. In case of previous build failure, we might still have bind mounts that we absolutely not want to remove recursively as it might empty e.g. LISA_HOME