### PR TITLE
tools/lisa-buildroot-create-rootfs: Update buildroot version

### DIFF
--- a/tools/lisa-buildroot-create-rootfs
+++ b/tools/lisa-buildroot-create-rootfs
@@ -19,7 +19,7 @@
 set -eu
 
 BUILDROOT_URI=git://git.busybox.net/buildroot
-BUILDROOT_VERSION=2020.02.6
+BUILDROOT_VERSION=2023.02.3
 BUILDROOT_DIR=$LISA_HOME/src/buildroot
 BUILDROOT_CONFIG=$(dirname "$0")/buildroot_config
 


### PR DESCRIPTION
Update from 2020.02.6 to 2023.02.3