### PR TITLE
lisa.wa: Fix WATraceCollector.traces

### DIFF
--- a/lisa/wa.py
+++ b/lisa/wa.py
@@ -651,7 +651,7 @@ class WATraceCollector(WAArtifactCollectorBase):
         to their corresponding :class:`lisa.trace.Trace`.
         """
         return LazyMapping({
-            f"{job.label}-{job.iteration}": lru_cache()(lambda k: Trace(job.get_artifact_path('trace-cmd-bin'), **self._trace_kwargs))
+            f"{job.label}-{job.iteration}": lru_cache()(lambda k, job=job: Trace(job.get_artifact_path('trace-cmd-bin'), **self._trace_kwargs))
             for job in self.wa_output.jobs
         })
 


### PR DESCRIPTION
FIX

WATraceCollector.traces property creates all Trace instances with the same path, which is the path of the trace of the last job.

Fix that by ensuring each Trace is created from the trace path associated with its job.