### PR TITLE
lisa.analysis.base: Disable undo/redo bokeh tools

### DIFF
--- a/lisa/analysis/base.py
+++ b/lisa/analysis/base.py
@@ -762,8 +762,12 @@ class AnalysisHelpers(Loggable, abc.ABC):
                         hv_fig,
                         name='tools',
                         val=[
-                            'undo',
-                            'redo',
+                            # TODO: revisit:
+                            # undo/redo tools are currently broken for some plots:
+                            # https://github.com/holoviz/holoviews/issues/5928
+                            #
+                            # 'undo',
+                            # 'redo',
                             'crosshair',
                             'hover',
                         ],


### PR DESCRIPTION
FIX

undo/redo tools are currently breaking some plots' HTML output, so disable them:
https://github.com/holoviz/holoviews/issues/5928