### PR TITLE
lisa.wlgen.rta: Fix PeriodicWload.unscaled_duty_cycle_pct()

### DIFF
--- a/lisa/wlgen/rta.py
+++ b/lisa/wlgen/rta.py
@@ -2991,7 +2991,7 @@ class PeriodicWload(WloadPropertyBase, ComposableMultiConcretePropertyBase):
             capa = plat_info.get_nested_key(['cpu-capacities', 'rtapp'], quiet=True)[cpu]
 
         if freq is not None:
-            freqs = plat_info.get_key(['freqs'], quiet=True)[cpu]
+            freqs = plat_info.get_key('freqs', quiet=True)[cpu]
             capa *= freq / max(freqs)
 
         capa /= PELT_SCALE


### PR DESCRIPTION
FIX

Fix invocation of plat_info.get_key() to pass a key name and not a string.

Fixes https://github.com/ARM-software/lisa/issues/2114