### PR TITLE
shell: Fix git hook install location

### DIFF
--- a/shell/lisa_shell
+++ b/shell/lisa_shell
@@ -201,7 +201,7 @@ function _lisa-copy-git-hook {
 
     local hooks_dir="$(git -C "$LISA_HOME" rev-parse --git-common-dir)/hooks"
     local src="$LISA_HOME/tools/git-hooks/$hook"
-    local dst="$hooks_dir/$hook"
+    local dst="$LISA_HOME/$hooks_dir/$hook"
 
     # Avoid overriding existing hooks unless they are provided by LISA
     if [[ ! -e "$dst" ]] || grep -q 'LISA-HOOK' "$dst"; then


### PR DESCRIPTION
FIX

Install location for git hooks is relative to $LISA_HOME, so prepend "$LISA_HOME" to the path.