### PR TITLE
lisa.trace: Update Trace.df_event() docstring

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -4020,6 +4020,8 @@ class Trace(Loggable, TraceBase):
                   will emit a bputs event that will be ignored at the moment.
                   We need to get a bprint event.
 
+                * Field names *must* be unique.
+
               .. code-block:: C
 
                   // trace.df_event('trace_printk@myevent')
@@ -4033,6 +4035,8 @@ class Trace(Loggable, TraceBase):
 
                   # trace.df_event('userspace@myevent')
                   echo "myevent: field1=foo field2=42" > /sys/kernel/debug/tracing/trace_marker
+
+              Note that the field names must be unique.
 
             .. note:: All meta event names are expected to be valid C language
                 identifiers. Usage of other characters will prevent correct


### PR DESCRIPTION
FIX

Specify that meta event field names must be unique.