### PR TITLE
lisa._kmod: Add util_est_unified trace events

### DIFF
--- a/lisa/_assets/kmodules/lisa/ftrace_events.h
+++ b/lisa/_assets/kmodules/lisa/ftrace_events.h
@@ -258,6 +258,38 @@ TRACE_EVENT(lisa__sched_util_est_se,
 );
 #endif
 
+#if HAS_KERNEL_FEATURE(SE_UTIL_EST_UNIFIED)
+TRACE_EVENT(lisa__sched_util_est_se_unified,
+
+	TP_PROTO(int cpu, const char *path, const char *comm, int pid,
+		 const struct sched_avg *avg),
+
+	TP_ARGS(cpu, path, comm, pid, avg),
+
+	TP_STRUCT__entry(
+		__field(	unsigned long,	util			)
+		__field( 	unsigned int,	util_est		)
+		__field(	int,		cpu			)
+		__field(	int,		pid			)
+		__array(	char,		path,	PATH_SIZE	)
+		__array(	char,		comm,	TASK_COMM_LEN	)
+	),
+
+	TP_fast_assign(
+		__entry->cpu		= cpu;
+		strlcpy(__entry->path, path, PATH_SIZE);
+		strlcpy(__entry->comm, comm, TASK_COMM_LEN);
+		__entry->pid		= pid;
+		__entry->util_est	= avg->util_est & ~UTIL_AVG_UNCHANGED;
+		__entry->util		= avg->util_avg;
+	),
+
+	TP_printk("cpu=%d path=%s comm=%s pid=%d util_est=%u util=%lu",
+		  __entry->cpu, __entry->path, __entry->comm, __entry->pid,
+		  __entry->util_est, __entry->util)
+);
+#endif
+
 #if HAS_KERNEL_FEATURE(CFS_UTIL_EST)
 TRACE_EVENT(lisa__sched_util_est_cfs,
 
@@ -284,6 +316,32 @@ TRACE_EVENT(lisa__sched_util_est_cfs,
 	TP_printk("cpu=%d path=%s enqueued=%u ewma=%u util=%lu",
 		  __entry->cpu, __entry->path, __entry->enqueued,
 		 __entry->ewma, __entry->util)
+);
+#endif
+
+#if HAS_KERNEL_FEATURE(CFS_UTIL_EST_UNIFIED)
+TRACE_EVENT(lisa__sched_util_est_cfs_unified,
+
+	TP_PROTO(int cpu, char *path, const struct sched_avg *avg),
+
+	TP_ARGS(cpu, path, avg),
+
+	TP_STRUCT__entry(
+		__field(	unsigned long,	util			)
+		__field( 	unsigned int,	util_est		)
+		__field(	int,		cpu			)
+		__array(	char,		path,	PATH_SIZE	)
+	),
+
+	TP_fast_assign(
+		__entry->cpu		= cpu;
+		strlcpy(__entry->path, path, PATH_SIZE);
+		__entry->util_est	= avg->util_est;
+		__entry->util		= avg->util_avg;
+	),
+
+	TP_printk("cpu=%d path=%s util_est=%u util=%lu",
+		  __entry->cpu, __entry->path, __entry->util_est, __entry->util)
 );
 #endif
 

--- a/lisa/_assets/kmodules/lisa/introspection.json
+++ b/lisa/_assets/kmodules/lisa/introspection.json
@@ -11,12 +11,14 @@
     "RQ_NR_RUNNING": "HAS_MEMBER(struct, rq, nr_running)",
 
     "CFS_PELT": "HAS_MEMBER(struct, cfs_rq, avg) && HAS_TYPE(struct, sched_avg)",
-    "CFS_UTIL_EST": "HAS_KERNEL_FEATURE(CFS_PELT) && HAS_MEMBER(struct, sched_avg, util_est)",
+    "CFS_UTIL_EST": "HAS_KERNEL_FEATURE(CFS_PELT) && HAS_MEMBER(struct, sched_avg, util_est) && HAS_TYPE(struct, util_est)",
+    "CFS_UTIL_EST_UNIFIED": "HAS_KERNEL_FEATURE(CFS_PELT) && HAS_MEMBER(struct, sched_avg, util_est) && !HAS_TYPE(struct, util_est)",
     "RQ_UCLAMP": "IS_ENABLED(CONFIG_UCLAMP_TASK) && HAS_MEMBER(struct, rq, uclamp)",
 
     "SE_PELT": "HAS_TYPE(struct, sched_avg) && HAS_MEMBER(struct, sched_entity, avg)",
     "SE_UCLAMP": "HAS_KERNEL_FEATURE(SE_PELT) && HAS_MEMBER(struct, uclamp_se, value)",
-    "SE_UTIL_EST": "HAS_KERNEL_FEATURE(SE_PELT) && HAS_MEMBER(struct, sched_avg, util_est)",
+    "SE_UTIL_EST": "HAS_KERNEL_FEATURE(SE_PELT) && HAS_MEMBER(struct, sched_avg, util_est) && HAS_TYPE(struct, util_est)",
+    "SE_UTIL_EST_UNIFIED": "HAS_KERNEL_FEATURE(SE_PELT) && HAS_MEMBER(struct, sched_avg, util_est) && !HAS_TYPE(struct, util_est)",
 
     "DL_PELT": "HAS_MEMBER(struct, rq, avg_dl)",
 

--- a/lisa/_assets/kmodules/lisa/tp.c
+++ b/lisa/_assets/kmodules/lisa/tp.c
@@ -168,12 +168,28 @@ static void sched_util_est_cfs_probe(void *feature, struct cfs_rq *cfs_rq)
 DEFINE_TP_EVENT_FEATURE(lisa__sched_util_est_cfs, TP_PROBES(TP_PROBE("sched_util_est_cfs_tp", sched_util_est_cfs_probe)));
 #endif
 
+#if HAS_KERNEL_FEATURE(CFS_UTIL_EST_UNIFIED)
+static void sched_util_est_cfs_unified_probe(void *feature, struct cfs_rq *cfs_rq)
+{
+	_trace_cfs(cfs_rq, trace_lisa__sched_util_est_cfs_unified);
+}
+DEFINE_TP_EVENT_FEATURE(lisa__sched_util_est_cfs_unified, TP_PROBES(TP_PROBE("sched_util_est_cfs_tp", sched_util_est_cfs_unified_probe)));
+#endif
+
 #if HAS_KERNEL_FEATURE(SE_UTIL_EST)
 static void sched_util_est_se_probe(void *feature, struct sched_entity *se)
 {
 	_trace_se(se, trace_lisa__sched_util_est_se);
 }
 DEFINE_TP_EVENT_FEATURE(lisa__sched_util_est_se, TP_PROBES(TP_PROBE("sched_util_est_se_tp", sched_util_est_se_probe)));
+#endif
+
+#if HAS_KERNEL_FEATURE(SE_UTIL_EST_UNIFIED)
+static void sched_util_est_se_unified_probe(void *feature, struct sched_entity *se)
+{
+	_trace_se(se, trace_lisa__sched_util_est_se_unified);
+}
+DEFINE_TP_EVENT_FEATURE(lisa__sched_util_est_se_unified, TP_PROBES(TP_PROBE("sched_util_est_se_tp", sched_util_est_se_unified_probe)));
 #endif
 
 #if HAS_KERNEL_FEATURE(RQ_CAPACITY)


### PR DESCRIPTION
FEATURE and FIX

Upstream has now removed struct util_est and effectively merged util_est.enqueued and util_est.ewma in a single int field. Provide a new trace event for it so the new kernel can trace it.

This also fixes LISA not being able to compile and load the module on the new kernel. We detect whether struct util_est exists to decide if the new signal should be used.