### PR TITLE
lisa/trace: Fix dataframe prefiltering for userspace ftrace events

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -3535,7 +3535,7 @@ class Trace(Loggable, TraceBase):
         # That said, it's not the end of the world if we don't filter on that
         # as the meta event name is supposed to be unique anyway
         if not is_numeric_dtype(df['ip'].dtype):
-            df = df[df['ip'] == 'tracing_mark_write']
+            df = df[df['ip'].str.startswith('tracing_mark_write')]
         return (df, 'buf')
 
     def _select_trace_printk(self, source_event, meta_event, df):


### PR DESCRIPTION
It looks like the appearance of userspace generated ftrace events has changed. What appears to be memory address has been added to the event meta data breaking the prefiltering of trace data in _select_userspace().

The event used contain the keyword 'tracing_mark_write:', but now has the format: 'tracing_mark_write.<address>:'.

Example:
   rt-app-21908 [001] 4470442.464974: print:
tracing_mark_write.10e87ffbd993ed977ebcbff93a794b6d: rtapp_main: event=end

Fix the event filtering to handle new format without breaking backwards compatibility.