### PR TITLE
.github/workflows/test.yml: Do not run tests on push events beyond main

### DIFF
--- a/.github/workflows/autobranch.yml
+++ b/.github/workflows/autobranch.yml
@@ -10,8 +10,7 @@ on:
 
   # Run the workflow when the base branch is updated.
   #
-  # Note that a push from a workflow will by default not trigger a push event,
-  # so we list both branches here as "main" only would currently do nothing:
+  # Note that a push from a workflow will by default not trigger a push event:
   # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,13 @@ on:
           required: false
           default: 'main'
 
-  # If someone pushes something to a branch on the repo directly. It is useful
-  # to test new github actions
-  push: null
+  # Run the tests when anything is merged in "main", since the test in the PR
+  # might have been carried on an older base. Github allows merging as long as
+  # the PR can be rebased without conflict, which does not guarantee in itself
+  # nothing is broken.
+  push:
+    branches:
+      - 'main'
 
 jobs:
   # Set the job key. The key is displayed as the job name


### PR DESCRIPTION
It is useful to run the tests when the main branch is updated, but not in other circumstances.