### PR TITLE
lisa.target: Fix adb-over-ip connection

### DIFF
--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -1146,6 +1146,8 @@ class _KernelBuildEnv(Loggable, SerializeViaConstructor):
                         toolchain = 'aarch64-linux-gnu-'
                     elif abi == 'armeabi':
                         toolchain = 'arm-linux-gnueabi-'
+                    elif abi == 'x86':
+                        toolchain = 'i686-linux-gnu-'
                     else:
                         raise KeyError(f'ABI {abi} not recognized, CROSS_COMPILE env var needs to be set')
 

--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -1149,7 +1149,8 @@ class _KernelBuildEnv(Loggable, SerializeViaConstructor):
                     elif abi == 'x86':
                         toolchain = 'i686-linux-gnu-'
                     else:
-                        raise KeyError(f'ABI {abi} not recognized, CROSS_COMPILE env var needs to be set')
+                        toolchain = None
+                        logger.error(f'ABI {abi} not recognized, CROSS_COMPILE env var needs to be set')
 
                     logger.debug(f'CROSS_COMPILE env var not set, assuming "{toolchain}"')
 


### PR DESCRIPTION
FIX

Pass approriate parameters to devlib to connect to an adb server over IP instead of trying to build a device string ourselves (which probably worked in the past but not in recent adb versions).