### PR TITLE
tools/recipes/trace-cmd.recipe: Avoid building shared object

### DIFF
--- a/tools/recipes/trace-cmd.recipe
+++ b/tools/recipes/trace-cmd.recipe
@@ -36,7 +36,7 @@ build_tracecmd() {
     # All variables need to be exported, NOT SET ON THE CLI of make-trace-cmd.sh
     # itself. Otherwise they will internally conflict with existing ones.
     export LDFLAGS="-static" NO_AUDIT=yes NO_PYTHON=yes CFLAGS="-O3"
-    ./make-trace-cmd.sh install install_libs
+    ./make-trace-cmd.sh install
     strip "$TRACE_CMD_BIN"
 }
 


### PR DESCRIPTION
FIX

Avoid using install_libs which attempts to build a shared object, when we only want a static binary.