### PR TITLE
lisa.conf: Forward memo in __deepcopy__

### DIFF
--- a/lisa/conf.py
+++ b/lisa/conf.py
@@ -1309,7 +1309,7 @@ class MultiSrcConf(MultiSrcConfABC, Loggable, Mapping):
         return self._copy(copy.copy)
 
     def __deepcopy__(self, memo):
-        return self._copy(copy.deepcopy)
+        return self._copy(lambda x: copy.deepcopy(x, memo))
 
     def to_map(self):
         """


### PR DESCRIPTION
FIX

Forward the "memo" parameter to nested copy.deepcopy()