### PR TITLE
Trace task uclamp instead of rq uclamp in uclamp_util_se

### DIFF
--- a/lisa/_assets/kmodules/lisa/ftrace_events.h
+++ b/lisa/_assets/kmodules/lisa/ftrace_events.h
@@ -314,8 +314,8 @@ TRACE_EVENT_CONDITION(lisa__uclamp_util_se,
 		__entry->uclamp_avg     = uclamp_rq_util_with(rq, p->se.avg.util_avg);
 
 #    if HAS_KERNEL_FEATURE(CFS_UCLAMP)
-		__entry->uclamp_min     = rq->uclamp[UCLAMP_MIN].value;
-		__entry->uclamp_max     = rq->uclamp[UCLAMP_MAX].value;
+		__entry->uclamp_min     = p->uclamp[UCLAMP_MIN].value;
+		__entry->uclamp_max     = p->uclamp[UCLAMP_MAX].value;
 #    endif
 		),
 


### PR DESCRIPTION
FIX

If we really want to trace the rq uclamp values, they are currently available in other events anyway.