### PR TITLE
lisa._assets.kmodules.lisa: Shield against missing arch_freq_scale

### DIFF
--- a/lisa/_assets/kmodules/lisa/Makefile
+++ b/lisa/_assets/kmodules/lisa/Makefile
@@ -77,8 +77,11 @@ ccflags-y := "-I$(MODULE_SRC)" -std=gnu11 -fno-stack-protector -Wno-declaration-
 # file regardless of the kernel config.
 CFLAGS_introspection_data.o := -g3 -gno-split-dwarf -gdwarf -fno-eliminate-unused-debug-types
 
-FEATURES_LDS := features.lds
 GENERATED := $(MODULE_OBJ)/generated
+FEATURES_LDS := $(MODULE_SRC)/features.lds
+SYMBOLS_LDS := $(GENERATED)/symbols.lds
+
+clean-files := $(GENERATED)
 
 $(GENERATED):
 	mkdir -p "$@"
@@ -87,21 +90,15 @@ SYMBOL_NAMESPACES_H := $(GENERATED)/symbol_namespaces.h
 MODULE_VERSION_H := $(GENERATED)/module_version.h
 KALLSYMS := $(GENERATED)/kallsyms
 
-# in-tree build
+ldflags-y += -T $(FEATURES_LDS)
+
 ifeq ($(IN_TREE_BUILD),1)
-
 ccflags-y += -I$(srctree) -D_IN_TREE_BUILD
-ldflags-y += -T $(srctree)/$(obj)/$(FEATURES_LDS)
-
-# out-of-tree build
 else
+ldflags-y += -T $(SYMBOLS_LDS)
+endif
 
 INTROSPECTION_DATA_H := $(GENERATED)/introspection_data.h
-
-ldflags-y += -T $(M)/$(FEATURES_LDS)
-
-clean-files := $(GENERATED)
-
 PRIVATE_TYPES_TXT := $(MODULE_SRC)/private_types.txt
 
 # Can be either a kernel image built with DWARF debug info, or the BTF blob
@@ -171,8 +168,8 @@ $(INTROSPECTION_DATA_H): $(GENERATED) $(KALLSYMS) $(PRIVATE_TYPES_TXT) $(VMLINUX
 	cat $(MODULE_OBJ)/_introspection_header $(MODULE_OBJ)/_renamed_header >> $@
 # cat $@
 
-# out-of-tree build
-endif
+$(SYMBOLS_LDS): $(GENERATED) $(KALLSYMS) $(VENV)
+	. $(VENV)/bin/activate && python3 $(MODULE_SRC)/introspect_header.py --kallsyms $(KALLSYMS) --symbols-lds >> $@
 
 # Some kernels require the use of MODULE_IMPORT_NS() before using symbols that are part of the given namespace:
 # https://docs.kernel.org/core-api/symbol-namespaces.html
@@ -200,7 +197,7 @@ $(KALLSYMS): $(GENERATED)
 
 
 # Make all object files depend on the generated sources
-$(addprefix $(MODULE_OBJ)/,$($(LISA_KMOD_NAME)-y)): $(INTROSPECTION_DATA_H) $(SYMBOL_NAMESPACES_H) $(MODULE_VERSION_H)
+$(addprefix $(MODULE_OBJ)/,$($(LISA_KMOD_NAME)-y)): $(INTROSPECTION_DATA_H) $(SYMBOL_NAMESPACES_H) $(MODULE_VERSION_H) $(SYMBOLS_LDS)
 
 # Non-Kbuild part
 else

--- a/lisa/_assets/kmodules/lisa/ftrace_events.h
+++ b/lisa/_assets/kmodules/lisa/ftrace_events.h
@@ -373,21 +373,36 @@ TRACE_EVENT(lisa__sched_cpu_capacity,
 		__field(	int,		cpu		)
 		__field(	unsigned long,	capacity	)
 		__field(	unsigned long,	capacity_orig	)
+#if HAS_KERNEL_FEATURE(FREQ_INVARIANCE)
 		__field(	unsigned long,	capacity_curr	)
+#endif
 	),
 
 	unsigned long scale_cpu = rq->cpu_capacity_orig;
+#if HAS_KERNEL_FEATURE(FREQ_INVARIANCE)
 	unsigned long scale_freq = arch_scale_freq_capacity(rq->cpu);
+#endif
 
 	TP_fast_assign(
 		__entry->cpu		= rq->cpu;
 		__entry->capacity	= rq->cpu_capacity;
 		__entry->capacity_orig	= scale_cpu;
+#if HAS_KERNEL_FEATURE(FREQ_INVARIANCE)
 		__entry->capacity_curr	= cap_scale(scale_cpu, scale_freq);
+#endif
 	),
 
-	TP_printk("cpu=%d capacity=%lu capacity_orig=%lu capacity_curr=%lu",
-		  __entry->cpu, __entry->capacity, __entry->capacity_orig, __entry->capacity_curr)
+	TP_printk(
+		"cpu=%d capacity=%lu capacity_orig=%lu"
+#if HAS_KERNEL_FEATURE(FREQ_INVARIANCE)
+		" capacity_curr=%lu"
+#endif
+		  ,
+		  __entry->cpu, __entry->capacity, __entry->capacity_orig
+#if HAS_KERNEL_FEATURE(FREQ_INVARIANCE)
+		  , __entry->capacity_curr
+#endif
+	)
 );
 #endif
 

