### PR TITLE
lisa.utils: Read LISA_CACHE_HOME env var

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -90,17 +90,24 @@ The detected location of your LISA installation
 """
 
 def _get_xdg_home(directory):
+    dir_upper = directory.upper()
+
     try:
-        base = os.environ['LISA_HOME']
+        base = os.environ[f'LISA_{dir_upper}_HOME']
     except KeyError:
         try:
-            base = os.environ[f'XDG_{directory.upper()}_HOME']
+            base = os.environ['LISA_HOME']
         except KeyError:
-            xdg_home = os.path.join(os.environ['HOME'], '.lisa', directory, VERSION_TOKEN)
+            try:
+                base = os.environ[f'XDG_{dir_upper}_HOME']
+            except KeyError:
+                xdg_home = os.path.join(os.environ['HOME'], '.lisa', directory, VERSION_TOKEN)
+            else:
+                xdg_home = os.path.join(base, 'lisa', VERSION_TOKEN)
         else:
-            xdg_home = os.path.join(base, 'lisa', VERSION_TOKEN)
+            xdg_home = os.path.join(base, directory, VERSION_TOKEN)
     else:
-        xdg_home = os.path.join(base, directory, VERSION_TOKEN)
+        xdg_home = os.path.join(base, VERSION_TOKEN)
 
     os.makedirs(xdg_home, exist_ok=True)
     return xdg_home


### PR DESCRIPTION
FEATURE

lisa's cache folder is found based on LISA_HOME and then XDG_CACHE_HOME as a fallback.

Add an extra level where LISA_CACHE_HOME will be checked first, allowing the user to override the folder used for cache.