### PR TITLE
lisa._kmod: Do not include __pycache__ in kmodule sources

### DIFF
--- a/lisa/_kmod.py
+++ b/lisa/_kmod.py
@@ -2227,8 +2227,12 @@ class KmodSrc(Loggable):
         :type extra: dict(str, str)
         """
         def get_files(root, dirs, files):
-            for f in files:
-                yield (Path(root) / f)
+            root = Path(root)
+            if root.name == '__pycache__':
+                return
+            else:
+                for f in files:
+                    yield (root / f)
 
         path = Path(path).resolve()
         src = {


### PR DESCRIPTION
FIX

__pycache__ is sometimes created around Python sources which later can affect the checksum of the module.

Ensure that the __pycache__ folders and all their contents are ignored when gathering module sources.