### PR TITLE
tools/exekall: Fix use of Path as str

### DIFF
--- a/tools/exekall/exekall/_utils.py
+++ b/tools/exekall/exekall/_utils.py
@@ -756,7 +756,7 @@ def import_file(python_src, *args, excep_handler=None, **kwargs):
         return _import_file(python_src, *args, **kwargs)
     except Exception as e:
         if excep_handler:
-            return excep_handler(python_src, e)
+            return excep_handler(str(python_src), e)
         else:
             raise
 


### PR DESCRIPTION
FIX

Ensure that a str is provided where an str is expected instead of a pathlib.Path.