--- a/lisa/_assets/kmodules/lisa/introspect_header.py
+++ b/lisa/_assets/kmodules/lisa/introspect_header.py
@@ -312,13 +312,22 @@ class SymbolRecord(namedtuple('SymbolRecord', ['name']), Record):
         return f'#define _SYMBOL_EXISTS_{self.name} 1'
 
 
+def is_global_symbol(code):
+    if code in ('u', 'v', 'w'):
+        return True
+    elif code in ('U', ):
+        return False
+    else:
+        return code.isupper()
+
+
 def process_kallsyms(path):
     with open(path, 'r') as f:
         kallsyms = f.read()
 
     def make_record(addr, code, name):
         # Uppercase codes are for STB_GLOBAL symbols, i.e. exported symbols.
-        if code.isupper() and name.isidentifier():
+        if name.isidentifier() and is_global_symbol(code):
             return SymbolRecord(name=name).make_define()
         else:
             return None

--- a/lisa/_assets/kmodules/lisa/introspect_header.py
+++ b/lisa/_assets/kmodules/lisa/introspect_header.py
@@ -35,17 +35,17 @@ from pycparserext.ext_c_generator import GnuCGenerator
 
 class Record(abc.ABC):
     @abc.abstractmethod
-    def make_define(self):
+    def make_entry(self):
         pass
 
 
 class TypeMemberRecord(namedtuple('TypeMemberRecord', ['type_kind', 'type_name', 'member_name']), Record):
-    def make_define(self):
+    def make_entry(self):
         return f'#define _TYPE_HAS_MEMBER_{self.type_kind}_{self.type_name}_LISA_SEPARATOR_{self.member_name} 1'
 
 
 class TypeExistsRecord(namedtuple('TypeExistsRecord', ['type_kind', 'type_name']), Record):
-    def make_define(self):
+    def make_entry(self):
         return f'#define _TYPE_EXISTS_{self.type_kind}_{self.type_name} 1'
 
 
@@ -204,7 +204,7 @@ def introspect_header(ast):
             '#define _TYPE_INTROSPECTION_INFO_AVAILABLE 1',
         ),
         (
-            record.make_define()
+            record.make_entry()
             for record in records
         ),
     )
@@ -308,37 +308,48 @@ def process_header(path, introspect, type_prefix, non_renamed_types):
 
 
 class SymbolRecord(namedtuple('SymbolRecord', ['name']), Record):
-    def make_define(self):
+    def make_entry(self):
         return f'#define _SYMBOL_EXISTS_{self.name} 1'
 
 
-def is_global_symbol(code):
-    if code in ('u', 'v', 'w'):
-        return True
-    elif code in ('U', ):
+class LinkerSymbolRecord(namedtuple('LinkerSymbolRecord', ['name', 'addr']), Record):
+    def make_entry(self):
+        return f'PROVIDE({self.name} = 0x{self.addr});'
+
+
+def is_exported_symbol(code):
+    # Unfortunately, a symbol being STB_GLOBAL does not mean it is exported, so
+    # we just scrap that address of all symbols and make a linker script for
+    # the module.
+    if code in ('U', ):
         return False
+    elif code in ('u', 'v', 'w'):
+        return True
     else:
-        return code.isupper()
+        # Since we parse kallsyms, we have access to symbols even if they were
+        # not global in the first place, so if we see it we can use it.
+        return True or code.isupper()
 
