### PR TITLE
lisa._kmod: Replace strlcpy() with strscpy()

### DIFF
--- a/lisa/_assets/kmodules/lisa/ftrace_events.h
+++ b/lisa/_assets/kmodules/lisa/ftrace_events.h
@@ -47,7 +47,7 @@ TRACE_EVENT(lisa__sched_pelt_cfs,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->path, path, PATH_SIZE);
 		__entry->load		= avg->load_avg;
 #if HAS_KERNEL_FEATURE(SCHED_AVG_RBL)
 		__entry->RBL_LOAD_ENTRY	= avg->RBL_LOAD_MEMBER;
@@ -153,8 +153,8 @@ TRACE_EVENT(lisa__sched_pelt_se,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
-		strlcpy(__entry->comm, comm, TASK_COMM_LEN);
+		strscpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->comm, comm, TASK_COMM_LEN);
 		__entry->pid		= pid;
 		__entry->load		= avg->load_avg;
 #if HAS_KERNEL_FEATURE(SCHED_AVG_RBL)
@@ -193,7 +193,7 @@ TRACE_EVENT(lisa__sched_overutilized,
 
 	TP_fast_assign(
 		__entry->overutilized	= overutilized;
-		strlcpy(__entry->span, span, SPAN_SIZE);
+		strscpy(__entry->span, span, SPAN_SIZE);
 	),
 
 	TP_printk("overutilized=%d span=0x%s",
@@ -244,8 +244,8 @@ TRACE_EVENT(lisa__sched_util_est_se,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
-		strlcpy(__entry->comm, comm, TASK_COMM_LEN);
+		strscpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->comm, comm, TASK_COMM_LEN);
 		__entry->pid		= pid;
 		__entry->enqueued	= avg->util_est.enqueued & ~UTIL_AVG_UNCHANGED;
 		__entry->ewma		= avg->util_est.ewma;
@@ -277,8 +277,8 @@ TRACE_EVENT(lisa__sched_util_est_se_unified,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
-		strlcpy(__entry->comm, comm, TASK_COMM_LEN);
+		strscpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->comm, comm, TASK_COMM_LEN);
 		__entry->pid		= pid;
 		__entry->util_est	= avg->util_est & ~UTIL_AVG_UNCHANGED;
 		__entry->util		= avg->util_avg;
@@ -307,7 +307,7 @@ TRACE_EVENT(lisa__sched_util_est_cfs,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->path, path, PATH_SIZE);
 		__entry->enqueued	= avg->util_est.enqueued;
 		__entry->ewma		= avg->util_est.ewma;
 		__entry->util		= avg->util_avg;
@@ -335,7 +335,7 @@ TRACE_EVENT(lisa__sched_util_est_cfs_unified,
 
 	TP_fast_assign(
 		__entry->cpu		= cpu;
-		strlcpy(__entry->path, path, PATH_SIZE);
+		strscpy(__entry->path, path, PATH_SIZE);
 		__entry->util_est	= avg->util_est;
 		__entry->util		= avg->util_avg;
 	),
@@ -491,7 +491,7 @@ TRACE_EVENT(lisa__pixel6_emeter,
 		__entry->device		= device;
 		__entry->chan		= chan;
 		__entry->value		= value;
-		strlcpy(__entry->chan_name, chan_name, PIXEL6_EMETER_CHAN_NAME_MAX_SIZE);
+		strscpy(__entry->chan_name, chan_name, PIXEL6_EMETER_CHAN_NAME_MAX_SIZE);
 	),
 
 	TP_printk("ts=%lu device=%u chan=%u chan_name=%s value=%lu",

--- a/lisa/_assets/kmodules/lisa/sched_helpers.h
+++ b/lisa/_assets/kmodules/lisa/sched_helpers.h
@@ -115,7 +115,7 @@ static inline void cfs_rq_tg_path(const struct cfs_rq *cfs_rq, char *path, int l
 		cgroup_path((struct cgroup *)cfs_rq->tg->css.cgroup, path, len);
 	else
 #    endif
-		strlcpy(path, "(null)", len);
+		strscpy(path, "(null)", len);
 }
 #endif
 
@@ -154,7 +154,7 @@ static inline char *cfs_rq_path(const struct cfs_rq *cfs_rq, char *str, int len)
 {
 	if (!cfs_rq) {
 		if (str)
-			strlcpy(str, "(null)", len);
+			strscpy(str, "(null)", len);
 		else
 			return NULL;
 	}


### PR DESCRIPTION
FIX

Upstream has just removed strlcpy(), which should be replaced by strscpy(). strscpy() is already there for quite a long time, so this change won't break old kernels.