### PR TITLE
[docs/setup] Fix order of commands when installing LISA from github

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -77,9 +77,10 @@ need.
 .. code:: shell
 
     git clone https://github.com/ARM-software/lisa.git
+    # Jump into the cloned repo directory
+    cd lisa
     # This will provide a more accurate changelog when building the doc
     git fetch origin refs/notes/changelog
-    cd lisa
     # A few packages need to be installed, like python3 or kernelshark. Python
     # modules will be installed in a venv at the next step, without touching
     # any system-wide install location.


### PR DESCRIPTION
The current order runs a git fetch prior to moving into the repository directory. Fix this by changing the order of commands.