-
-def process_kallsyms(path):
+def open_kallsyms(path):
     with open(path, 'r') as f:
-        kallsyms = f.read()
+        yield from (
+            line.split(maxsplit=2)
+            for line in map(str.strip, f)
+            if line
+        )
 
+
+def process_kallsyms_introspection(path):
     def make_record(addr, code, name):
         # Uppercase codes are for STB_GLOBAL symbols, i.e. exported symbols.
-        if name.isidentifier() and is_global_symbol(code):
-            return SymbolRecord(name=name).make_define()
+        if name.isidentifier() and is_exported_symbol(code):
+            return SymbolRecord(name=name).make_entry()
         else:
             return None
 
     records = itertools.starmap(
         make_record,
-        (
-            line.split(maxsplit=2)
-            for line in kallsyms.splitlines()
-            if line
-        )
+        open_kallsyms(path),
     )
     records = set(record for record in records if record)
 
@@ -352,6 +363,21 @@ def process_kallsyms(path):
     # If the file is empty, we assume there is no kallsyms available
     else:
         return []
+
+
+def process_kallsyms_lds(path):
+    def make_record(addr, code, name):
+        if name.isidentifier():
+            return LinkerSymbolRecord(name=name, addr=addr).make_entry()
+        else:
+            return None
+
+    records = itertools.starmap(
+        make_record,
+        open_kallsyms(path),
+    )
+    records = sorted(set(record for record in records if record))
+    return records
 
 
 def process_kernel_features(path):
@@ -411,6 +437,7 @@ def main():
     parser.add_argument('--non-renamed-types', help='File containing list of type names that will not be renamed by --type-prefix')
     parser.add_argument('--kallsyms', help='kallsyms content to parse')
     parser.add_argument('--kernel-features', help='JSON list of kernel features')
+    parser.add_argument('--symbols-lds', action='store_true', help='Create a linker script with the content of --kallsyms')
 
     args = parser.parse_args()
 
@@ -422,10 +449,13 @@ def main():
         out.append(process_header(args.header, args.introspect, args.type_prefix, args.non_renamed_types))
 
     if args.kallsyms and args.introspect:
-        out.append(process_kallsyms(args.kallsyms))
+        out.append(process_kallsyms_introspection(args.kallsyms))
 
     if args.kernel_features:
         out.append(process_kernel_features(args.kernel_features))
+
+    if args.kallsyms and args.symbols_lds:
+        out.append(process_kallsyms_lds(args.kallsyms))
 
     for rec in sorted(set(itertools.chain.from_iterable(out))):
         print(rec)

--- a/lisa/_assets/kmodules/lisa/kernel_features.json
+++ b/lisa/_assets/kmodules/lisa/kernel_features.json
@@ -21,5 +21,6 @@
   "SCHED_AUTOGROUP": "IS_ENABLED(CONFIG_SCHED_AUTOGROUP) && HAS_MEMBER(struct, task_group, autogroup)",
   "SCHED_AVG_RBL": "HAS_MEMBER(struct, sched_avg, runnable_load_avg) || HAS_MEMBER(struct, sched_avg, runnable_avg)",
 
-  "FILE_IO": "HAS_SYMBOL(kernel_read) && HAS_SYMBOL(kernel_write) && HAS_SYMBOL(filp_open)"
+  "FILE_IO": "HAS_SYMBOL(kernel_read) && HAS_SYMBOL(kernel_write) && HAS_SYMBOL(filp_open)",
+  "FREQ_INVARIANCE": "HAS_SYMBOL(arch_freq_scale)"
 }

--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -2428,9 +2428,14 @@ class LISAFtraceDynamicKmod(FtraceDynamicKmod):
         extra['vmlinux'] = btf
 
         try:
-            kallsyms = target.read_value('/proc/kallsyms')
+            # Ensure addresses are real, since we will use them in a linker script
+            with target.batch_revertable_write_value((
+                dict(path='/proc/sys/kernel/kptr_restrict', value='0'),
+                dict(path='/proc/sys/kernel/perf_event_paranoid', value='-1'),
+            )):
+                kallsyms = target.read_value('/proc/kallsyms')
         except TargetStableError:
-            pass
+            extra['kallsyms'] = b''
         else:
             extra['kallsyms'] = kallsyms.encode('utf-8')
 


### PR DESCRIPTION
FIX

Remove capacity from events if arch_freq_scale symbol is not exported by the kernel.