### PR TITLE
lisa/_assets/kmodules/lisa: Include in-tree headers in sched_helpers.h

### DIFF
--- a/lisa/_assets/kmodules/lisa/pixel6.c
+++ b/lisa/_assets/kmodules/lisa/pixel6.c
@@ -4,11 +4,6 @@
 #include <linux/fs.h>
 #include <linux/types.h>
 
-#ifdef _IN_TREE_BUILD
-#include <linux/sched/cputime.h>
-#include <kernel/sched/sched.h>
-#endif
-
 #include "main.h"
 #include "features.h"
 #include "wq.h"

--- a/lisa/_assets/kmodules/lisa/sched_helpers.h
+++ b/lisa/_assets/kmodules/lisa/sched_helpers.h
@@ -9,6 +9,8 @@
 
 #ifdef _IN_TREE_BUILD
 
+#include <linux/sched/cputime.h>
+#include <kernel/sched/sched.h>
 #include <kernel/sched/autogroup.h>
 
 #else


### PR DESCRIPTION
Fold including internal kernel headers required for the in-tree build into sched_helpers.h. This way including sched_helpers.h will work on its own in both workflows instead of requiring duplicated defines wherever it is used.