### PR TITLE
install_base.sh: follow symlink when trying determining JAVA_HOME

### DIFF
--- a/install_base.sh
+++ b/install_base.sh
@@ -85,7 +85,7 @@ install_android_sdk_manager() {
 # according to the distribution
 ANDROID_SDK_JAVA_VERSION=17
 find_java_home() {
-    _JAVA_BIN=$(find /usr/lib/jvm -path "*$ANDROID_SDK_JAVA_VERSION*/bin/java" -not -path '*/jre/bin/*' -print -quit)
+    _JAVA_BIN=$(find -L /usr/lib/jvm -path "*$ANDROID_SDK_JAVA_VERSION*/bin/java" -not -path '*/jre/bin/*' -print -quit)
     _JAVA_HOME=$(dirname "$_JAVA_BIN")/../
 
     echo "Found JAVA_HOME=$_JAVA_HOME"


### PR DESCRIPTION
FIX

On some distributions /usr/lib/jvm will only contain symlinks that points outside that directory, therefore we must make sure to follow the symlinks.