### PR TITLE
lisa._kmod: Use rmmod -f if rmmod failed

### DIFF
--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -2133,7 +2133,13 @@ class DynamicKmod(Loggable):
         """
         Unload the module from the target.
         """
-        self.target.execute(f'rmmod {quote(self.src.mod_name)}')
+        mod = quote(self.src.mod_name)
+        execute = self.target.execute
+
+        try:
+            execute(f'rmmod {mod}')
+        except TargetStableError:
+            execute(f'rmmod -f {mod}')
 
     @destroyablecontextmanager
     def run(self, **kwargs):


### PR DESCRIPTION
FEATURE

If rmmod failed, try -f. This is currently necessary as failure to initialize some features will make the module init return a non-zero exit code. This unfortunately requires an rmmod -f to unload.