### PR TITLE
lisa._assets.kmodules.lisa: Don't rely on rq->cpu_capacity_orig anymore

### DIFF
--- a/lisa/_assets/kmodules/lisa/introspection.json
+++ b/lisa/_assets/kmodules/lisa/introspection.json
@@ -29,6 +29,7 @@
     "SCHED_AVG_RBL": "HAS_MEMBER(struct, sched_avg, runnable_load_avg) || HAS_MEMBER(struct, sched_avg, runnable_avg)",
 
     "FILE_IO": "HAS_SYMBOL(kernel_read) && HAS_SYMBOL(kernel_write) && HAS_SYMBOL(filp_open)",
-    "FREQ_INVARIANCE": "HAS_SYMBOL(arch_freq_scale) && HAS_MEMBER(struct, rq, cpu_capacity_orig)"
+    "FREQ_INVARIANCE": "HAS_SYMBOL(arch_freq_scale)",
+    "UARCH_INVARIANCE": "HAS_SYMBOL(cpu_scale)"
   }
 }

--- a/lisa/_assets/kmodules/lisa/sched_helpers.h
+++ b/lisa/_assets/kmodules/lisa/sched_helpers.h
@@ -214,11 +214,15 @@ static inline int rq_cpu_capacity(const struct rq *rq)
 	;
 }
 
+#    if HAS_KERNEL_FEATURE(UARCH_INVARIANCE)
+DECLARE_PER_CPU(unsigned long, cpu_scale);
+#    endif
+
 static inline int rq_cpu_orig_capacity(const struct rq *rq)
 {
 	return
-#    if HAS_KERNEL_FEATURE(FREQ_INVARIANCE)
-		rq->cpu_capacity_orig;
+#    if HAS_KERNEL_FEATURE(UARCH_INVARIANCE)
+		 per_cpu(cpu_scale, rq->cpu)
 #    else
 		rq_cpu_capacity(rq)
 #    endif


### PR DESCRIPTION
The kernel commit 7bc263840bc3 ("sched/topology: Consolidate and clean up access to a CPU's max compute") removed rq->cpu_capacity_orig so we can't use it anymore to retrieve the original CPU capacity nor for setting the FREQ_INVARIANCE kernel feature in LISA.

Replace rq->cpu_capacity_orig with arch_scale_cpu_capacity(cpu) in Lisa trace module's rq_cpu_orig_capacity() and remove the HAS_MEMBER(struct, rq, cpu_capacity_orig) check from the FREQ_INVARIANCE test.

Since arch_scale_cpu_capacity(cpu) exists in the kernel for a long time we don't have to take care of activating this only for newer Linux kernel versions.