### PR TITLE
.github/workflows/test.yml: Use Ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,8 @@ jobs:
       matrix:
         os:
           #- ubuntu-18.04
-          - ubuntu-20.04
+          # Use ubuntu 22.04 as it solved the firefox-geckodriver package mess compared to 20.04
+          - ubuntu-22.04
         python-version:
           # Github seems to always block 3 jobs these days, so keep at most 3
           # versions there:


### PR DESCRIPTION
The packaging situation of firefox-geckodriver on Ubuntu 20.04 is a mess and leads to broken packages:

  The following packages have unmet dependencies:
   firefox-geckodriver : Depends: firefox (= 116.0.2+build1-0ubuntu0.20.04.1) but 116.0.3+build1-0ubuntu0.20.04.1~mt1 is to be installed
  E: Unable to correct problems, you have held broken packages.

Therefore, use Ubuntu 22.04 where the firefox package includes the selenium driver so no more version mismatch.