### PR TITLE
lisa.trace: Only show closest matches in MissingTraceEventError

### DIFF
--- a/lisa/trace.py
+++ b/lisa/trace.py
@@ -5591,9 +5591,8 @@ class MissingTraceEventError(RuntimeError, ValueError):
                 )
                 if matches
             }
-            available = '. Closest available matches are: {}. Available events are: {}'.format(
+            available = '. Closest available matches are: {}'.format(
                 ', '.join(sorted(closest)),
-                ', '.join(sorted(available))
             )
         else:
             available = ''


### PR DESCRIPTION
FEATURE

Do not show the full set of available events as it typically is very large and makes the output hard to read. Instead, only show the closest matches for the events that are missing.