### PR TITLE
lisa/utils: Fix wrong function signature in dispatch_kwargs()

### DIFF
--- a/lisa/utils.py
+++ b/lisa/utils.py
@@ -2273,10 +2273,18 @@ def dispatch_kwargs(funcs, kwargs, call=True, allow_overlap=False):
     """
     funcs = list(funcs)
 
+    def get_sig(f):
+        # If this is a method, we need to bind it to something to get rid
+        # of the "self" parameter.
+        if isinstance(f, UnboundMethodType):
+            f = f.__get__(0)
+
+        return inspect.signature(f)
+
     params = {
         func: {
             param.name
-            for param in inspect.signature(func).parameters.values()
+            for param in get_sig(func).parameters.values()
             if param.kind not in (
                 param.VAR_POSITIONAL,
                 param.VAR_KEYWORD,


### PR DESCRIPTION
Fixes bug in dispatch_kwargs where the object 'self' reference is passed in kwargs causing 'self' to be dispatched twice: Positional argument and kw argument.

The bug can be reproduced by creating an default RTA object, RTA(). Normally RTA objects are created through other functions, so the problem only occurs when trying to create an RTA object from a provided rtapp json file.

The bug is caused by inspect.signature() misbehaving for unbound methods. This problem is already fixed in kwargs_dispatched(), so it needs to be fixed in dispatch_kwargs() too.