### PR TITLE
tools/kmodules/lisa-in-tree: Adjust defaults and documentation

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -398,6 +398,10 @@ In order to do that, follow the steps below:
   and follow the instructions in ``--help`` to link or fetch the Lisa module sources into
   the source tree.
 
+.. code-block:: sh
+
+   ./fetch_lisa_module.py --module-kernel-path ./private/gs-google/drivers/soc/arm/vh/kernel/lisa --git-ref main
+
 With all these steps complete, rebuild the kernel:
 
 .. code-block:: sh

--- a/tools/kmodules/lisa-in-tree/fetch_lisa_module.py
+++ b/tools/kmodules/lisa-in-tree/fetch_lisa_module.py
@@ -30,7 +30,7 @@ def main():
     parser.add_argument('--module-kernel-path',
                         help='Path relative to the kernel tree root where the module will be stored')
     parser.add_argument('--git-remote', help='Git remote to pull the module from',
-                        default='git@github.com:ARM-software/lisa.git')
+                        default='https://github.com/ARM-software/lisa.git')
     args = parser.parse_args()
 
     module_kernel_path = Path(args.module_kernel_path).resolve()

--- a/tools/kmodules/lisa-in-tree/linux/0001-arm-vh-Include-Lisa-module-stub.patch
+++ b/tools/kmodules/lisa-in-tree/linux/0001-arm-vh-Include-Lisa-module-stub.patch
@@ -1,4 +1,4 @@
-From 4251bcc1e0641992e3a99f19c654245d2b6aff87 Mon Sep 17 00:00:00 2001
+From 7e0578ee83ca6a840f82303f5f58a7b7ced68320 Mon Sep 17 00:00:00 2001
 From: Kajetan Puchalski <kajetan.puchalski@arm.com>
 Date: Tue, 27 Jun 2023 14:05:40 +0000
 Subject: [PATCH] arm: vh: Include Lisa module stub
@@ -37,11 +37,11 @@ index 000000000000..022ec9498e15
 +obj-y += vh/kernel/
 diff --git a/drivers/soc/arm/vh/kernel/.gitignore b/drivers/soc/arm/vh/kernel/.gitignore
 new file mode 100644
-index 000000000000..1a7fe6a32c57
+index 000000000000..824ab08cfc04
 --- /dev/null
 +++ b/drivers/soc/arm/vh/kernel/.gitignore
 @@ -0,0 +1,2 @@
-+lisa-module-git/
++lisa-git/
 +lisa
 diff --git a/drivers/soc/arm/vh/kernel/Makefile b/drivers/soc/arm/vh/kernel/Makefile
 new file mode 100644


### PR DESCRIPTION
1. Add a usage example to the section in doc/setup.rst

Because we removed the default value for --module-kernel-path, it may not be clear to the user what the argument should actually look like. Add a usage example in the documentation to account for that.

2. Change the default remote from ssh to https

Defaulting to accessing the GitHub repo over ssh is prone to failing if ssh is not set up on the machine. Https does not have that issue and so is probably a more reasonable default.

3. Fix an omission in the kernel stub patch

The kernel stub patch still had `lisa-module-git` in the gitignore where it should be `lisa-git`.