### PR TITLE
lisa._kmod: Rename LISAFtraceDynamicKmod to LISADynamicKmod

### DIFF
--- a/lisa/_cli_tools/lisa_load_kmod.py
+++ b/lisa/_cli_tools/lisa_load_kmod.py
@@ -11,7 +11,7 @@ import tempfile
 import shlex
 
 from lisa.target import Target
-from lisa._kmod import LISAFtraceDynamicKmod
+from lisa._kmod import LISADynamicKmod
 from lisa.utils import ignore_exceps
 
 def main():
@@ -59,7 +59,7 @@ def _main(args, target):
     if features is not None:
         kmod_params['features'] = list(features)
 
-    kmod = target.get_kmod(LISAFtraceDynamicKmod)
+    kmod = target.get_kmod(LISADynamicKmod)
     _kmod_cm = kmod.run(kmod_params=kmod_params)
 
     if keep_loaded:

--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -2626,7 +2626,7 @@ class FtraceDynamicKmod(DynamicKmod):
         })
 
 
-class LISAFtraceDynamicKmod(FtraceDynamicKmod):
+class LISADynamicKmod(FtraceDynamicKmod):
     """
     Module providing ftrace events used in various places by :mod:`lisa`.
 

--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -60,7 +60,7 @@ from lisa.conf import SimpleMultiSrcConf, LevelKeyDesc, KeyDesc, TopLevelKeyDesc
 from lisa.datautils import SignalDesc, df_add_delta, df_deduplicate, df_window, df_window_signals, series_convert
 from lisa.version import VERSION_TOKEN
 from lisa._typeclass import FromString
-from lisa._kmod import LISAFtraceDynamicKmod
+from lisa._kmod import LISADynamicKmod
 from lisa._assets import get_bin
 
 
@@ -5873,7 +5873,7 @@ class FtraceCollector(CollectorBase, Configurable):
     Thin wrapper around :class:`devlib.collector.ftrace.FtraceCollector`.
 
     .. note:: Events are expected to be provided by the target's kernel, but if
-        they are not :class:`lisa._kmod.LISAFtraceDynamicKmod` will build a
+        they are not :class:`lisa._kmod.LISADynamicKmod` will build a
         kernel module to attempt to satisfy the missing events. This will
         typically require correct target setup, see
         :class:`lisa.target.TargetConf` ``kernel/src`` configurations.
@@ -5898,7 +5898,7 @@ class FtraceCollector(CollectorBase, Configurable):
         tracing_path = devlib.FtraceCollector.find_tracing_path(target)
         target_available_events, avoided = self._target_available_events(target, tracing_path)
 
-        kmod = target.get_kmod(LISAFtraceDynamicKmod)
+        kmod = target.get_kmod(LISADynamicKmod)
         # Get the events possibly defined in the module. Note that it's a
         # superset of the events actually defined as this is based on pretty
         # crude filtering of the source files, rather than analyzing the events
@@ -6086,7 +6086,7 @@ class FtraceCollector(CollectorBase, Configurable):
 
     @classmethod
     def _get_kmod(cls, target, target_available_events, needed_events):
-        kmod = target.get_kmod(LISAFtraceDynamicKmod)
+        kmod = target.get_kmod(LISADynamicKmod)
         defined_events = set(kmod.defined_events)
         needed = needed_events & defined_events
         if needed:

--- a/lisa/wa/plugins/_kmod.py
+++ b/lisa/wa/plugins/_kmod.py
@@ -23,7 +23,7 @@ from wa.framework.instrument import very_slow, very_fast
 from wa.utils.types import list_of_strings
 
 from lisa.target import Target as LISATarget
-from lisa._kmod import LISAFtraceDynamicKmod
+from lisa._kmod import LISADynamicKmod
 from lisa.utils import get_nested_key
 
 
@@ -232,7 +232,7 @@ class LisaKmodInstrument(Instrument):
         # Note that this function will be ran for each monkey patched
         # instrument, unlike the other methods ran in job context.
         events = self._all_ftrace_events(context)
-        kmod = self._lisa_target.get_kmod(LISAFtraceDynamicKmod)
+        kmod = self._lisa_target.get_kmod(LISADynamicKmod)
         self._features = set(kmod._event_features(events))
         self._kmod = kmod
 


### PR DESCRIPTION
FEATURE

Since this kernel module is meant to host more than just ftrace events, rename it to a more general name.