### PR TITLE
Fix a couple of GroupBy.apply() deprecations

### DIFF
--- a/lisa/analysis/pixel6.py
+++ b/lisa/analysis/pixel6.py
@@ -67,7 +67,7 @@ class Pixel6Analysis(TraceAnalysisBase):
             df = pd.DataFrame(dict(power=power, channel=df['chan_name']))
             return df.dropna()
 
-        df = grouped.apply(make_chan_df)
+        df = grouped[df.columns].apply(make_chan_df)
         df['channel'] = df['channel'].astype('category').cat.rename_categories(Pixel6Analysis.EMETER_CHAN_NAMES)
 
         return df

--- a/lisa/datautils.py
+++ b/lisa/datautils.py
@@ -1429,7 +1429,7 @@ def df_combine_duplicates(df, func, output_col, cols=None, all_col=True, prune=T
     # Apply the function to each group, and assign the result to the output
     # Note that we cannot use GroupBy.transform() as it currently cannot handle
     # NaN groups.
-    output = df.groupby('duplicate_group', sort=False, as_index=True, group_keys=False, observed=True).apply(func)
+    output = df.groupby('duplicate_group', sort=False, as_index=True, group_keys=False, observed=True)[df.columns].apply(func)
     if not output.empty:
         init_df[output_col].update(output)
 


### PR DESCRIPTION
FIX

Pandas 2.2.0 GroupBy.apply() no longer includes the group column by default. It must be explicitly selected.